### PR TITLE
fix(runtime): safely adopt image bootstrap receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Managed runtimes accept released images' initial CLI bootstrap receipts
+  without a spurious invalid-status warning. Adoption revalidates the installed
+  CLI; malformed or unsafe state now stops instead of being overwritten.
 - OpenClaw sync serializes asynchronous discovery commands to reduce overlapping
   memory use. Skill polling survives inventory failures without reporting false
   deletions, and skill synchronization performs fewer workspace lookups.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1103,6 +1103,26 @@ CLI self-upgrade verifies a new exact package before atomically switching the
 active link inside the root-only managed directory. There is no shared
 `/var/lib/clawdi/bin` compatibility path and no migration or dual-path read.
 
+The `clawdi.cliNpmBootstrapStatus.v1` reader supports the exact initial
+bootstrap field set written by released images (without `verification`,
+`previous`, or `bad`) as well as the complete CLI-authored receipt. It never
+fills in a partial verification record. Adoption validates receipt/path
+identity and service ownership, runs the existing exact-version and isolated
+`runtime verify --json` probes, then writes the full v1 receipt without an
+invalid-status warning. Invalid or unreadable receipts stop mutation instead
+of being treated as missing. A stale device/inode/size/mtime invalidates the
+verification cache and revalidates the existing target; a failed probe does
+not permit reinstalling over it. The CLI retains its verified rollback path.
+
+Released image verifiers may reject stale metadata before this CLI runs, so
+that bootstrap reuse fix also requires a compatible image. Ship this additive
+reader before qualifying the new image/CLI pair. No new receipt version or
+runtime verification command is required.
+
+Done: `bash scripts/test.sh cli tests/runtime.test.ts src/runtime/observed-v2.test.ts`
+passes bootstrap adoption without warnings, stale-metadata revalidation,
+invalid-state preservation, and the existing activation/rollback contracts.
+
 The image bootstrap and CLI self-upgrade are independent atomic activation
 owners. If the image bootstrap replaces the active CLI while an older activated
 self-upgrade transaction remains, the transaction controller compares the full

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -9,8 +9,10 @@ import {
 	readdirSync,
 	readFileSync,
 	readlinkSync,
+	realpathSync,
 	renameSync,
 	rmSync,
+	type Stats,
 	statSync,
 	symlinkSync,
 } from "node:fs";
@@ -112,12 +114,20 @@ const runtimeCliStateSchema = z
 		verification: runtimeCliVerificationSchema,
 		previous: runtimeCliTargetSchema.nullable(),
 		bad: runtimeCliBadSchema.nullable(),
-		error: z.string().nullable(),
+		error: z.null(),
 	})
 	.strict();
 
