### PR TITLE
fix(cli): prevent raw egress flow and control-frame logging

### DIFF
--- a/packages/cli/src/runtime/egress-sidecar.ts
+++ b/packages/cli/src/runtime/egress-sidecar.ts
@@ -107,7 +107,24 @@ function startMitmdump(config: TransparentEgressEnvConfig): ChildProcess {
 	if (!existsSync(config.addonPath)) {
 		throw new Error(`egress addon is missing: ${config.addonPath}`);
 	}
-	const mitmdumpArgs = [
+	const childEnv = buildEgressEngineEnv(process.env, {
+		envFile: config.envFile,
+		home: config.caDir,
+	});
+	const command = config.engineBinaryPath;
+	const args = buildMitmdumpArgs(config);
+	const child = runningAsRoot()
+		? spawnWithNumericIdentity(config.egressUid, config.egressGid, command, args, childEnv)
+		: spawnWithCurrentEgressIdentity(config.egressUid, config.egressGid, command, args, childEnv);
+	child.stdout?.pipe(process.stdout);
+	child.stderr?.pipe(process.stderr);
+	return child;
+}
+
+export function buildMitmdumpArgs(
+	config: Pick<TransparentEgressEnvConfig, "transparentPort" | "caDir" | "addonPath">,
+): string[] {
+	return [
 		"--mode",
 		"transparent",
 		"--listen-host",
@@ -119,22 +136,14 @@ function startMitmdump(config: TransparentEgressEnvConfig): ChildProcess {
 		"--set",
 		"stream_large_bodies=1",
 		"--set",
-		"termlog_verbosity=info",
+		// The default flow dumper bypasses the addon's URL redaction.
+		"flow_detail=0",
+		"--set",
+		// INFO also includes raw WebSocket ping/pong payloads outside the dumper.
+		"termlog_verbosity=warn",
 		"-s",
 		config.addonPath,
 	];
-	const childEnv = buildEgressEngineEnv(process.env, {
-		envFile: config.envFile,
-		home: config.caDir,
-	});
-	const command = config.engineBinaryPath;
-	const args = mitmdumpArgs;
-	const child = runningAsRoot()
-		? spawnWithNumericIdentity(config.egressUid, config.egressGid, command, args, childEnv)
-		: spawnWithCurrentEgressIdentity(config.egressUid, config.egressGid, command, args, childEnv);
-	child.stdout?.pipe(process.stdout);
-	child.stderr?.pipe(process.stderr);
-	return child;
 }
 
 export function assertCurrentEgressIdentity(

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -5,9 +5,39 @@ import { dirname, join } from "node:path";
 
 import {
 	assertCurrentEgressIdentity,
+	buildMitmdumpArgs,
 	publishEgressSystemCaBundle,
 } from "../../src/runtime/egress-sidecar";
 import { runtimeUserUid } from "../../src/runtime/runtime-user-command";
+
+describe("runtime sidecar egress logging", () => {
+	it("omits raw flows and control payloads while retaining warnings and TLS defaults", () => {
+		expect(
+			buildMitmdumpArgs({
+				transparentPort: 25_080,
+				caDir: "/run/clawdi/egress/ca",
+				addonPath: "/opt/clawdi/egress-addon.py",
+			}),
+		).toEqual([
+			"--mode",
+			"transparent",
+			"--listen-host",
+			"127.0.0.1",
+			"--listen-port",
+			"25080",
+			"--set",
+			"confdir=/run/clawdi/egress/ca",
+			"--set",
+			"stream_large_bodies=1",
+			"--set",
+			"flow_detail=0",
+			"--set",
+			"termlog_verbosity=warn",
+			"-s",
+			"/opt/clawdi/egress-addon.py",
+		]);
+	});
+});
 
 describe("runtime sidecar egress privilege drop", () => {
 	it("accepts the current numeric uid without a passwd entry", () => {


### PR DESCRIPTION
## Summary
Disable mitmdump raw flow output and INFO-level WebSocket control-frame payload logs through native flow_detail=0 and termlog_verbosity=warn options. Keep WARNING/ERROR output and all TLS certificate verification unchanged. The tradeoff is loss of INFO and dumper-only per-flow summaries.

The existing addon URL redaction does not cover the default mitmdump dumper. This fixes that logging boundary, not the separate non-positive peer-certificate serial warning.

## Verification
- Docker CLI typecheck passed
- 12 focused runtime tests and 22 addon tests passed
- Checksum-pinned mitmproxy 12.2.3 synthetic HTTP/WebSocket verification passed
- Synthetic zero-serial certificate still emits its warning
- Biome and git diff --check passed

No production changes, dependency changes, warning filters or TLS bypasses.