### PR TITLE
fix(runtime): native service lifecycle and CLI 0.14.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ database migration, CI, and implementation details.
 - Hosted OpenClaw upgrades now retire the legacy Clawdi provider plugin even
   when OpenClaw requires capability consent before it can inspect the plugin.
 
+## Clawdi CLI v0.14.48
+
+Package: `clawdi@0.14.48`
+
+### Fixed
+
+- Reuse existing Hermes and OpenClaw background services instead of reinstalling
+  them when version displays or native service definitions change.
+- Prepare Hermes service configuration before starting the gateway, and reload
+  systemd when native service changes precede reconciliation.
+- Preserve the latest failed installer log after successful recovery, and avoid
+  treating failed inspections or stale cached versions as a repair request.
+- Reduce overlapping OpenClaw discovery processes and keep skill polling alive
+  through inventory failures without reporting false deletions.
+
 ## Clawdi CLI v0.14.35
 
 Package: `clawdi@0.14.35`

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.48-beta.0",
+      "version": "0.14.48",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -242,6 +242,20 @@ systemd activation and runtime readiness still determine whether the adopted
 service works. Service file fingerprints are bookkeeping, not proof of the
 running source version or dependency capabilities.
 
+OpenClaw also adopts existing regular native units without forcing installation
+on fingerprint drift. Its pinned
+[`2026.8.1` source](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/entry.version-fast-path.ts)
+prints `OpenClaw <version> (<commit>)` on a local fast path, not a remote-update
+banner. The diagnostic commit can still come from `GIT_COMMIT` or `GIT_SHA`;
+neither that display nor a changed unit proves a broken service. The native
+[updater](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/cli/update-cli/update-command-service.ts)
+owns service refresh and restart after an update, subject to its ownership and
+definition-mutation checks. Clawdi retains missing/generated-unit installation,
+inspection-error handling, failed-unit recovery, and activation proof. It does
+not emulate upstream service repair: stale entrypoint or target errors that
+remain after systemd activation require the native owner workflow
+(`openclaw gateway start/restart` or an intentional `gateway install --force`).
+
 When Hermes service installation is necessary, Clawdi publishes its environment
 and drop-in first and invokes native `gateway install --force --no-start-now`.
 The existing activation phase starts the service after prerequisites are ready.