-export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliStateSchema>;
-type RuntimeCliState = RuntimeCliBootstrapStatus;
+// Released images write this phase before the CLI has adopted the installation.
+// Only the complete legacy field set is accepted, never a partial verification.
+const runtimeCliBootstrapSchema = runtimeCliStateSchema.omit({
+	verification: true,
+	previous: true,
+	bad: true,
+});
+const runtimeCliReceiptSchema = z.union([runtimeCliStateSchema, runtimeCliBootstrapSchema]);
+export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliReceiptSchema>;
+type RuntimeCliState = z.infer<typeof runtimeCliStateSchema>;
 
 interface VerifiedCliTarget extends RuntimeCliTarget {
 	verification: RuntimeCliVerification;
@@ -175,7 +185,7 @@ export function applyRuntimeCliDesiredState(
 		throw new Error(`clawdi CLI packageSpec must be clawdi@<exact-semver>: ${packageSpec}`);
 	}
 	validateRegistry(manifest.clawdiCli?.registry);
-	const status = readRuntimeCliBootstrapStatus(paths);
+	const status = readRuntimeCliBootstrapStatus(paths, { strict: true });
 	let state = parseCliState(paths, status);
 	const retainedBad = state?.bad ?? null;
 	if (
@@ -252,8 +262,9 @@ export function rollbackPendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	reason: string,
 ): RuntimeCliRollbackResult {
-	const before = readCliState(paths);
+	let before: RuntimeCliState | null = null;
 	try {
+		before = readCliState(paths);
 		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths);
 		if (reconciliation.status === "rolled_back" && before?.previous) {
 			return rollbackResult(before, "rolled_back");
@@ -294,12 +305,16 @@ export function reconcilePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	runningVersion?: string,
 ): RuntimeCliReconciliationResult {
-	const status = readRuntimeCliBootstrapStatus(paths);
+	assertCliDirectories(paths, dirname(paths.cliManagedBin));
+	const status = readRuntimeCliBootstrapStatus(paths, { strict: true });
 	let state = parseCliState(paths, status);
 	const activeTarget = activeLinkTarget(paths.cliManagedBin);
 	if (!state) {
+		if (status && activeTarget !== status.activeTarget) {
+			throw new Error("clawdi CLI bootstrap target does not match its receipt");
+		}
 		if (!activeTarget) return { status: "unchanged", selfReexec: false };
-		const recovered = requireVerifiedCliTarget(paths, { activeTarget });
+		const recovered = requireVerifiedCliTarget(paths, { activeTarget, version: status?.version });
 		writeCliState(paths, recovered, null, null);
 		pruneCliPackagePrefixes(paths, [prefixForActiveTarget(recovered.activeTarget)]);
 		return reconciliationResult("unchanged", recovered.version, runningVersion);
@@ -347,11 +362,26 @@ export function reconcilePendingRuntimeCliUpgrade(
 
 export function readRuntimeCliBootstrapStatus(
 	paths: RuntimePaths,
+	opts: { strict?: boolean } = {},
 ): RuntimeCliBootstrapStatus | null {
-	if (!existsSync(paths.cliBootstrapStatus)) return null;
 	try {
-		return runtimeCliStateSchema.parse(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")));
+		assertCliDirectories(paths, dirname(paths.cliBootstrapStatus));
+		const file = optionalCliLstat(paths.cliBootstrapStatus);
+		if (!file) return null;
+		assertCliOwnership(file);
+		if (!file.isFile()) throw new Error("clawdi CLI receipt is not a regular file");
+		let value: unknown;
+		try {
+			value = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		} catch (error) {
+			if (error instanceof SyntaxError) throw new Error("clawdi CLI receipt has malformed JSON");
+			throw error;
+		}
+		const parsed = runtimeCliReceiptSchema.safeParse(value);
+		if (!parsed.success) throw new Error("clawdi CLI receipt format is invalid");
+		return parsed.data;
 	} catch (error) {
+		if (opts.strict) throw error;
 		log.warn("runtime.cli_bootstrap_status_invalid", {
 			path: paths.cliBootstrapStatus,
 			error: toErrorMessage(error),
@@ -423,25 +453,23 @@ function parseCliState(
 	paths: RuntimePaths,
 	status: RuntimeCliBootstrapStatus | null,
 ): RuntimeCliState | null {
-	const parsed = runtimeCliStateSchema.safeParse(status);
-	if (!parsed.success) return null;
-	const state = parsed.data;
+	if (!status) return null;
+	const state = status;
 	if (
 		state.activePath !== paths.cliManagedBin ||
 		state.npmCache !== paths.cliNpmCache ||
 		state.npmPrefix !== prefixForActiveTarget(state.activeTarget) ||
 		!isManagedCliTarget(paths, state.activeTarget) ||
 		exactNpmPackageVersion(state.packageSpec) !== state.version ||
-		!isValidRetryState(state.bad)
+		("bad" in state && !isValidRetryState(state.bad))
 	) {
-		log.warn("runtime.cli_state_invalid", { path: paths.cliBootstrapStatus });
-		return null;
+		throw new Error("clawdi CLI receipt identity is invalid");
 	}
-	return state;
+	return "verification" in state ? state : null;
 }
 
 function readCliState(paths: RuntimePaths): RuntimeCliState | null {
-	return parseCliState(paths, readRuntimeCliBootstrapStatus(paths));
+	return parseCliState(paths, readRuntimeCliBootstrapStatus(paths, { strict: true }));
 }
 
 function writeCliState(
@@ -631,8 +659,8 @@ function tryVerifyCliTarget(
 	target: { activeTarget: string; version?: string },
 	state?: RuntimeCliState,
 ): VerifiedCliTarget | null {
-	if (!isManagedCliTarget(paths, target.activeTarget) || !isExecutable(target.activeTarget))
-		return null;
+	assertCliTarget(paths, target.activeTarget);
+	if (!isExecutable(target.activeTarget)) return null;
 	const before = cliVerificationIdentity(target.activeTarget);
 	if (!before) return null;
 	if (
@@ -718,7 +746,53 @@ function isManagedCliPrefix(paths: RuntimePaths, path: string): boolean {
 }
 
 function isManagedCliTarget(paths: RuntimePaths, path: string): boolean {
-	return isManagedCliPrefix(paths, path) && path.endsWith("/bin/clawdi");
+	return path === resolve(path) && isManagedCliPrefix(paths, path) && path.endsWith("/bin/clawdi");
+}
+
+function optionalCliLstat(path: string): Stats | null {
+	try {
+		return lstatSync(path);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+function assertCliOwnership(node: Stats): void {
+	if (node.uid !== process.getuid?.() || (node.mode & 0o022) !== 0) {
+		throw new Error("clawdi CLI path has unsafe ownership or permissions");
+	}
+}
+
+function assertCliDirectories(paths: RuntimePaths, path: string): void {
+	const root = resolve(paths.serviceStateRoot);
+	if (path !== root && !path.startsWith(`${root}/`)) {
+		throw new Error("clawdi CLI path escaped its state root");
+	}
+	for (let current = path; ; current = dirname(current)) {
+		const node = optionalCliLstat(current);
+		if (node) {
+			assertCliOwnership(node);
+			if (!node.isDirectory()) throw new Error("clawdi CLI directory is not a real directory");
+		}
+		if (current === root) break;
+	}
+}
+
+function assertCliTarget(paths: RuntimePaths, target: string): void {
+	if (!isManagedCliTarget(paths, target)) throw new Error("clawdi CLI target is not managed");
+	assertCliDirectories(paths, dirname(target));
+	const node = optionalCliLstat(target);
+	if (!node) return;
+	if (node.uid !== process.getuid?.()) throw new Error("clawdi CLI target has unsafe ownership");
+	const executable = realpathSync(target);
+	if (!executable.startsWith(`${prefixForActiveTarget(target)}/`)) {
+		throw new Error("clawdi CLI executable escaped its npm prefix");
+	}
+	assertCliDirectories(paths, dirname(executable));
+	const file = statSync(target);
+	assertCliOwnership(file);
+	if (!file.isFile()) throw new Error("clawdi CLI executable is not a regular file");
 }
 
 function ensureManagedCliDirectory(path: string): void {
@@ -726,11 +800,12 @@ function ensureManagedCliDirectory(path: string): void {
 }
 
 function activeLinkTarget(activePath: string): string | null {
-	try {
-		return resolve(dirname(activePath), readlinkSync(activePath));
-	} catch {
-		return null;
+	const node = optionalCliLstat(activePath);
+	if (!node) return null;
+	if (!node.isSymbolicLink() || node.uid !== process.getuid?.()) {
+		throw new Error("clawdi CLI active path is not a trusted symlink");
 	}
+	return resolve(dirname(activePath), readlinkSync(activePath));
 }
 
 function swapActiveCli(activePath: string, activeTarget: string): void {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -368,7 +368,7 @@ export function readRuntimeCliBootstrapStatus(
 		assertCliDirectories(paths, dirname(paths.cliBootstrapStatus));
 		const file = optionalCliLstat(paths.cliBootstrapStatus);
 		if (!file) return null;
-		assertCliOwnership(file);
+		assertCliOwnership(file, "receipt", paths.cliBootstrapStatus);
 		if (!file.isFile()) throw new Error("clawdi CLI receipt is not a regular file");
 		let value: unknown;
 		try {
@@ -614,7 +614,8 @@ function installCliPackage(paths: RuntimePaths, packageSpec: string): VerifiedCl
 		NPM_REGISTRY,
 		packageSpec,
 	];
-	const result = spawnSync("npm", args, {
+	// npm's umask config does not cover Arborist's intermediate mkdir calls.
+	const result = spawnSync("/bin/sh", ["-c", 'umask 077; exec npm "$@"', "npm", ...args], {
 		encoding: "utf8",
 		timeout: NPM_INSTALL_TIMEOUT_MS,
 		env: {
@@ -758,9 +759,11 @@ function optionalCliLstat(path: string): Stats | null {
 	}
 }
 
-function assertCliOwnership(node: Stats): void {
+function assertCliOwnership(node: Stats, role: string, path: string): void {
 	if (node.uid !== process.getuid?.() || (node.mode & 0o022) !== 0) {
-		throw new Error("clawdi CLI path has unsafe ownership or permissions");
+		throw new Error(
+			`clawdi CLI path has unsafe ownership or permissions (role=${role}, path=${JSON.stringify(path)}, uid=${process.getuid?.()}, euid=${process.geteuid?.()}, ownerUid=${node.uid}, ownerGid=${node.gid}, mode=0${(node.mode & 0o7777).toString(8)})`,
+		);
 	}
 }
 
@@ -772,7 +775,10 @@ function assertCliDirectories(paths: RuntimePaths, path: string): void {
 	for (let current = path; ; current = dirname(current)) {
 		const node = optionalCliLstat(current);
 		if (node) {
-			assertCliOwnership(node);
+			let role = "directory";
+			if (current === root) role = "service-state root";
+			else if (current === paths.managedCliRoot) role = "managed CLI root";
+			assertCliOwnership(node, role, current);
 			if (!node.isDirectory()) throw new Error("clawdi CLI directory is not a real directory");
 		}
 		if (current === root) break;
@@ -791,12 +797,12 @@ function assertCliTarget(paths: RuntimePaths, target: string): void {
 	}
 	assertCliDirectories(paths, dirname(executable));
 	const file = statSync(target);
-	assertCliOwnership(file);
+	assertCliOwnership(file, "executable", target);
 	if (!file.isFile()) throw new Error("clawdi CLI executable is not a regular file");
 }
 
 function ensureManagedCliDirectory(path: string): void {
-	mkdirSync(path, { recursive: true });
+	mkdirSync(path, { recursive: true, mode: 0o755 });
 }
 
 function activeLinkTarget(activePath: string): string | null {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -30,6 +30,7 @@ import {
 import { getCliVersion } from "../../src/lib/version";
 import { readRuntimeAppliedState } from "../../src/runtime/applied-state";
 import { applyRuntimeBundleChannelsToManifestLoad } from "../../src/runtime/channels";
+import { reconcilePendingRuntimeCliUpgrade } from "../../src/runtime/cli-update";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import { prepareHostedSkillArchives } from "../../src/runtime/hosted-sourced-skill-archive";
 import {
@@ -48,7 +49,7 @@ import { LEGACY_CLAWDI_MANAGED_PROVIDER_PLUGIN_ID } from "../../src/runtime/open
 import { openClawPluginCapabilityConsentArgs } from "../../src/runtime/openclaw-plugin-cli";
 import { getRuntimePaths } from "../../src/runtime/paths";
 import { HERMES_DASHBOARD_BUILD_REVISION_FILE } from "../../src/runtime/runtime-systemd-reconciliation";
-import { ensureRuntimeStateDirs } from "../../src/runtime/state";
+import { ensureRuntimePlatformDirectory, ensureRuntimeStateDirs } from "../../src/runtime/state";
 import {
 	applySystemdRuntimeUpdate,
 	readSystemdUnitSnapshot,
@@ -377,9 +378,15 @@ function userUnitDiagnostics(unitName: string, runtimeHome: string, runtimeUid: 
 function seedLocalCli(paths: ReturnType<typeof getRuntimePaths>): string {
 	const version = getCliVersion();
 	const prefix = join(paths.cliNpmPrefix, "packages", version);
+	// Bootstrap establishes the private boundary before npm creates package content.
+	ensureRuntimePlatformDirectory(paths, prefix, { mode: 0o700 });
+	ensureRuntimePlatformDirectory(paths, dirname(paths.cliManagedBin), { mode: 0o700 });
 	const install = spawnSync(
-		"npm",
+		"/bin/sh",
 		[
+			"-c",
+			'umask 077; exec npm "$@"',
+			"npm",
 			"install",
 			"--global",
 			`--prefix=${prefix}`,
@@ -392,36 +399,8 @@ function seedLocalCli(paths: ReturnType<typeof getRuntimePaths>): string {
 	);
 	expect(install.status, install.stderr).toBe(0);
 	const activeTarget = join(prefix, "bin", "clawdi");
-	const activeIdentity = statSync(activeTarget);
-	mkdirSync(dirname(paths.cliManagedBin), { recursive: true, mode: 0o755 });
 	symlinkSync(activeTarget, paths.cliManagedBin);
-	writeFileSync(
-		paths.cliBootstrapStatus,
-		`${JSON.stringify({
-			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-			generatedAt: new Date().toISOString(),
-			status: "installed",
-			source: "npm",
-			packageSpec: `clawdi@${version}`,
-			registry: "https://registry.npmjs.org",
-			npmPrefix: prefix,
-			npmCache: paths.cliNpmCache,
-			activePath: paths.cliManagedBin,
-			activeTarget,
-			version,
-			verification: {
-				verifiedAt: new Date().toISOString(),
-				device: activeIdentity.dev,
-				inode: activeIdentity.ino,
-				size: activeIdentity.size,
-				modifiedAtMs: activeIdentity.mtimeMs,
-			},
-			previous: null,
-			bad: null,
-			error: null,
-		})}\n`,
-		{ mode: 0o600 },
-	);
+	reconcilePendingRuntimeCliUpgrade(paths);
 	return prefix;
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -46,6 +46,7 @@ import { applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsT
 import {
 	applyRuntimeCliDesiredState,
 	completePendingRuntimeCliUpgrade,
+	readRuntimeCliBootstrapStatus,
 	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../src/runtime/cli-update";
@@ -106,6 +107,7 @@ import {
 } from "../src/runtime/systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
 import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
+import { log } from "../src/serve/log";
 import { getDaemonControlTokenPath } from "../src/serve/paths";
 import { ensureTestOpenClawWorkspaceCli } from "../src/test-support/runtime-workspace";
 import { mockFetch } from "./commands/helpers";
@@ -8611,16 +8613,21 @@ chmod +x "$prefix/bin/clawdi"
 		},
 	);
 
-	it("re-verifies the active CLI when its file identity drifts", () => {
+	it("adopts a released image bootstrap receipt and re-verifies stale CLI metadata", () => {
 		const state = join(root, "state-cli-verification-cache");
 		const run = join(root, "run-cli-verification-cache");
 		const commandLog = join(root, "cli-verification-cache.log");
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "1.2.3");
 		const paths = getRuntimePaths();
-		const activeTarget = readlinkSync(paths.cliManagedBin);
+		const identity = createVersionedCliFixture(
+			paths,
+			"1.2.3",
+			join(paths.cliNpmPrefix, "installs", "install-bootstrap"),
+		);
+		pointManagedCliAt(paths, identity);
+		const { activeTarget } = identity;
 		writeFileSync(
 			activeTarget,
 			`#!/usr/bin/env bash
@@ -8632,16 +8639,97 @@ exit 64
 		);
 		chmodSync(activeTarget, 0o700);
 		const manifest = cliManifest("1.2.3");
+		const bootstrap = {
+			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+			generatedAt: "2026-09-06T00:00:00Z",
+			status: "installed",
+			source: "npm",
+			...identity,
+			npmCache: paths.cliNpmCache,
+			activePath: paths.cliManagedBin,
+			error: null,
+		};
+		mkdirSync(paths.statusRoot, { recursive: true });
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrap));
+		const warn = spyOn(log, "warn");
+		try {
+			expect(readRuntimeCliBootstrapStatus(paths, { strict: true })).toEqual(bootstrap);
+			expect(applyRuntimeCliDesiredState(manifest, paths).status).toBe("current");
+			expect(warn).not.toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
 
+		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(2);
+		const adopted = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		expect(adopted).toMatchObject({
+			...identity,
+			previous: null,
+			bad: null,
+		});
+		expect(adopted.verification.inode).toBe(statSync(activeTarget).ino);
 		applyRuntimeCliDesiredState(manifest, paths);
 		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(2);
-		applyRuntimeCliDesiredState(manifest, paths);
-		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(2);
 
-		const driftedAt = new Date(Date.now() + 1_000);
-		utimesSync(activeTarget, driftedAt, driftedAt);
-		applyRuntimeCliDesiredState(manifest, paths);
+		adopted.verification.device += 1;
+		adopted.verification.inode += 1;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(adopted));
+		expect(applyRuntimeCliDesiredState(manifest, paths).status).toBe("current");
 		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(4);
+		expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
+		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).verification).toMatchObject({
+			device: statSync(activeTarget).dev,
+			inode: statSync(activeTarget).ino,
+		});
+	});
+
+	it.each(["partial", "mismatch", "permissions", "symlink", "probe"] as const)(
+		"does not adopt or overwrite an invalid CLI receipt/target: %s",
+		(failure) => {
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-invalid");
+			const paths = getRuntimePaths();
+			const identity = createVersionedCliFixture(paths, "1.2.3");
+			pointManagedCliAt(paths, identity);
+			reconcilePendingRuntimeCliUpgrade(paths);
+			const receipt = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+			switch (failure) {
+				case "partial":
+					delete receipt.verification;
+					break;
+				case "mismatch":
+					receipt.version = "1.2.4";
+					break;
+				case "permissions":
+					chmodSync(identity.activeTarget, 0o777);
+					break;
+				case "symlink":
+					rmSync(identity.activeTarget);
+					symlinkSync("/bin/true", identity.activeTarget);
+					break;
+				case "probe":
+					writeFileSync(identity.activeTarget, "#!/bin/sh\nexit 42\n");
+					break;
+			}
+			writeFileSync(paths.cliBootstrapStatus, JSON.stringify(receipt));
+			const before = readFileSync(paths.cliBootstrapStatus, "utf-8");
+			expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths)).toThrow();
+			expect(readFileSync(paths.cliBootstrapStatus, "utf-8")).toBe(before);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(identity.activeTarget);
+			if (failure === "permissions") {
+				expect(statSync(identity.activeTarget).mode & 0o777).toBe(0o777);
+			}
+		},
+	);
+
+	it("rejects an unreadable CLI receipt instead of recovering it as missing", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-unreadable");
+		const paths = getRuntimePaths();
+		mkdirSync(paths.statusRoot, { recursive: true });
+		writeFileSync(paths.cliBootstrapStatus, "{}", { mode: 0o000 });
+		expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths)).toThrow("EACCES");
+		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0);
 	});
 
 	it("rolls back when the active symlink disagrees with state", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8552,6 +8552,7 @@ chmod +x "$prefix/bin/clawdi"
 			process.env.CLAWDI_RUN_DIR = run;
 			const desiredSpec = `clawdi@${desiredVersion}`;
 			seedCurrentCliInstall(state, currentVersion);
+			const previousUmask = process.umask(0o002);
 
 			try {
 				const desired = normalizeHostedManifestFixture(
@@ -8559,6 +8560,7 @@ chmod +x "$prefix/bin/clawdi"
 				);
 				const paths = getRuntimePaths();
 				const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+				expect(process.umask()).toBe(0o002);
 
 				expect(result.status).toBe("installed");
 				expect(result.selfReexec).toBe(true);
@@ -8572,7 +8574,7 @@ chmod +x "$prefix/bin/clawdi"
 				expect(statSync(paths.cliNpmPrefix).mode & 0o777).toBe(0o755);
 				expect(statSync(result.npmPrefix).mode & 0o777).toBe(0o755);
 				if (!result.activeTarget) throw new Error("CLI update did not return an active target");
-				expect(statSync(result.activeTarget).mode & 0o777).toBe(0o755);
+				expect(statSync(result.activeTarget).mode & 0o777).toBe(0o700);
 				expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
 				const pending = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 				expect(pending).toMatchObject({
@@ -8607,6 +8609,7 @@ chmod +x "$prefix/bin/clawdi"
 					expect(applyRuntimeCliDesiredState(desired.manifest, paths).status).toBe("deferred");
 				}
 			} finally {
+				process.umask(previousUmask);
 				if (previousPath === undefined) delete process.env.PATH;
 				else process.env.PATH = previousPath;
 			}


### PR DESCRIPTION
## Summary
Accept the exact legacy image bootstrap receipt and complete CLI receipt as distinct supported field sets under the existing v1 contract. Reuse verified installations without spurious invalid-status warnings. Reject malformed, unsafe or unreadable receipt/target state instead of overwriting it as missing.

Preserve exact-version/runtime probes, verification freshness and rollback ownership. No new receipt version, CLI release input, filesystem layout or runtime reinstall policy.

## Verification
- Docker CLI typecheck and 127 targeted runtime/observation tests passed
- Pinned Biome 2.5.11 check of changed TS files passed (isolated 6GiB runner)
- git diff --check passed
- Rebased onto the merged logging fix; range-diff unchanged

The image-side verifier fix is a companion Hosted PR. This reader must ship before qualification of the new image/CLI pair. No production operations or package publishing in this PR.