### PR TITLE
fix(cli): align Files startup database environment with durable config

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -429,6 +429,12 @@ platform state. FileBrowser Quantum's primary DB uses
 its SQLite indexes live separately under `cache/sql`. Retention checks should
 read user settings through the Files API, not hash a mutable database during
 concurrent writes. `/run/clawdi-files` remains service-scoped and disposable.
+The service environment sets `FILEBROWSER_DATABASE` to the same
+`/var/lib/clawdi-files/filebrowser.db` path as YAML `server.database`.
+Upstream [default initialization](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/common/settings/config.go#L976)
+checks this environment path (otherwise `./database.db`) before loading YAML.
+This avoids a misleading missing-database warning on retained-state boots;
+a genuinely missing database still produces the native warning.
 The tenant can therefore inspect or alter its
 own Files state and can signal the same-UID Files process, but cannot replace
 the root-owned binary or configuration source, write receipts, or control the

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4673,6 +4673,7 @@ esac
 		const config = readFileSync(paths.fileBrowserConfig, "utf8");
 		expect(parseYaml(config)).toMatchObject({
 			server: {
+				database: join(paths.fileBrowserStateRoot, "filebrowser.db"),
 				sources: [
 					{
 						config: {
@@ -4746,6 +4747,9 @@ esac
 		expect(unit).toContain("TasksMax=128");
 		expect(unit).toContain(
 			`EnvironmentFile=${join(paths.systemdEnvRoot, "clawdi-files.service.env")}`,
+		);
+		expect(readFileSync(join(paths.systemdEnvRoot, "clawdi-files.service.env"), "utf8")).toContain(
+			`FILEBROWSER_DATABASE="${join(paths.fileBrowserStateRoot, "filebrowser.db")}"`,
 		);
 		const second = convergeRuntimeManifest(fileBrowserManifestLoad(manifest), paths, options);
 		expect(second.installErrors).toEqual([]);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1088,6 +1088,8 @@ function writeFileBrowserSystemdUnit(input: {
 		directoryKind: "file-browser",
 		env: {
 			HOME: "/nonexistent",
+			// FileBrowser checks this path before loading server.database from YAML.
+			FILEBROWSER_DATABASE: join(input.paths.fileBrowserStateRoot, "filebrowser.db"),
 			CLAWDI_MANAGED_CONTENT_DIGEST: runtimeImpactRevision({
 				companion: input.manifest.companions?.filebrowser ?? null,
 			}),


### PR DESCRIPTION
## Summary
- Set native FILEBROWSER_DATABASE to the existing YAML database path before upstream default initialization.
- Preserve genuine missing-database warnings, storage layout and permissions; no log suppression.
- Extend existing reconciliation assertions and document upstream ordering.

## Verification
- Agent ran isolated CLI typecheck and 176 tests, Biome, and three native Files startup comparisons.
- Root reviewed the complete diff. No production rollout performed.