@@ -251,6 +265,20 @@ drop-in until after installation. These Hermes semantics were checked against
 [`1cb3ab6`](https://github.com/NousResearch/hermes-agent/blob/1cb3ab617363ffab9e55239a7d2ab0d6f9c10473/hermes_cli/gateway.py)
 and the pinned systemd fixture's
 [`cc4cab2`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/gateway.py).
+
+OpenClaw's pinned
+[installer](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/daemon/systemd-install.ts)
+publishes the native unit, then runs `daemon-reload`, `enable`, and `restart`.
+Clawdi therefore activates egress and proves tenant CA readability before a
+necessary gateway install, projects native authentication first, and publishes
+the OpenClaw drop-in after installation. Final activation processes system
+roles before user roles; this is not a dependency requiring the sync daemon to
+wait for the gateway. Hermes dashboard dependencies are built before a new
+gateway install. Files has its own readiness probe, and runtime-watch applies
+are serialized by the convergence lock. Both system and user managers are
+reloaded when they report `NeedDaemonReload`, including edits predating the
+current filesystem snapshot. Reused HOME units remain guarded by their
+boot-regenerated environment file, not merely by enablement state.
 
 Installer diagnostics retain the latest attempt as `<installer>.log` and the
 last failed attempt as `<installer>.failed.log` under the private status

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -232,6 +232,31 @@ official binary. Clawdi does not intercept that command. After an updater
 replaces files, the process manager may restart the relevant official program,
 but the update transaction remains owned by the runtime.
 
+For Hermes, an existing regular native gateway unit is adopted, not reinstalled
+because its bytes or displayed version changed. Hermes refreshes that unit
+during native gateway startup and updates. Its human-readable `--version`
+includes dependency and remote-update information and is not an installation
+identity. Clawdi installs only a missing gateway unit or a recognized legacy
+Clawdi-generated unit. Inspection failures do not authorize replacement;
+systemd activation and runtime readiness still determine whether the adopted
+service works. Service file fingerprints are bookkeeping, not proof of the
+running source version or dependency capabilities.
+
+When Hermes service installation is necessary, Clawdi publishes its environment
+and drop-in first and invokes native `gateway install --force --no-start-now`.
+The existing activation phase starts the service after prerequisites are ready.
+This flag does not stop an already running service or disable an enabled unit.
+OpenClaw's separate native install-time validation still requires deferring its
+drop-in until after installation. These Hermes semantics were checked against
+[`1cb3ab6`](https://github.com/NousResearch/hermes-agent/blob/1cb3ab617363ffab9e55239a7d2ab0d6f9c10473/hermes_cli/gateway.py)
+and the pinned systemd fixture's
+[`cc4cab2`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/gateway.py).
+
+Installer diagnostics retain the latest attempt as `<installer>.log` and the
+last failed attempt as `<installer>.failed.log` under the private status
+`installer-logs` directory. Both are mode `0600`; successful recovery does not
+overwrite the failure, and repeated failures do not create unbounded history.
+
 The bootstrap boundary is deliberately small: systemd owns `/etc/clawdi`,
 `/var/lib/clawdi`, `/var/cache/clawdi`, and `/run/clawdi` through its
 `ConfigurationDirectory=`, `StateDirectory=`, `CacheDirectory=`, and

--- a/docs/plans/managed-runtime-cli.md
+++ b/docs/plans/managed-runtime-cli.md
@@ -149,7 +149,8 @@ Rules:
 The support modules are not interchangeable:
 
 - `runtime watch` reconciles manifests and can use Clawdi API auth.
-- `daemon run` serves live sync only when live-sync agents are declared.
+- `daemon run` reports runtime observations even without live-sync agents and
+  runs their sync engines when declared.
 - `runtime sidecar` proxies outbound runtime traffic only when egress profiles
   are enabled.
 
@@ -161,10 +162,10 @@ The runtime image is a stable capability envelope, while the CLI owns egress
 module paths, numeric UID/GID permissions, and name-free privilege dropping.
 See [ADR-0002](../adr/0002-runtime-image-is-a-stable-capability-envelope.md).
 
-Hermes deployments that need both gateway and dashboard should declare two
-official Hermes user services. The official Hermes Docker image is useful
-prior art for this fan-out, but the Linux-like host keeps in-place
-`hermes update` available.
+Hermes deployments that need both gateway and dashboard use the native
+`hermes-gateway.service` and the Clawdi-owned compatibility unit
+`clawdi-hermes-dashboard.service`. Both launch official Hermes commands, and
+the Linux-like host keeps in-place `hermes update` available.
 
 ## Provider Projection
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.48-beta.0",
+	"version": "0.14.48",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -960,7 +960,6 @@ function prepareRuntimeActivation(
 		state.runtimeSystemdUserPrograms,
 		paths,
 		opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
-		context.appliedState?.officialServiceCommandRevisions ?? {},
 	);
 	const publishSystemdUnits = (deferredRuntimeUserUnitNames: readonly string[] = []) =>
 		writeRuntimeSystemdState({

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -367,7 +367,6 @@ function prepareRuntimeInstallStage(
 			projectionHome,
 			paths,
 			hostedRuntimeContract.identity,
-			officialServiceCommandRevision(context, name),
 		);
 		state.observations.set(name, observation);
 		if (observation.error) state.installErrors.push(observation.error);
@@ -991,7 +990,10 @@ function prepareRuntimeActivation(
 			deferredRuntimeUserUnitNames,
 		});
 	const systemdUnits = publishSystemdUnits(
-		officialServicePlan.pending.map((item) => item.unitName),
+		// Hermes permits its environment before installation and defers startup to activation.
+		officialServicePlan.pending
+			.filter((item) => item.program.runtime === "openclaw")
+			.map((item) => item.unitName),
 	);
 	state.staleSystemdFiles = systemdUnits.staleFiles;
 	const staleSystemdFileErrors = removeStaleRuntimeSystemdFiles(state.staleSystemdFiles);

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -77,7 +77,6 @@ const runtimeCommandRevisions = new Map<
 	string,
 	{ executableRevision: string; commandRevision: string; version: string }
 >();
-const hermesDashboardCapabilityRevisions = new Map<string, string>();
 function runtimeInstallTimeoutMs(): number {
 	const raw = process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT;
 	if (raw === undefined) return DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS;
@@ -91,7 +90,6 @@ function runtimeInstallTimeoutMs(): number {
 function hermesDashboardCapabilityError(
 	name: string,
 	runtime: RuntimeManifest["runtimes"][string],
-	officialServiceCommandRevision?: string | null,
 ): string | null {
 	if (name !== "hermes" || !runtime.enabled || !runtime.install || !runtime.services?.dashboard)
 		return null;
@@ -99,11 +97,6 @@ function hermesDashboardCapabilityError(
 	if (!executableExists(python)) {
 		return `Hermes dashboard runtime is missing its managed Python interpreter: ${python}`;
 	}
-	const capabilityRevision = [
-		officialServiceCommandRevision ?? "uncommitted",
-		runtimeFileCurrentRevision(python) ?? "missing",
-	].join("\0");
-	if (hermesDashboardCapabilityRevisions.get(python) === capabilityRevision) return null;
 	let result: ReturnType<typeof spawnRuntimeUserCommand>;
 	try {
 		result = spawnRuntimeUserCommand(
@@ -119,7 +112,6 @@ function hermesDashboardCapabilityError(
 		}`;
 	}
 	if (result.status === 0) {
-		hermesDashboardCapabilityRevisions.set(python, capabilityRevision);
 		return null;
 	}
 	return `Hermes dashboard runtime is incompatible: ${
@@ -345,7 +337,6 @@ export function observeRuntimeInstall(
 	home: string,
 	paths: RuntimePaths,
 	identity: { uid: number; gid: number },
-	officialServiceCommandRevision?: string | null,
 ) {
 	if (!runtime.enabled) {
 		return runtimeInstallObservation({
@@ -380,11 +371,7 @@ export function observeRuntimeInstall(
 	}
 	const observation = runOfficialInstaller(name, runtime.install, paths, identity);
 	if (observation.error) return observation;
-	const capabilityError = hermesDashboardCapabilityError(
-		name,
-		runtime,
-		officialServiceCommandRevision,
-	);
+	const capabilityError = hermesDashboardCapabilityError(name, runtime);
 	return capabilityError
 		? { ...observation, status: "install_failed" as const, error: capabilityError }
 		: observation;
@@ -429,21 +416,28 @@ export function writeRuntimeInstallerLog(
 			? result.error.message
 			: String(result.error)
 		: "";
-	writeRuntimePlatformFileAtomic(
-		paths,
-		path,
-		[
-			`exitCode=${result.status ?? "unavailable"}`,
-			`signal=${result.signal ?? "none"}`,
-			`spawnError=${error}`,
-			"--- stdout ---",
-			String(result.stdout ?? ""),
-			"--- stderr ---",
-			String(result.stderr ?? ""),
-			"",
-		].join("\n"),
-		{ mode: 0o600, dirMode: 0o700 },
-	);
+	const contents = [
+		`recordedAt=${new Date().toISOString()}`,
+		`exitCode=${result.status ?? "unavailable"}`,
+		`signal=${result.signal ?? "none"}`,
+		`spawnError=${error}`,
+		"--- stdout ---",
+		String(result.stdout ?? ""),
+		"--- stderr ---",
+		String(result.stderr ?? ""),
+		"",
+	].join("\n");
+	const options = { mode: 0o600, dirMode: 0o700 };
+	// Keep one failure per installer even when recovery overwrites the latest attempt.
+	if (result.status !== 0 || result.signal || result.error) {
+		writeRuntimePlatformFileAtomic(
+			paths,
+			join(paths.statusRoot, "installer-logs", `${name}.failed.log`),
+			contents,
+			options,
+		);
+	}
+	writeRuntimePlatformFileAtomic(paths, path, contents, options);
 	return path;
 }
 export function runtimeFileCurrentRevision(path: string): string | null {
@@ -479,7 +473,7 @@ export function runtimeCommandCurrentRevision(
 	const cacheKey = `${command}\0${home}\0${cwd}`;
 	const cached = runtimeCommandRevisions.get(cacheKey);
 	if (cached?.executableRevision === executableRevision) return cached.commandRevision;
-	runtimeCommandVersion(command, home, cwd);
+	if (!runtimeCommandVersion(command, home, cwd)) return null;
 	return runtimeCommandRevisions.get(cacheKey)?.commandRevision ?? null;
 }
 export function runtimeCommandVersion(command: string, home: string, cwd: string): string | null {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -729,7 +729,7 @@ case "$*" in
 	"config schema")
 		printf '%s\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'
 		;;
-  "gateway install --force --json"|"gateway install --force"|"gateway install")
+  "gateway install --force --json"|"gateway install --force --no-start-now"|"gateway install")
     ${
 			input.failInstall
 				? "exit 41"

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -99,7 +99,7 @@ test("adopts a persisted native Hermes service in a fresh process without reinst
 		env: {},
 		resolvedSecretEnv: {},
 	};
-	const adopted = planOfficialRuntimeServices([program], paths, true, {});
+	const adopted = planOfficialRuntimeServices([program], paths, true);
 	expect(adopted.pending).toEqual([]);
 	const modulePath = fileURLToPath(new URL("./runtime-systemd-reconciliation.ts", import.meta.url));
 	const child = spawnSync(
@@ -107,9 +107,9 @@ test("adopts a persisted native Hermes service in a fresh process without reinst
 		[
 			"--eval",
 			`import { planOfficialRuntimeServices } from ${JSON.stringify(modulePath)};
-const { program, paths, revisions } = JSON.parse(process.argv[1]);
-console.log(JSON.stringify(planOfficialRuntimeServices([program], paths, true, revisions)));`,
-			JSON.stringify({ program, paths, revisions: adopted.serviceRevisions }),
+const { program, paths } = JSON.parse(process.argv[1]);
+console.log(JSON.stringify(planOfficialRuntimeServices([program], paths, true)));`,
+			JSON.stringify({ program, paths }),
 		],
 		{ encoding: "utf8", timeout: 15_000 },
 	);
@@ -1555,7 +1555,7 @@ esac
 	});
 
 	test.each(installGateHarnesses)(
-		"adopts %s command revision when no revision is committed and repairs later drift",
+		"adopts %s native revisions and repairs a subsequently missing unit",
 		(_name, createHarness) => {
 			const harness = createHarness();
 			expect(harness.converge().installErrors).toEqual([]);
@@ -1565,6 +1565,12 @@ esac
 			expect(harness.installCount()).toBe(1);
 
 			harness.drift();
+			const nativeUnit = harness.unitContents();
+			expect(harness.converge().installErrors).toEqual([]);
+			expect(harness.installCount()).toBe(1);
+			expect(harness.unitContents()).toBe(nativeUnit);
+
+			harness.removeUnit();
 			harness.failNextInstall();
 			expect(harness.converge().installErrors.join("\n")).toContain("install failed");
 			expect(harness.installCount()).toBe(2);
@@ -1604,7 +1610,7 @@ esac
 	});
 
 	test.each(installGateHarnesses)(
-		"reconciles a real %s command revision change exactly once",
+		"adopts %s version changes without reinstalling its native unit",
 		(_name, createHarness) => {
 			const harness = createHarness();
 			expect(harness.converge().installErrors).toEqual([]);
@@ -1612,9 +1618,9 @@ esac
 
 			harness.revise();
 			expect(harness.converge().installErrors).toEqual([]);
-			expect(harness.installCount()).toBe(2);
+			expect(harness.installCount()).toBe(1);
 			expect(harness.converge().installErrors).toEqual([]);
-			expect(harness.installCount()).toBe(2);
+			expect(harness.installCount()).toBe(1);
 		},
 	);
 
@@ -1632,14 +1638,17 @@ esac
 		expect(harness.installCount()).toBe(1);
 	});
 
-	test.each(installGateHarnesses)("detects post-commit %s drift", (_name, createHarness) => {
-		const harness = createHarness();
-		expect(harness.converge(harness.drift).installErrors).toEqual([]);
-		expect(harness.installCount()).toBe(1);
+	test.each(installGateHarnesses)(
+		"preserves post-commit %s native edits",
+		(_name, createHarness) => {
+			const harness = createHarness();
+			expect(harness.converge(harness.drift).installErrors).toEqual([]);
+			expect(harness.installCount()).toBe(1);
 
-		expect(harness.converge().installErrors).toEqual([]);
-		expect(harness.installCount()).toBe(2);
-	});
+			expect(harness.converge().installErrors).toEqual([]);
+			expect(harness.installCount()).toBe(1);
+		},
+	);
 
 	test.each([
 		["Hermes", "hermes"],

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -21,16 +21,22 @@ import {
 	type RuntimeManifest,
 } from "./manifest";
 import { OFFICIAL_INSTALL_URLS, officialInstallArgs } from "./manifest-contract";
-import { observeRuntimeInstall, runtimeCommandCurrentRevision } from "./manifest-install";
+import {
+	observeRuntimeInstall,
+	runtimeCommandCurrentRevision,
+	writeRuntimeInstallerLog,
+} from "./manifest-install";
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import {
 	HERMES_DASHBOARD_BUILD_REVISION_FILE,
+	planOfficialRuntimeServices,
 	prepareOfficialRuntimeServiceDependencies,
 	type RuntimeSystemdUserProgram,
 } from "./runtime-systemd-reconciliation";
 import { ensureRuntimeStateDirs } from "./state";
+import { RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const originalEnv = { ...process.env };
@@ -71,17 +77,69 @@ printf '%s\n' '${version}'
 	expect(readFileSync(log, "utf8").trim().split("\n")).toEqual(["--version", "--version"]);
 });
 
-test("reuses the Hermes dashboard capability until its service revision changes", () => {
+test("adopts a persisted native Hermes service in a fresh process without reinstalling", () => {
+	const paths = tempRuntimePaths();
+	const command = join(paths.userHome, ".local", "bin", "hermes");
+	const unitPath = join(paths.systemdUserRoot, "hermes-gateway.service");
+	writeFakeGatewayCli({
+		path: command,
+		logPath: join(paths.runRoot, "commands.log"),
+		runtime: "hermes",
+		unitPath,
+	});
+	mkdirSync(dirname(unitPath), { recursive: true });
+	writeFileSync(unitPath, "[Service]\nExecStart=hermes gateway run\n");
+	const program: RuntimeSystemdUserProgram = {
+		programKind: "runtime",
+		runtime: "hermes",
+		service: null,
+		command,
+		args: ["gateway", "run"],
+		cwd: paths.userHome,
+		env: {},
+		resolvedSecretEnv: {},
+	};
+	const adopted = planOfficialRuntimeServices([program], paths, true, {});
+	expect(adopted.pending).toEqual([]);
+	const modulePath = fileURLToPath(new URL("./runtime-systemd-reconciliation.ts", import.meta.url));
+	const child = spawnSync(
+		process.execPath,
+		[
+			"--eval",
+			`import { planOfficialRuntimeServices } from ${JSON.stringify(modulePath)};
+const { program, paths, revisions } = JSON.parse(process.argv[1]);
+console.log(JSON.stringify(planOfficialRuntimeServices([program], paths, true, revisions)));`,
+			JSON.stringify({ program, paths, revisions: adopted.serviceRevisions }),
+		],
+		{ encoding: "utf8", timeout: 15_000 },
+	);
+	expect(child.status).toBe(0);
+	expect(child.stderr).toBe("");
+	expect(JSON.parse(child.stdout)).toEqual(adopted);
+});
+
+test("rechecks Hermes dashboard dependencies even when its launcher has not changed", () => {
 	const paths = tempRuntimePaths();
 	mkdirSync(paths.runRoot, { recursive: true });
 	const command = join(paths.userHome, ".local", "bin", "hermes");
 	const python = join(paths.userHome, ".hermes", "hermes-agent", "venv", "bin", "python");
 	const log = join(paths.runRoot, "dashboard-capability.log");
+	const dependencyError = join(paths.runRoot, "dependency-error");
 	for (const executable of [command, python]) {
 		mkdirSync(dirname(executable), { recursive: true });
-		writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' "$*" >> '${log}'\n`, {
-			mode: 0o755,
-		});
+		writeFileSync(
+			executable,
+			`#!/bin/sh
+printf '%s\\n' "$*" >> '${log}'
+if [ -f '${dependencyError}' ]; then
+  printf '%s\\n' 'dependency unavailable' >&2
+  exit 1
+fi
+`,
+			{
+				mode: 0o755,
+			},
+		);
 	}
 	const runtime: RuntimeManifest["runtimes"][string] = {
 		enabled: true,
@@ -94,21 +152,15 @@ test("reuses the Hermes dashboard capability until its service revision changes"
 		},
 		services: { dashboard: runSettings(command, ["dashboard"]) },
 	};
-	const observe = (revision: string) =>
-		observeRuntimeInstall(
-			"hermes",
-			runtime,
-			paths.userHome,
-			paths,
-			{ uid: TEST_PROCESS_UID, gid: TEST_PROCESS_GID },
-			revision,
-		);
+	const observe = () =>
+		observeRuntimeInstall("hermes", runtime, paths.userHome, paths, {
+			uid: TEST_PROCESS_UID,
+			gid: TEST_PROCESS_GID,
+		});
 
-	expect(observe("a".repeat(64)).error).toBeNull();
-	expect(observe("a".repeat(64)).error).toBeNull();
-	expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(1);
-	expect(observe("b".repeat(64)).error).toBeNull();
-	expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(2);
+	expect(observe().error).toBeNull();
+	writeFileSync(dependencyError, "dependency changed without replacing Python\n");
+	expect(observe().error).toContain("dependency unavailable");
 });
 
 test("reuses a Hermes dashboard build until its runtime revision changes", () => {
@@ -310,6 +362,7 @@ function writeFakeGatewayCli(input: {
 	unitPath: string;
 	version?: string;
 	hangVersion?: boolean;
+	failVersion?: boolean;
 	failInstall?: boolean;
 	failUninstall?: boolean;
 	requiredSystemdState?: {
@@ -340,9 +393,9 @@ function writeFakeGatewayCli(input: {
 	set -euo pipefail
 	case "$*" in
 	  "--version")
-		${input.hangVersion ? "exec sleep 60" : `printf '%s\\n' '${version}'`}
+		${input.hangVersion ? "exec sleep 60" : input.failVersion ? "exit 1" : `printf '%s\\n' '${version}'`}
 		;;
-  "gateway install --force --json"|"gateway install --force"|"gateway install")
+  "gateway install --force --json"|"gateway install --force --no-start-now"|"gateway install")
 	${stateCheck}
 	printf '%s %s\\n' '${input.runtime}' "$*" >> '${input.logPath}'
 	${
@@ -427,6 +480,10 @@ interface OfficialServiceInstallHarness extends InstallGateHarness {
 	addForeignDropIn: () => string;
 	driftMetadata: () => void;
 	hangVersionProbe: () => void;
+	failVersionProbe: () => void;
+	managedDropIn: () => string;
+	removeUnit: () => void;
+	unitContents: () => string;
 }
 
 function officialServiceHarness(
@@ -504,11 +561,19 @@ function officialServiceHarness(
 		driftMetadata: () => chmodSync(unitPath, 0o600),
 		hangVersionProbe: () =>
 			writeFakeGatewayCli({ path: command, logPath, runtime, unitPath, hangVersion: true }),
+		failVersionProbe: () =>
+			writeFakeGatewayCli({ path: command, logPath, runtime, unitPath, failVersion: true }),
+		managedDropIn: () =>
+			readFileSync(
+				join(paths.systemdUserRoot, `${runtime}-gateway.service.d`, RUNTIME_SYSTEMD_DROP_IN_FILE),
+				"utf8",
+			),
+		removeUnit: () => rmSync(unitPath),
+		unitContents: () => readFileSync(unitPath, "utf8"),
 	};
 }
 
 const installGateHarnesses = [
-	["Hermes official service", () => officialServiceHarness("hermes")],
 	["OpenClaw official service", () => officialServiceHarness("openclaw")],
 ] as const;
 
@@ -605,7 +670,7 @@ const merge = (currentValue, patchValue) => {
 fs.writeFileSync(configPath, JSON.stringify(merge(current, patch)) + "\\n");
 NODE
     ;;
-  "gateway install --force --json"|"gateway install --force"|"gateway install")
+  "gateway install --force --json"|"gateway install --force --no-start-now"|"gateway install")
     mkdir -p '${dirname(unitPath)}'
     printf '%s\n' '[Service]' 'ExecStart=openclaw gateway run' > '${unitPath}'
     ;;
@@ -1380,7 +1445,7 @@ esac
 		}
 	});
 
-	test("installs official base units before publishing hosted drop-ins", () => {
+	test("publishes Hermes environment before deferred startup and respects OpenClaw installer validation", () => {
 		const paths = tempRuntimePaths();
 		const logPath = join(paths.runRoot, "official-service-commands.log");
 		const openclawCommand = join(paths.userHome, ".local", "bin", "openclaw");
@@ -1405,7 +1470,15 @@ esac
 				logPath,
 				runtime,
 				unitPath: join(paths.systemdUserRoot, `${name}.service`),
-				forbiddenDropInPath: dropInPath,
+				...(runtime === "hermes"
+					? {
+							requiredSystemdState: {
+								dropInPath,
+								envPath,
+								snapshotPrefix: join(paths.runRoot, "hermes-install"),
+							},
+						}
+					: { forbiddenDropInPath: dropInPath }),
 			});
 		}
 		const manifest: RuntimeManifest = {
@@ -1463,8 +1536,8 @@ esac
 		expect(finalActivations).toBe(1);
 		expect(invalidatedUserUnits).toEqual(["hermes-gateway.service", "openclaw-gateway.service"]);
 		expect(readFileSync(logPath, "utf8").trim().split("\n").slice(-4)).toEqual([
-			"hermes drop-in absent",
-			"hermes gateway install --force",
+			"hermes systemd state ready",
+			"hermes gateway install --force --no-start-now",
 			"openclaw drop-in absent",
 			"openclaw gateway install --force --json",
 		]);
@@ -1502,6 +1575,33 @@ esac
 			expect(harness.installCount()).toBe(3);
 		},
 	);
+
+	test("preserves Hermes native updates and only reinstalls a missing gateway unit", () => {
+		const harness = officialServiceHarness("hermes");
+		expect(harness.converge().installErrors).toEqual([]);
+		harness.drift();
+		const nativeUnit = harness.unitContents();
+		harness.revise();
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(1);
+		expect(harness.unitContents()).toBe(nativeUnit);
+
+		const environment = harness.managedDropIn();
+		harness.failVersionProbe();
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(1);
+		expect(harness.managedDropIn()).toBe(environment);
+
+		harness.removeUnit();
+		harness.failNextInstall();
+		expect(harness.converge().installErrors.join("\n")).toContain("install failed");
+		expect(harness.installCount()).toBe(2);
+		expect(harness.managedDropIn()).toBe(environment);
+		harness.restoreInstaller();
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(3);
+	});
 
 	test.each(installGateHarnesses)(
 		"reconciles a real %s command revision change exactly once",
@@ -1572,6 +1672,42 @@ esac
 		expect(result.installErrors.join("\n")).toContain("runtime --version probe for");
 		expect(result.installErrors.join("\n")).toContain("timed out after 10000ms");
 	}, 15_000);
+
+	test.each(installGateHarnesses)(
+		"does not reinstall %s or remove its environment when the version probe fails",
+		(_name, createHarness) => {
+			const harness = createHarness();
+			const dropIn = harness.managedDropIn();
+			harness.failVersionProbe();
+
+			expect(harness.converge().installErrors.join("\n")).toContain("refusing service reinstall");
+			expect(harness.installCount()).toBe(1);
+			expect(harness.managedDropIn()).toBe(dropIn);
+
+			harness.restoreInstaller();
+			expect(harness.converge().installErrors).toEqual([]);
+			expect(harness.installCount()).toBe(1);
+		},
+	);
+
+	test("retains a bounded private installer failure log after successful recovery", () => {
+		const paths = tempRuntimePaths();
+		ensureRuntimeStateDirs(paths);
+		const latest = writeRuntimeInstallerLog(paths, "hermes-gateway-service", {
+			status: 23,
+			stderr: "first installer failure",
+		});
+		const failure = join(paths.statusRoot, "installer-logs", "hermes-gateway-service.failed.log");
+		const contents = readFileSync(failure, "utf8");
+		expect(contents).toContain("exitCode=23");
+		expect(contents).toContain("first installer failure");
+		expect(statSync(failure).mode & 0o777).toBe(0o600);
+		writeRuntimeInstallerLog(paths, "hermes-gateway-service", { status: 0, stdout: "recovered" });
+		expect(readFileSync(latest, "utf8")).toContain("recovered");
+		expect(readFileSync(failure, "utf8")).toBe(contents);
+		writeRuntimeInstallerLog(paths, "hermes-gateway-service", { signal: "SIGTERM" });
+		expect(readFileSync(failure, "utf8")).toContain("signal=SIGTERM");
+	});
 
 	test("uninstalls stale official gateway services when manifest disables them", () => {
 		const paths = tempRuntimePaths();
@@ -1654,7 +1790,7 @@ esac
 				.split("\n")
 				.filter((line) => line.includes(" gateway ")),
 		).toEqual([
-			"hermes gateway install --force",
+			"hermes gateway install --force --no-start-now",
 			"openclaw gateway install --force --json",
 			"hermes gateway uninstall",
 			"openclaw gateway uninstall",

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -18,6 +18,7 @@ import type { RuntimeManifest } from "./manifest-contract";
 import {
 	runtimeCommandCurrentRevision,
 	runtimeCommandPath,
+	runtimeFileCurrentRevision,
 	writeRuntimeInstallerLog,
 } from "./manifest-install";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
@@ -44,7 +45,6 @@ import {
 	commandResolvable,
 	executableExists,
 	makeRuntimeUserOwned,
-	RuntimeUserCommandTimeoutError,
 	runningAsRoot,
 	runRuntimeUserCommand,
 	runtimeEgressGid,
@@ -373,7 +373,7 @@ const OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS: OfficialRuntimeServiceDescriptor[] =
 		runtime: "hermes",
 		programName: "hermes-gateway",
 		command: "hermes",
-		installArgs: ["gateway", "install", "--force"],
+		installArgs: ["gateway", "install", "--force", "--no-start-now"],
 		uninstallArgs: ["gateway", "uninstall"],
 		service: "gateway",
 		matchesProgram: (program) => (program.service ?? program.args[0] ?? "") === "gateway",
@@ -416,22 +416,28 @@ function officialRuntimeServiceRevision(
 	if (!descriptor) return null;
 	const unitName = systemdUnitFileName(descriptor.programName);
 	const unitPath = join(paths.systemdUserRoot, unitName);
+	let contents: Buffer;
 	try {
 		const unitStat = lstatSync(unitPath);
-		if (!unitStat.isFile()) return null;
-		const contents = readFileSync(unitPath);
-		if (isGeneratedRuntimeSystemdFile(contents.toString("utf8"))) return null;
-		const commandRevision = runtimeCommandCurrentRevision(
-			officialRuntimeServiceCommand(descriptor, paths),
-			paths.userHome,
-			paths.userHome,
-		);
-		if (!commandRevision) return null;
-		return createHash("sha256").update(commandRevision).update("\0").update(contents).digest("hex");
+		if (!unitStat.isFile()) throw new Error(`official ${unitName} unit is not a regular file`);
+		contents = readFileSync(unitPath);
 	} catch (error) {
-		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
-		return null;
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
 	}
+	if (isGeneratedRuntimeSystemdFile(contents.toString("utf8"))) return null;
+	const command = officialRuntimeServiceCommand(descriptor, paths);
+	const commandRevision =
+		descriptor.runtime === "hermes"
+			? runtimeFileCurrentRevision(command)
+			: runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
+	// An unavailable observation is not evidence that a valid service needs reinstalling.
+	if (!commandRevision) {
+		throw new Error(
+			`official ${unitName} command revision is unavailable; refusing service reinstall`,
+		);
+	}
+	return createHash("sha256").update(commandRevision).update("\0").update(contents).digest("hex");
 }
 
 export function planOfficialRuntimeServices(
@@ -447,9 +453,11 @@ export function planOfficialRuntimeServices(
 		const unitName = systemdUnitFileName(runtimeSystemdProgramName(program));
 		const serviceRevision = officialRuntimeServiceRevision(program, paths);
 		if (serviceRevision) serviceRevisions[unitName] = serviceRevision;
+		// Hermes owns native unit refresh during gateway startup and runtime updates.
 		if (
 			!serviceRevision ||
-			(committedServiceRevisions[unitName] ?? serviceRevision) !== serviceRevision
+			(program.runtime !== "hermes" &&
+				(committedServiceRevisions[unitName] ?? serviceRevision) !== serviceRevision)
 		) {
 			pending.push({ unitName, program, serviceRevision });
 		}

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -444,7 +444,6 @@ export function planOfficialRuntimeServices(
 	programs: RuntimeSystemdUserProgram[],
 	paths: RuntimePaths,
 	executeInstallers: boolean,
-	committedServiceRevisions: Readonly<Record<string, string>>,
 ): OfficialRuntimeServicePlan {
 	const pending: OfficialRuntimeServicePlan["pending"] = [];
 	const serviceRevisions: Record<string, string> = {};
@@ -453,12 +452,8 @@ export function planOfficialRuntimeServices(
 		const unitName = systemdUnitFileName(runtimeSystemdProgramName(program));
 		const serviceRevision = officialRuntimeServiceRevision(program, paths);
 		if (serviceRevision) serviceRevisions[unitName] = serviceRevision;
-		// Hermes owns native unit refresh during gateway startup and runtime updates.
-		if (
-			!serviceRevision ||
-			(program.runtime !== "hermes" &&
-				(committedServiceRevisions[unitName] ?? serviceRevision) !== serviceRevision)
-		) {
+		// Native updaters own service refresh. Fingerprint drift alone is not a repair request.
+		if (!serviceRevision) {
 			pending.push({ unitName, program, serviceRevision });
 		}
 	}

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -207,10 +207,21 @@ export function applySystemdRuntimeUpdate(
 		...system.removed,
 	]);
 	const userStates = readSystemdRuntimeUnits(paths, "user", [...user.present, ...user.removed]);
-	if (system.added.length > 0 || system.changed.length > 0 || system.removed.length > 0) {
+	// Native updates and interrupted applies can predate the filesystem snapshot.
+	if (
+		system.added.length > 0 ||
+		system.changed.length > 0 ||
+		system.removed.length > 0 ||
+		[...systemStates.values()].some((state) => state.needDaemonReload)
+	) {
 		systemctl(["daemon-reload"]);
 	}
-	if (user.added.length > 0 || user.changed.length > 0 || user.removed.length > 0) {
+	if (
+		user.added.length > 0 ||
+		user.changed.length > 0 ||
+		user.removed.length > 0 ||
+		[...userStates.values()].some((state) => state.needDaemonReload)
+	) {
 		runtimeUserSystemctl(paths, ["daemon-reload"]);
 	}
 	if (system.removed.length > 0) {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -926,6 +926,39 @@ exec /usr/bin/systemctl "$@"
 				);
 			}
 			expect(manifestFetches).toBeGreaterThanOrEqual(2);
+
+			if (runtime === "openclaw") {
+				const unitName = "openclaw-gateway.service";
+				const unitPath = join(paths.systemdUserRoot, unitName);
+				const installerLog = join(
+					paths.statusRoot,
+					"installer-logs",
+					"openclaw-gateway-service.log",
+				);
+				const installedAt = statSync(installerLog).mtimeMs;
+				const nativeUnit = `${readFileSync(unitPath, "utf8")}\n[Service]\nEnvironment=CLAWDI_TEST_NATIVE_REFRESH=1\n`;
+				writeFileSync(unitPath, nativeUnit);
+				expect(runUserSystemctl("show", unitName, "--property=NeedDaemonReload").stdout).toContain(
+					"NeedDaemonReload=yes",
+				);
+
+				const refreshed = await runManagedInit();
+				expect(refreshed.status, `${refreshed.stdout}\n${refreshed.stderr}`).toBe(0);
+				expect(readFileSync(unitPath, "utf8")).toBe(nativeUnit);
+				expect(statSync(installerLog).mtimeMs).toBe(installedAt);
+				const pid = Number(
+					runUserSystemctl("show", unitName, "--property=MainPID", "--value").stdout,
+				);
+				expect(pid).toBeGreaterThan(1);
+				expect(pid).not.toBe(firstPids.get(unitName));
+				expect(readFileSync(`/proc/${pid}/environ`, "utf8").split("\0")).toContain(
+					"CLAWDI_TEST_NATIVE_REFRESH=1",
+				);
+				expect(runUserSystemctl("show", unitName, "--property=NeedDaemonReload").stdout).toContain(
+					"NeedDaemonReload=no",
+				);
+				await waitForTcpPort(18789, VIRGIN_RUNTIME_PORT_TIMEOUT_MS);
+			}
 		} finally {
 			manifestServer?.stop(true);
 			if (previousUmask !== null) process.umask(previousUmask);

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -960,7 +960,7 @@ exec /usr/bin/systemctl "$@"
 	VIRGIN_RUNTIME_TEST_TIMEOUT_MS,
 );
 
-test("propagates the real official OpenClaw installer failure without committing authority", () => {
+test("rejects a non-file native unit before invoking the official OpenClaw installer", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 	expect(process.geteuid?.()).toBe(0);
@@ -1147,15 +1147,10 @@ test("propagates the real official OpenClaw installer failure without committing
 		"installer-logs",
 		"openclaw-gateway-service.log",
 	);
-	expect(detail).toContain("official openclaw-gateway service install failed");
-	expect(detail).toContain(`see ${installerOutputLog}`);
+	expect(detail).toContain("official openclaw-gateway.service unit is not a regular file");
 	expect(detail).not.toContain("Gateway install failed:");
 	expect(detail).not.toContain("EISDIR");
-	const installerOutput = readFileSync(installerOutputLog, "utf8");
-	expect(installerOutput).toContain("exitCode=1");
-	expect(installerOutput).toContain('"ok": false');
-	expect(installerOutput).toContain('"error":');
-	expect(statSync(installerOutputLog).mode & 0o777).toBe(0o600);
+	expect(existsSync(installerOutputLog)).toBe(false);
 	expect(authorityCommits).toBe(0);
 	expect(statSync(unitPath).isDirectory()).toBe(true);
 	expect(readFileSync(unitSentinel, "utf8")).toBe("preserve directory target\n");
@@ -2253,7 +2248,7 @@ case "$*" in
   "config path"|"config get "*|"config set "*|"config unset "*)
 	exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
     ;;
-  "gateway install --force")
+  "gateway install --force --no-start-now")
     printf '%s\\n' install >> ${JSON.stringify(installLog)}
     mkdir -p "$HOME/.config/systemd/user"
     cat > "$HOME/.config/systemd/user/${unitName}" <<'EOF'
@@ -2444,8 +2439,9 @@ WantedBy=default.target
 
 		const repaired = await converge();
 		expect(repaired.installErrors).toEqual([]);
-		expect(readFileSync(unitPath, "utf8")).not.toContain("Existing Hermes Gateway");
-		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
+		expect(readFileSync(unitPath, "utf8")).toContain("Existing Hermes Gateway");
+		expect(readFileSync(unitPath, "utf8")).toContain("# tenant drift");
+		expect(readFileSync(installLog, "utf8")).toBe("");
 		expect([statSync(unitPath).uid, statSync(unitPath).gid]).toEqual([runtimeUid, runtimeGid]);
 		expect([statSync(rootOwnedSentinel).uid, statSync(rootOwnedSentinel).gid]).toEqual([0, 0]);
 		const repairedState = runUserSystemctl(
@@ -2460,7 +2456,13 @@ WantedBy=default.target
 			10,
 		);
 		expect(repairedPid).toBeGreaterThan(1);
+		// Native unit adoption does not bypass proof that changed content was activated.
 		expect(repairedPid).not.toBe(tamperedPid);
+		expect((await converge()).installErrors).toEqual([]);
+		expect(runUserSystemctl("show", unitName, "--property=MainPID").stdout.trim()).toBe(
+			`MainPID=${repairedPid}`,
+		);
+		expect(readFileSync(installLog, "utf8")).toBe("");
 	} finally {
 		runUserSystemctl("disable", "--now", unitName);
 		rmSync(unitPath, { force: true });

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update \
 		systemd-sysv \
 	&& rm -rf /var/lib/apt/lists/*
 
+# The disposable container must not configure its host's shared kernel.
+RUN systemctl mask systemd-sysctl.service systemd-modules-load.service
+
 RUN groupadd --gid 10001 clawdi \
 	&& useradd --uid 10001 --gid 10001 --create-home --home-dir /home/clawdi --shell /bin/bash clawdi
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8093,7 +8093,9 @@ chmod +x "$prefix/bin/clawdi"
 			const serviceName = `${runtime}-gateway`;
 			const runtimeUnit = join(home, ".config", "systemd", "user", `${serviceName}.service`);
 			const installArgs =
-				runtime === "openclaw" ? "gateway install --force --json" : "gateway install --force";
+				runtime === "openclaw"
+					? "gateway install --force --json"
+					: "gateway install --force --no-start-now";
 			const previousLog = console.log;
 			const previousUmask = process.umask(0o022);
 			const previousExitCode = process.exitCode;
@@ -8137,10 +8139,10 @@ elif [ "${runtime}" = "hermes" ] && [ "\${1:-}" = "config" ]; then
 elif [ "$*" = "${installArgs}" ]; then
   printf '%s\n' 'official ${runtime} installer' >> '${systemctlLog}'
   test -r '${paths.egressSystemCaFile}'
-  test ! -e '${join(paths.systemdUserRoot, `${serviceName}.service.d`, "10-clawdi-hosted.conf")}'
+  test ${runtime === "hermes" ? "-r" : "! -e"} '${join(paths.systemdUserRoot, `${serviceName}.service.d`, "10-clawdi-hosted.conf")}'
   mkdir -p '${dirname(runtimeUnit)}' '${systemctlStateRoot}'
   printf '[Service]\\nExecStart=${runtime} gateway run\\n' > '${runtimeUnit}'
-	  systemctl --user enable --now '${serviceName}.service'
+	  systemctl --user enable ${runtime === "hermes" ? "" : "--now"} '${serviceName}.service'
 fi
 exit 0
 `,
@@ -8239,7 +8241,15 @@ esac
 			}
 			expect(officialInstaller).toBeGreaterThan(sidecarActivation);
 			expect(finalSystemActivation).toBeGreaterThan(officialInstaller);
-			expect(calls).toContain(`--user restart ${serviceName}.service`);
+			if (runtime === "hermes") {
+				const gatewayStart = calls.findIndex(
+					(call) => call.startsWith("--user start ") && call.includes(`${serviceName}.service`),
+				);
+				expect(gatewayStart).toBeGreaterThan(officialInstaller);
+				expect(calls).not.toContain(`--user restart ${serviceName}.service`);
+			} else {
+				expect(calls).toContain(`--user restart ${serviceName}.service`);
+			}
 			const installerCalls = readFileSync(installerLog, "utf8").trim().split("\n");
 			const installIndex = installerCalls.indexOf(installArgs);
 			if (runtime === "openclaw") {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5982,6 +5982,38 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(calls).toContain(`--user start ${unit}`);
 	});
 
+	it("reloads manager state changed before the apply snapshot without restarting active services", () => {
+		const paths = seedRuntimeWatchLocaleBaseline(
+			join(root, "home", "clawdi"),
+			join(root, "var", "lib", "clawdi"),
+			join(root, "run", "clawdi"),
+		);
+		const snapshot = readSystemdUnitSnapshot(paths);
+		const logPath = join(root, "systemctl-reload.log");
+		const stateRoot = join(root, "systemctl-reload-state");
+		const command = join(root, "bin", "systemctl");
+		writeFakeSystemdManager({ path: command, logPath, stateRoot });
+		seedFakeSystemdSnapshotProcesses(paths, stateRoot, snapshot);
+		for (const [scope, unit] of [
+			["system", "clawdi-runtime-sidecar.service"],
+			["user", "openclaw-gateway.service"],
+		] as const) {
+			writeFileSync(fakeSystemdStatePath(stateRoot, scope, unit, "reload"), "\n");
+		}
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = command;
+
+		expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {})).toMatchObject({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [],
+		});
+		const calls = readFileSync(logPath, "utf8").trim().split("\n");
+		expect(calls).toContain("daemon-reload");
+		expect(calls).toContain("--user daemon-reload");
+		expect(calls.some((call) => /\b(?:start|restart|stop)\b/.test(call))).toBe(false);
+	});
+
 	it("runtime watch keeps polling after SSE authentication failure", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");


### PR DESCRIPTION
## Summary

Release `clawdi@0.14.48` to the stable npm `latest` channel, explicitly authorized by the owner.

- Adopt existing native Hermes and OpenClaw services instead of forcing reinstallation on diagnostic version or native file changes.
- Respect each upstream installer contract, prepare Hermes environment before deferred activation, and preserve OpenClaw configuration/authentication and egress prerequisites.
- Honor systemd NeedDaemonReload for changes preceding the current snapshot; preserve activation and readiness checks.
- Reject failed observations without repairing from stale caches; retain one private last-failure installer log.
- No added service manager, wrapper, dependency upgrade, custom kernel change or runtime version ledger.

## Release identity

Version-only follow-up: `f64953e4c`; package and lockfile both `0.14.48`. Registry returned 404 for that exact version before preparation. Existing implementation head `1e6d5e083` passed full isolated CLI tests (1756) and final native systemd CI (9 tests, 409 assertions). This PR now triggers protected CLI publishing on merge; no local npm publishing.

## Verification

- Final version bump is limited to package identity, matching workspace lock entry, and a concise changelog.
- Pinned Biome 2.5.11, publish-manifest check and diff check passed in the prescribed verification boundary.
- Final-version Docker CLI suite and new PR checks must complete before merge.

## Operational boundaries

Stable publishing updates latest for general CLI users. Hosted global CLI settings, default image and other tenant deployments remain unchanged. Owner-only canary is a separate exact-artifact qualification and rollout step. Kernel sysinfo compatibility, initial discovery failures, sustained OOM acceptance and historical bootstrap causality are not claimed fixed by this release.