### PR TITLE
fix(backend): reserve database capacity for deployment control

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -550,6 +550,9 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 status.HTTP_503_SERVICE_UNAVAILABLE,
                 "OAuth CLI authentication is not configured",
             )
+        # Only the validated setting value is needed during the JWKS network
+        # lookup. Principal authority locks are acquired after JWT verification.
+        await db.rollback()
     signing_key = await _resolve_clerk_signing_key(token)
     if signing_key is None:
         return None

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -209,12 +209,8 @@ class Settings(BaseSettings):
 
     database_url: str = "postgresql+asyncpg://clawdi:clawdi_dev@localhost:5433/clawdi"
 
-    # SQLAlchemy connection pool. Default sqlalchemy values
-    # (pool_size=5 + max_overflow=10) start to choke at ~10k
-    # connected daemons because every SSE refresh tick takes
-    # one connection for the duration of the visibility query.
-    # Override via env in prod (e.g. DB_POOL_SIZE=20,
-    # DB_MAX_OVERFLOW=40 sized to the daemon population).
+    # Ordinary SQLAlchemy pool per process. Budget API processes for the
+    # separate two-connection control pool and LISTEN connection as well.
     db_pool_size: int = 10
     db_max_overflow: int = 20
     db_pool_timeout: float = 30.0

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -8,7 +8,13 @@ import anyio
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, ExceptionContext
 from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.pool import ConnectionPoolEntry, PoolProxiedConnection
 
 from app.core.config import settings
@@ -23,30 +29,41 @@ log = logging.getLogger(__name__)
 _QUERY_STARTED_AT = "clawdi_query_started_at"
 _CONNECTION_CHECKED_OUT_AT = "clawdi_connection_checked_out_at"
 
-# Explicit pool sizing — sqlalchemy's defaults (5+10) starve at
-# ~10k daemons since each SSE refresh tick burns one connection
-# for the duration of the visibility query. Production should
-# size DB_POOL_SIZE / DB_MAX_OVERFLOW from the expected concurrent
-# daemon population (rule of thumb: pool_size = peak_concurrent_qps
-# * avg_query_duration_ms / 1000 + safety margin).
-engine = create_async_engine(
-    settings.database_url,
-    echo=settings.debug,
-    hide_parameters=True,
-    pool_size=settings.db_pool_size,
-    max_overflow=settings.db_max_overflow,
-    pool_timeout=settings.db_pool_timeout,
-    pool_recycle=settings.db_pool_recycle,
-    pool_pre_ping=True,
-    # Alembic creates a separate synchronous engine, so long-running DDL does
-    # not inherit these runtime request safeguards.
-    connect_args={
-        "server_settings": {
-            "statement_timeout": "120s",
-            "idle_in_transaction_session_timeout": "5min",
-        }
-    },
-)
+# Reserved for internal control, never borrowed by ordinary requests or workers.
+# config/deploy.yml deducts these slots from the web role's ordinary pool budget.
+CONTROL_POOL_SIZE = 1
+
+
+def _create_engine(
+    *, pool_size: int, max_overflow: int, lock_timeout: str | None = None
+) -> AsyncEngine:
+    server_settings = {
+        "statement_timeout": "120s",
+        "idle_in_transaction_session_timeout": "5min",
+    }
+    if lock_timeout is not None:
+        server_settings["lock_timeout"] = lock_timeout
+    return create_async_engine(
+        settings.database_url,
+        echo=settings.debug,
+        hide_parameters=True,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_timeout=settings.db_pool_timeout,
+        pool_recycle=settings.db_pool_recycle,
+        pool_pre_ping=True,
+        # Alembic's separate engine does not inherit runtime request safeguards.
+        connect_args={"server_settings": server_settings},
+    )
+
+
+engine = _create_engine(pool_size=settings.db_pool_size, max_overflow=settings.db_max_overflow)
+# SQLAlchemy opens connections lazily; non-API roles never check out this pool.
+control_engine = _create_engine(pool_size=CONTROL_POOL_SIZE, max_overflow=0, lock_timeout="5s")
+# Runtime-source reads retain an authorization transaction while opening a
+# separate consistent snapshot. Reserve its slot separately to avoid nested
+# checkout deadlocks between concurrent control requests.
+control_snapshot_engine = _create_engine(pool_size=1, max_overflow=0)
 
 
 def _finish_query(connection: Connection) -> None:
@@ -101,11 +118,12 @@ def _connection_checkin(
         db_pool_checked_out.dec()
 
 
-event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
-event.listen(engine.sync_engine, "after_cursor_execute", _after_cursor_execute)
-event.listen(engine.sync_engine, "handle_error", _handle_error)
-event.listen(engine.sync_engine.pool, "checkout", _connection_checkout)
-event.listen(engine.sync_engine.pool, "checkin", _connection_checkin)
+for observed_engine in (engine, control_engine, control_snapshot_engine):
+    event.listen(observed_engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+    event.listen(observed_engine.sync_engine, "after_cursor_execute", _after_cursor_execute)
+    event.listen(observed_engine.sync_engine, "handle_error", _handle_error)
+    event.listen(observed_engine.sync_engine.pool, "checkout", _connection_checkout)
+    event.listen(observed_engine.sync_engine.pool, "checkin", _connection_checkin)
 
 
 async def _close_session(session: AsyncSession) -> None:
@@ -149,6 +167,37 @@ async_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
     class_=_CancellationSafeAsyncSession,
     expire_on_commit=False,
 )
+control_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+    control_engine,
+    class_=_CancellationSafeAsyncSession,
+    expire_on_commit=False,
+)
+control_snapshot_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+    control_snapshot_engine,
+    class_=_CancellationSafeAsyncSession,
+    expire_on_commit=False,
+)
+
+
+class ControlLockTimeoutError(RuntimeError):
+    """PostgreSQL could not acquire a control transaction's lock in time."""
+
+
+@asynccontextmanager
+async def _control_session() -> AsyncGenerator[AsyncSession, None]:
+    try:
+        async with control_session_factory() as session:
+            yield session
+    except DBAPIError as exc:
+        if getattr(exc.orig, "sqlstate", None) == "55P03":
+            raise ControlLockTimeoutError() from None
+        raise
+
+
+async def get_control_session() -> AsyncGenerator[AsyncSession, None]:
+    """Deployment/recovery control and its authentication, never channel management."""
+    async with _control_session() as session:
+        yield session
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
@@ -160,7 +209,7 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None]:
-    """Open one repeatable-read observation snapshot that may persist expiry.
+    """Open an internal control observation snapshot that may persist expiry.
 
     Successful reads remain side-effect free. A known consumer presenting an
     unknown or stale cursor must, however, atomically persist its explicit reset
@@ -168,18 +217,17 @@ async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None
     cannot be PostgreSQL read-only.
     """
 
-    session = async_session_factory()
-    try:
+    async with _control_session() as session:
         await session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
         yield session
-    finally:
-        await _close_session(session)
 
 
 @asynccontextmanager
-async def runtime_snapshot_session() -> AsyncGenerator[AsyncSession, None]:
+async def runtime_snapshot_session(
+    *, session_factory: async_sessionmaker[AsyncSession] | None = None
+) -> AsyncGenerator[AsyncSession, None]:
     """Open the consistent read-only snapshot shared by runtime renderers."""
-    session = async_session_factory()
+    session = (session_factory or async_session_factory)()
     try:
         await _configure_runtime_snapshot(session)
         yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Literal
 
-from fastapi import Depends, FastAPI, Request, Response, status
+from fastapi import Depends, FastAPI, Request, Response, WebSocket, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
@@ -18,7 +18,12 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.auth import AccountSuspendedHTTPException, warm_clerk_jwks
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import (
+    ControlLockTimeoutError,
+    control_engine,
+    control_snapshot_engine,
+    get_session,
+)
 from app.core.logging_config import configure_application_logging
 from app.core.sentry import init_sentry
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
@@ -73,7 +78,7 @@ from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder, LocalServiceEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
-from app.services.metrics import db_pool_timeouts, observe_event_loop_lag
+from app.services.metrics import db_control_lock_timeouts, db_pool_timeouts, observe_event_loop_lag
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarClientPool
 
@@ -162,7 +167,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
                     try:
                         await close_composio_client()
                     finally:
-                        await LocalServiceEmbedder.close_shared()
+                        try:
+                            await LocalServiceEmbedder.close_shared()
+                        finally:
+                            try:
+                                await control_engine.dispose()
+                            finally:
+                                await control_snapshot_engine.dispose()
 
 
 app = FastAPI(
@@ -414,13 +425,32 @@ async def memory_provider_upstream_exception_handler(
     )
 
 
+@app.exception_handler(ControlLockTimeoutError)
+async def control_lock_timeout_exception_handler(
+    _request: Request,
+    _exc: ControlLockTimeoutError,
+) -> JSONResponse:
+    db_control_lock_timeouts.inc()
+    log.warning("database_control_lock_timeout")
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"detail": "Deployment control temporarily unavailable"},
+        headers={"Retry-After": "1", "Cache-Control": "no-store"},
+    )
+
+
 @app.exception_handler(SQLAlchemyTimeoutError)
 async def database_pool_timeout_exception_handler(
-    request: Request,
+    request: Request | WebSocket,
     _exc: SQLAlchemyTimeoutError,
-) -> Response:
+) -> Response | None:
     db_pool_timeouts.inc()
     log.warning("database_pool_exhausted")
+    if isinstance(request, WebSocket):
+        # Before accept this rejects the handshake; afterwards it closes with
+        # Try Again Later. Neither path emits an HTTP ASGI response on a socket.
+        await request.close(code=status.WS_1013_TRY_AGAIN_LATER)
+        return None
     response = JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content={"detail": "Database capacity temporarily unavailable"},

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -40,7 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.auth import require_admin_api_key
-from app.core.database import get_session
+from app.core.database import get_control_session, get_session
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
 from app.models.app_setting import AppSetting
@@ -283,7 +283,7 @@ async def admin_set_principal_suspension(
     body: AdminPrincipalSuspensionUpdate,
     response: Response,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminPrincipalSuspensionResponse:
     """Idempotently set or clear the platform-owned authentication fence."""
 
@@ -865,7 +865,7 @@ async def _assert_admin_cleanup_target_owns_environment(
 async def admin_mint_api_key(
     body: AdminApiKeyCreate,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> ApiKeyCreated:
     """Mint an api_key on behalf of a user identified by Clerk id.
 
@@ -963,7 +963,7 @@ async def admin_mint_api_key(
 async def admin_revoke_api_key(
     key_id: UUID,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> ApiKeyRevokeResponse:
     """Revoke any user's api_key. Used by SaaS admin/account-deletion
     paths (which don't have the user's Clerk JWT) to close the
@@ -1016,7 +1016,7 @@ async def admin_get_clawdi_managed_ai_provider(
     owner_kind: Annotated[str | None, Query(alias="kind")] = None,
     owner_ref: Annotated[str | None, Query(alias="ref")] = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminDeploymentManagedAiProviderResponse:
     """Read one first-party managed provider within an explicit owner scope."""
 
@@ -1087,7 +1087,7 @@ async def admin_upsert_clawdi_managed_ai_provider(
     provider_id: str,
     body: AdminManagedAiProviderUpsert | AdminDeploymentManagedAiProviderUpsert,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminManagedAiProviderResponse | AdminDeploymentManagedAiProviderResponse:
     """Upsert the first-party managed AI provider for a target user.
 
@@ -1262,7 +1262,7 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
     provider_id: str,
     body: AdminDeploymentManagedAiProviderRuntimeMetadataReplace,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminDeploymentManagedAiProviderResponse:
     """Replace deployment-managed runtime metadata without changing auth state."""
 
@@ -1350,7 +1350,7 @@ async def admin_get_ai_provider_removal_authority(
     owner_kind: Annotated[str | None, Query(alias="kind")] = None,
     owner_ref: Annotated[str | None, Query(alias="ref")] = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminAiProviderRemovalAuthorityResponse:
     """Read the exact Cloud incarnation to which removal must compare-and-set."""
 
@@ -1401,7 +1401,7 @@ async def admin_archive_ai_provider(
     ],
     provider_id: str = Path(..., min_length=1, max_length=80),
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminAiProviderArchiveReceipt:
     """Archive exactly the Cloud incarnation confirmed before Hosted Unset."""
 
@@ -1524,7 +1524,7 @@ async def admin_cleanup_deployment_managed_ai_provider(
     provider_id: str,
     body: AdminDeploymentManagedAiProviderCleanup,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminDeploymentManagedAiProviderCleanupReceipt:
     """Archive or prove one exact deployment-scoped managed provider."""
 
@@ -1623,7 +1623,7 @@ async def admin_delete_clawdi_managed_ai_provider(
     owner_kind: Annotated[str | None, Query(alias="kind")] = None,
     owner_ref: Annotated[str | None, Query(alias="ref")] = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AiProviderDeleteResponse:
     """Archive one first-party managed provider within an explicit owner scope."""
 
@@ -2269,7 +2269,7 @@ async def _admin_register_environment(
 async def admin_register_agent(
     body: AdminAgentCreate,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> EnvironmentCreatedResponse:
     return await _admin_register_environment(
         AdminEnvironmentCreate(
@@ -2294,7 +2294,7 @@ async def admin_register_agent(
 async def admin_register_environment(
     body: AdminEnvironmentCreate,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> EnvironmentCreatedResponse:
     """Register an AgentEnvironment row on behalf of a target user.
 
@@ -2380,7 +2380,7 @@ async def admin_delete_agent(
     agent_id: UUID,
     target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> None:
     await _admin_delete_environment(agent_id, target_clerk_id, db)
 
@@ -2394,7 +2394,7 @@ async def admin_delete_environment(
     environment_id: UUID,
     target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> None:
     """Delete an AgentEnvironment row on behalf of first-party hosted infra.
 
@@ -2628,7 +2628,7 @@ async def admin_get_runtime_source_authority(
     agent_id: UUID,
     owner: Annotated[PlatformOwner, Query()],
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> RuntimeSourceAuthorityResponse:
     target = await _find_admin_owner(db, owner)
     try:
@@ -2660,7 +2660,7 @@ async def admin_upsert_agent_runtime_state(
     agent_id: UUID,
     body: AdminRuntimeStateUpsert,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminRuntimeStateResponse:
     return await _admin_upsert_runtime_state(agent_id, body, db)
 
@@ -2674,7 +2674,7 @@ async def admin_upsert_runtime_state(
     environment_id: UUID,
     body: AdminRuntimeStateUpsert,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> AdminRuntimeStateResponse:
     return await _admin_upsert_runtime_state(environment_id, body, db)
 
@@ -2767,7 +2767,7 @@ async def admin_delete_agent_runtime_state(
     agent_id: UUID,
     target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> None:
     await _admin_delete_runtime_state(agent_id, target_clerk_id, db)
 
@@ -2781,7 +2781,7 @@ async def admin_delete_runtime_state(
     environment_id: UUID,
     target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> None:
     await _admin_delete_runtime_state(environment_id, target_clerk_id, db)
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -384,14 +384,15 @@ async def telegram_bot_api(
     authorization: str | None = Header(default=None),
     db: AsyncSession = Depends(get_session),
 ) -> _TelegramJsonObject | Response:
+    # Read the bounded request body before checking out an auth connection.
+    raw_body = await request.body()
+    params = await _telegram_request_params(request)
     agent, _agent_token = await _resolve_telegram_agent(
         db,
         routing_id=routing_id,
         authorization=authorization,
     )
     account = agent.account
-    raw_body = await request.body()
-    params = await _telegram_request_params(request)
     duplicate_parameter = await _telegram_duplicate_security_parameter(request, raw_body, params)
     if duplicate_parameter is not None:
         return _telegram_error_response(

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -14,6 +14,7 @@ from fastapi import (
 )
 from pydantic import JsonValue
 from sqlalchemy import select, update
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -373,6 +374,9 @@ async def _run_whatsapp_baileys_websocket(
         return
     except _WhatsAppSessionAuthorityRevoked:
         return
+    except SQLAlchemyTimeoutError:
+        # Let the protocol-aware pool boundary close with Try Again Later.
+        raise
     except Exception as exc:  # noqa: BLE001 - close malformed agent sockets without leaking internals.
         with contextlib.suppress(Exception):
             await record_runtime_event(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import get_session
+from app.core.database import get_control_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -172,7 +172,7 @@ def _oauth_form_value(form: Any, name: str) -> str:
 )
 async def platform_workload_oauth_token(
     request: Request,
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
     resolver: PlatformWorkloadKeyResolver = Depends(get_platform_workload_key_resolver),
 ) -> PlatformOAuthTokenResponse | Response:
     if request.headers.getlist("authorization") or request.headers.getlist("x-admin-key"):
@@ -632,7 +632,7 @@ async def platform_create_agent(
     request: Request,
     idempotency_key: IdempotencyKey,
     _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:agents:create")),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> EnvironmentCreatedResponse | Response:
     action = "agent_environment.create"
     owner = await _resolve_owner(
@@ -726,7 +726,7 @@ async def platform_delete_agent(
     request: Request,
     idempotency_key: IdempotencyKey,
     _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:agents:delete")),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> Response:
     action = "agent_environment.delete"
     owner = await _resolve_owner(
@@ -809,7 +809,7 @@ async def platform_get_runtime_source_authority(
     _auth: PlatformMutationAuth = Depends(
         require_platform_mutation_auth("platform:runtime-state:write")
     ),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> RuntimeSourceAuthorityResponse:
     owner_user_id = await _resolve_runtime_source_authority_owner_id(db, owner)
     try:
@@ -845,7 +845,7 @@ async def platform_upsert_runtime_state(
     _auth: PlatformMutationAuth = Depends(
         require_platform_mutation_auth("platform:runtime-state:write")
     ),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> PlatformRuntimeStateResponse | Response:
     action = "hosted_runtime_state.upsert"
     owner = await _resolve_owner(
@@ -1101,7 +1101,7 @@ async def platform_delete_runtime_state(
     _auth: PlatformMutationAuth = Depends(
         require_platform_mutation_auth("platform:runtime-state:write")
     ),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> Response:
     action = "hosted_runtime_state.delete"
     owner = await _resolve_owner(
@@ -1185,7 +1185,7 @@ async def platform_mint_api_key(
     request: Request,
     idempotency_key: IdempotencyKey,
     _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:keys:mint")),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> ApiKeyCreated | Response:
     action = "api_key.mint"
     owner = await _resolve_owner(
@@ -1271,7 +1271,7 @@ async def platform_revoke_api_key(
     request: Request,
     idempotency_key: IdempotencyKey,
     _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:keys:revoke")),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> ApiKeyRevokeResponse | Response:
     action = "api_key.revoke"
     owner = await _resolve_owner(

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -16,7 +16,7 @@ from app.core.auth import (
     is_runtime_deployment_principal,
     require_admin_api_key,
 )
-from app.core.database import get_runtime_observation_session, get_session
+from app.core.database import get_control_session, get_runtime_observation_session, get_session
 from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.user import PRINCIPAL_KIND_CLERK, PRINCIPAL_KIND_PARTNER_TENANT, User
@@ -393,7 +393,7 @@ async def create_runtime_deployment_key(
     body: RuntimeDeploymentKeyCreate,
     idempotency_key: IdempotencyKey,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> JSONResponse:
     owner = await _resolve_owner(db, body.owner)
     request_payload = body.model_dump(mode="json", by_alias=True)
@@ -536,7 +536,7 @@ async def retire_runtime_environment_endpoint(
     body: RuntimeEnvironmentRetireRequest,
     idempotency_key: IdempotencyKey,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> JSONResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
     binding_owner_id = binding.owner_id
@@ -662,7 +662,7 @@ async def cleanup_retired_runtime_state_endpoint(
     auth: PlatformMutationAuth = Depends(
         require_platform_mutation_auth("platform:runtime-environments:retire")
     ),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> JSONResponse:
     try:
         if body.environment_reference != environment_id:
@@ -752,7 +752,7 @@ async def register_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerRequest,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> RuntimeObservationConsumerResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
     try:
@@ -824,7 +824,7 @@ async def acknowledge_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerAckRequest,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> RuntimeObservationConsumerResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
     try:
@@ -857,7 +857,7 @@ async def reset_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerRequest,
     _: None = Depends(require_admin_api_key),
-    db: AsyncSession = Depends(get_session),
+    db: AsyncSession = Depends(get_control_session),
 ) -> RuntimeObservationConsumerResetResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
     try:

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -155,6 +155,11 @@ db_pool_timeouts = Counter(
     "Requests rejected because the backend database pool was exhausted",
     registry=registry,
 )
+db_control_lock_timeouts = Counter(
+    "clawdi_backend_db_control_lock_timeouts_total",
+    "Control requests rejected because PostgreSQL could not acquire a lock in time",
+    registry=registry,
+)
 embedding_in_flight = Gauge(
     "clawdi_backend_embedding_in_flight",
     "Embedding requests currently executing or waiting on the configured backend",

--- a/backend/app/services/platform_workload_auth.py
+++ b/backend/app/services/platform_workload_auth.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import require_admin_api_key
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import get_control_session
 from app.models.platform_workload_auth import (
     PLATFORM_WORKLOAD_CLIENT_ACTIVE,
     PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
@@ -706,7 +706,7 @@ def _require_platform_auth(required_scope: str, *, allow_legacy_admin: bool):
         request: Request,
         x_admin_key: Annotated[str | None, Header(alias="X-Admin-Key")] = None,
         authorization: Annotated[str | None, Header(alias="Authorization")] = None,
-        db: AsyncSession = Depends(get_session),
+        db: AsyncSession = Depends(get_control_session),
         resolver: PlatformWorkloadKeyResolver = Depends(get_platform_workload_key_resolver),
     ) -> PlatformMutationAuth:
         admin_values = _credential_values(request, "x-admin-key")

--- a/backend/app/services/runtime_source_authority.py
+++ b/backend/app/services/runtime_source_authority.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.database import runtime_snapshot_session
+from app.core.database import control_snapshot_session_factory, runtime_snapshot_session
 from app.models.agent_plugin import AgentPluginInstallation
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -142,7 +142,9 @@ async def load_runtime_source_authority(
 ) -> RuntimeSourceAuthority:
     """Load the persisted authority, rendering only an unbackfilled legacy row."""
 
-    async with runtime_snapshot_session() as source_db:
+    async with runtime_snapshot_session(
+        session_factory=control_snapshot_session_factory
+    ) as source_db:
         persisted = await load_persisted_runtime_source_authority(
             source_db,
             environment_id=environment_id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,7 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.core.auth import AuthContext, get_auth, get_auth_short_session, optional_web_auth
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import get_control_session, get_session
 from app.main import app
 from app.models.user import User
 
@@ -529,6 +529,7 @@ async def client(db_session: AsyncSession, seed_user: User) -> AsyncIterator[htt
         return AuthContext(user=seed_user)
 
     overrides = {
+        get_control_session: _override_get_session,
         get_session: _override_get_session,
         get_auth: _override_get_auth,
         get_auth_short_session: _override_get_auth,
@@ -561,6 +562,7 @@ async def anon_client(
 
     with _dependency_overrides(
         {
+            get_control_session: _override_get_session,
             get_session: _override_get_session,
             optional_web_auth: _override_optional_web_auth,
         }
@@ -590,6 +592,7 @@ async def cli_client(db_session: AsyncSession, seed_user: User) -> AsyncIterator
 
     with _dependency_overrides(
         {
+            get_control_session: _override_get_session,
             get_session: _override_get_session,
             get_auth: _override_get_auth,
             get_auth_short_session: _override_get_auth,

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -22,7 +22,7 @@ from httpx import ASGITransport
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import get_control_session, get_session
 from app.main import app
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_API_MODE,
@@ -157,6 +157,7 @@ async def admin_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncClient
 
     original_admin_key = settings.admin_api_key
     settings.admin_api_key = _ADMIN_KEY
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
 
     # Outer try/finally guards `settings.admin_api_key` restoration
@@ -185,6 +186,7 @@ async def _isolated_admin_client(engine) -> AsyncIterator[httpx.AsyncClient]:
 
     original_admin_key = settings.admin_api_key
     settings.admin_api_key = _ADMIN_KEY
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     try:
         async with httpx.AsyncClient(
@@ -379,6 +381,7 @@ async def test_admin_endpoints_disabled_when_unset(db_session, seed_user):
     original = settings.admin_api_key
     settings.admin_api_key = ""
 
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     try:
         transport = ASGITransport(app=app)

--- a/backend/tests/test_database_timeouts.py
+++ b/backend/tests/test_database_timeouts.py
@@ -1,25 +1,81 @@
+import asyncio
+
+import httpx
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.exc import DBAPIError
 
-from app.core.database import engine
+from app.core.config import settings
+from app.core.database import async_session_factory, control_engine, control_snapshot_engine, engine
+from app.main import app
+from app.models.api_key import ApiKey
+from app.services.api_key import mint_api_key
+from app.services.metrics import registry
 
 
 @pytest.mark.asyncio
-async def test_database_engine_applies_and_enforces_postgres_timeouts():
-    async with engine.connect() as connection:
+@pytest.mark.parametrize(
+    ("database_engine", "lock_timeout"),
+    [(engine, "0"), (control_engine, "5s"), (control_snapshot_engine, "0")],
+    ids=["ordinary", "control", "snapshot"],
+)
+async def test_database_engine_applies_and_enforces_postgres_timeouts(
+    database_engine, lock_timeout
+):
+    async with database_engine.connect() as connection:
         configured = (
             await connection.execute(
                 text(
                     "SELECT current_setting('statement_timeout'), "
-                    "current_setting('idle_in_transaction_session_timeout')"
+                    "current_setting('idle_in_transaction_session_timeout'), "
+                    "current_setting('lock_timeout')"
                 )
             )
         ).one()
-        assert configured == ("2min", "5min")
+        assert configured == ("2min", "5min", lock_timeout)
 
         await connection.execute(text("SET LOCAL statement_timeout = '10ms'"))
         with pytest.raises(DBAPIError) as cancelled:
             await connection.execute(text("SELECT pg_sleep(0.1)"))
 
         assert cancelled.value.orig.sqlstate == "57014"
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_control_authority_lock_timeout_is_retryable_and_recovers(
+    db_session, seed_user, monkeypatch
+):
+    minted = await mint_api_key(db_session, user_id=seed_user.id, label="control-lock-timeout")
+    key_id = minted.api_key.id
+    await db_session.commit()
+    monkeypatch.setattr(settings, "admin_api_key", "test-control-lock-key")
+    lock_metric = "clawdi_backend_db_control_lock_timeouts_total"
+    pool_metric = "clawdi_backend_db_pool_timeouts_total"
+    locks_before = registry.get_sample_value(lock_metric)
+    pools_before = registry.get_sample_value(pool_metric)
+    assert locks_before is not None
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with async_session_factory() as ordinary:
+            await ordinary.execute(select(ApiKey.id).where(ApiKey.id == key_id).with_for_update())
+            # The ordinary authority transaction stays open past the control
+            # lock timeout. An unchanged 120s statement timeout fails this bound.
+            async with asyncio.timeout(12):
+                rejected = await client.delete(
+                    f"/v1/admin/auth/keys/{key_id}",
+                    headers={"X-Admin-Key": "test-control-lock-key"},
+                )
+            assert rejected.status_code == 503
+            assert rejected.json() == {"detail": "Deployment control temporarily unavailable"}
+            assert rejected.headers["Retry-After"] == "1"
+            assert registry.get_sample_value(lock_metric) == locks_before + 1
+            assert registry.get_sample_value(pool_metric) == pools_before
+
+        recovered = await client.delete(
+            f"/v1/admin/auth/keys/{key_id}",
+            headers={"X-Admin-Key": "test-control-lock-key"},
+        )
+        assert recovered.status_code == 200, recovered.text
+        assert recovered.json() == {"status": "revoked"}

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -13,7 +13,7 @@ from httpx import ASGITransport
 from sqlalchemy import func, select
 
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import get_control_session, get_session
 from app.main import app
 from app.models.api_key import ApiKey
 from app.models.audit import ControlPlaneAuditEvent
@@ -86,6 +86,7 @@ async def platform_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncCli
     original_clerk_issuer = settings.clerk_jwt_issuer
     settings.admin_api_key = _ADMIN_KEY
     settings.clerk_jwt_issuer = _CLERK_ISSUER
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     try:
         async with httpx.AsyncClient(
@@ -500,6 +501,7 @@ async def test_retirement_fences_late_runtime_state_writes_and_old_replay(
             yield session
 
     previous_session_override = app.dependency_overrides[get_session]
+    app.dependency_overrides[get_control_session] = _fresh_session
     app.dependency_overrides[get_session] = _fresh_session
     try:
         client = platform_client
@@ -574,6 +576,7 @@ async def test_retirement_fences_late_runtime_state_writes_and_old_replay(
         assert admin.status_code == 409, admin.text
         assert admin.json()["detail"]["code"] == "runtime_environment_retired"
     finally:
+        app.dependency_overrides[get_control_session] = previous_session_override
         app.dependency_overrides[get_session] = previous_session_override
 
 

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from collections.abc import AsyncIterator
@@ -15,9 +16,12 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import ASGITransport
 from sqlalchemy import delete, func, select
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
+from app.core import database
+from app.core.auth import AuthContext, get_auth_short_session
 from app.core.config import settings
-from app.core.database import get_runtime_observation_session, get_session
+from app.core.database import get_control_session, get_runtime_observation_session, get_session
 from app.main import app
 from app.models.ai_provider import AiProviderAuthPayload
 from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES, ApiKey
@@ -33,7 +37,10 @@ from app.models.platform_workload_auth import (
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
 from app.models.user import User
-from app.services import platform_workload_auth
+from app.routes import admin as admin_route
+from app.routes import sync as sync_route
+from app.routes.channel_routers.discord import _discord_gateway_consumer_lease
+from app.services import platform_workload_auth, runtime_source_authority
 from app.services.platform_workload_auth import (
     PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
     PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
@@ -48,6 +55,11 @@ from app.services.platform_workload_auth import (
 )
 from app.services.runtime_observation import retire_runtime_environment
 from app.services.vault_crypto import encrypt
+from tests.conftest import create_test_hosted_runtime_state
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOLS,
+    ensure_canonical_codex_tool_provider,
+)
 
 _ADMIN_KEY = "test-platform-admin-secret"
 _CLERK_ISSUER = "https://platform-workload.clerk.example.test"
@@ -133,6 +145,7 @@ async def workload_harness(db_session, seed_user) -> AsyncIterator[WorkloadHarne
     settings.public_api_url = "http://test"
     settings.platform_workload_token_endpoint = ""
     settings.platform_workload_issuer = "clawdi-cloud-platform-test"
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     app.dependency_overrides[get_runtime_observation_session] = _override_get_session
     app.dependency_overrides[get_platform_workload_key_resolver] = _override_resolver
@@ -253,6 +266,127 @@ def _agent_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, Any]:
         "agent_version": "1.0.0",
         "os_name": "linux",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
+    workload_harness, seed_user, db_session, monkeypatch
+):
+    """Real pool contention must not strand token issuance or deployment recovery."""
+    monkeypatch.setattr(settings, "db_pool_timeout", 1.0)
+    ordinary = database._create_engine(pool_size=2, max_overflow=0)
+    control = database._create_engine(pool_size=database.CONTROL_POOL_SIZE, max_overflow=0)
+    snapshot = database._create_engine(pool_size=1, max_overflow=0)
+    ordinary_sessions = async_sessionmaker(
+        ordinary, class_=database.async_session_factory.class_, expire_on_commit=False
+    )
+    control_sessions = async_sessionmaker(
+        control, class_=database.control_session_factory.class_, expire_on_commit=False
+    )
+    monkeypatch.setattr(database, "async_session_factory", ordinary_sessions)
+    monkeypatch.setattr(database, "control_session_factory", control_sessions)
+    monkeypatch.setattr(sync_route, "async_session_factory", ordinary_sessions)
+    monkeypatch.setattr(
+        runtime_source_authority,
+        "control_snapshot_session_factory",
+        async_sessionmaker(
+            snapshot,
+            class_=database.control_snapshot_session_factory.class_,
+            expire_on_commit=False,
+        ),
+    )
+    for dependency in (get_session, get_control_session, get_runtime_observation_session):
+        monkeypatch.delitem(app.dependency_overrides, dependency)
+
+    async def sync_auth():
+        return AuthContext(user=seed_user)
+
+    monkeypatch.setitem(app.dependency_overrides, get_auth_short_session, sync_auth)
+    provider_started = asyncio.Event()
+
+    async def slow_provider_webhook(**kwargs):
+        provider_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(admin_route, "configure_telegram_provider_webhook", slow_provider_webhook)
+    owner = _owner(seed_user)
+    agent_id = uuid.uuid4()
+    await db_session.commit()
+    client = workload_harness.client
+    try:
+        # A gateway lease and a channel transaction awaiting provider I/O consume
+        # both ordinary slots. Only the external provider call is stubbed.
+        async with _discord_gateway_consumer_lease(
+            account_id=uuid.uuid4(), bot_agent_link_id=uuid.uuid4(), lock_engine=ordinary
+        ) as acquired:
+            assert acquired
+            pressure = asyncio.create_task(
+                client.post(
+                    "/v1/admin/channels",
+                    headers={"X-Admin-Key": _ADMIN_KEY},
+                    json={
+                        "provider": "telegram",
+                        "name": f"slow-provider-{agent_id}",
+                        "visibility": "public",
+                        "provider_token": "test-provider-token",
+                    },
+                )
+            )
+            try:
+                await asyncio.wait_for(provider_started.wait(), timeout=2)
+                async with asyncio.timeout(10):
+                    saturated = await client.get("/v1/sync/events")
+                    assert saturated.status_code == 503, saturated.text
+                    assert saturated.headers["Retry-After"] == "1"
+                    token = await _access_token(
+                        workload_harness, "platform:agents:create platform:agents:delete"
+                    )
+                    created = await client.post(
+                        "/v1/platform/agents",
+                        headers=_workload_headers(token, f"capacity-create-{agent_id}"),
+                        json=_agent_body(owner, agent_id),
+                    )
+                    assert created.status_code == 200, created.text
+                    agent = await db_session.get(AgentEnvironment, agent_id)
+                    state = await create_test_hosted_runtime_state(
+                        db_session, agent, runtime_name="openclaw"
+                    )
+                    await ensure_canonical_codex_tool_provider(db_session, seed_user)
+                    state.tools = CANONICAL_CODEX_TOOLS
+                    await db_session.commit()
+                    # These reads retain the outer authorization transaction
+                    # while loading a nested snapshot. Concurrent callers must
+                    # neither fall back to the ordinary pool nor deadlock.
+                    reads = await asyncio.gather(
+                        *(
+                            client.get(
+                                f"{prefix}/admin/agents/{agent_id}/runtime-state",
+                                params=owner,
+                                headers={"X-Admin-Key": _ADMIN_KEY},
+                            )
+                            for prefix in ("/v1", "/api")
+                        )
+                    )
+                    for result in reads:
+                        assert result.status_code == 200, result.text
+                    recovered = await client.request(
+                        "DELETE",
+                        f"/v1/platform/agents/{agent_id}",
+                        headers=_workload_headers(token, f"capacity-delete-{agent_id}"),
+                        json={"owner": owner},
+                    )
+                    assert recovered.status_code == 204, recovered.text
+
+                    assert not pressure.done()
+            finally:
+                pressure.cancel()
+                await asyncio.gather(pressure, return_exceptions=True)
+        assert (await client.get("/ready")).status_code == 200
+    finally:
+        await ordinary.dispose()
+        await control.dispose()
+        await snapshot.dispose()
 
 
 def _runtime_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, Any]:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
 from app.core.database import engine as runtime_engine
-from app.core.database import get_session
+from app.core.database import get_control_session, get_session
 from app.main import app
 from app.models.agent_plugin import (
     AgentPluginInstallation,
@@ -459,6 +459,7 @@ async def admin_client(db_session) -> AsyncIterator[httpx.AsyncClient]:
     original_clerk_issuer = settings.clerk_jwt_issuer
     settings.admin_api_key = _ADMIN_KEY
     settings.clerk_jwt_issuer = "https://runtime-manifest.clerk.example.test"
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     try:
         transport = ASGITransport(app=app)
@@ -491,6 +492,7 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
     async def _override_get_auth():
         return AuthContext(user=seed_user, api_key=api_key)
 
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     app.dependency_overrides[get_auth] = _override_get_auth
     transport = ASGITransport(app=app)
@@ -511,6 +513,7 @@ async def _isolated_admin_client(engine) -> AsyncIterator[httpx.AsyncClient]:
 
     original_admin_key = settings.admin_api_key
     settings.admin_api_key = _ADMIN_KEY
+    app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     try:
         async with httpx.AsyncClient(

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from fastapi.testclient import TestClient
 from httpx import ASGITransport
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from starlette.websockets import WebSocketDisconnect
 
 from app.core.database import get_session
 from app.main import app
+from app.routes.channel_routers import discord, whatsapp
 
 
 @pytest.mark.asyncio
@@ -71,6 +74,26 @@ async def test_unauthenticated_request_rejected():
         r = await ac.get("/v1/memories")
     # HTTPBearer returns 403 when the Authorization header is absent.
     assert r.status_code in (401, 403), r.text
+
+
+@pytest.mark.parametrize("provider", ["whatsapp", "discord"])
+def test_websocket_pool_timeout_rejects_or_closes_without_http_response(monkeypatch, provider):
+    async def exhausted_auth(*args, **kwargs):
+        raise SQLAlchemyTimeoutError("private pool state")
+
+    route = whatsapp if provider == "whatsapp" else discord
+    monkeypatch.setattr(route, "resolve_channel_agent_by_token", exhausted_auth)
+    path = f"/v1/channels/{provider}/{'baileys' if provider == 'whatsapp' else 'gateway'}"
+    # No lifespan: authentication fails before any actual database or provider I/O.
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as closed:
+        with client.websocket_connect(path, headers={"Authorization": "Bearer test"}) as socket:
+            assert provider == "discord"  # Discord accepts before IDENTIFY; WhatsApp does not.
+            assert socket.receive_json()["op"] == 10
+            socket.send_json({"op": 2, "d": {"token": "test"}})
+            socket.receive_json()
+    assert closed.value.code == 1013
+    assert "private" not in closed.value.reason
 
 
 @pytest.mark.asyncio

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,10 +59,11 @@ servers:
         # This is the smallest measured capacity step. The local ONNX model is
         # isolated below, so two API workers no longer duplicate its RSS.
         WEB_CONCURRENCY: 2
-        # Keep the web role at 20 total connections across both workers. The
-        # release helper rolls database-owning roles sequentially (60/100 max).
+        # Per worker: 5+3 ordinary + 2 reserved control = 10 pooled connections.
+        # Both workers total 20; channels totals 20. Sequential role rolls peak
+        # at 60 pooled + 5 LISTEN = 65 of 97 ordinary PostgreSQL client slots.
         DB_POOL_SIZE: 5
-        DB_MAX_OVERFLOW: 5
+        DB_MAX_OVERFLOW: 3
         DB_POOL_TIMEOUT: 5
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
   embedding-worker:

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -395,6 +395,55 @@ limit 10;
 
 ## Local admin API
 
+Deployment control routes use `get_control_session`, not the ordinary request
+pool: Agent registration/deletion, credentials and principal suspension,
+deployment-managed providers, platform token issuance/authentication and
+mutations, and internal runtime observation/recovery, including their aliases.
+Settings and all channel management (including WhatsApp pairing, command sync,
+and deletion) use the ordinary pool. Their external provider calls may retain
+transactions needed for atomic ownership and lifecycle transitions; an admin
+credential does not entitle them to the deployment reserve. The repeatable-read
+observation dependency uses the same control pool. Credential and scope
+checks remain mandatory; a URL prefix or client-supplied header never selects
+the pool for an ordinary route. Platform credentials must be read from this
+pool to authenticate even while ordinary traffic is saturated.
+
+Each API process reserves one control transaction connection and one separate
+control runtime-source snapshot connection, both without overflow. A source
+read holds its authorization transaction while opening a consistent snapshot;
+separate pools prevent nested checkout deadlocks between concurrent callers.
+Both use the ordinary pool's timeout, metrics, and cancellation-safe cleanup.
+Only control transactions additionally set a code-owned 5s `lock_timeout` per
+lock acquisition. PostgreSQL SQLSTATE `55P03` becomes a sanitized 503 with
+`Retry-After: 1`, counted by `clawdi_backend_db_control_lock_timeouts_total`,
+not the pool-timeout counter. Ordinary and read-only snapshot pools do not
+inherit this lock timeout.
+It isolates pool starvation, not PostgreSQL row locks, CPU saturation, or
+excessive internal-control traffic. See the [release budget](runbooks/release.md).
+SSE auth/visibility/lease queries and Telegram long polls release their query
+connections between waits. OAuth CLI authentication releases its read-only
+setting lookup before waiting on Clerk JWKS. Discord's session advisory lock
+must retain its ordinary connection for the consumer lifetime; releasing it would permit
+duplicate consumers. Delivery transactions that fence authority across sends
+also retain their locks deliberately.
+
+Pool timeout handling distinguishes HTTP from WebSocket: HTTP returns 503
+with `Retry-After: 1`; WebSocket sends `websocket.close` (1013 after acceptance,
+handshake rejection before acceptance). This follows the pinned
+[SQLAlchemy 2.0.52 pool](https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0_52/lib/sqlalchemy/pool/impl.py),
+[Starlette 1.6.0 exception handling](https://github.com/Kludex/starlette/blob/1.6.0/starlette/_exception_handler.py),
+and [Uvicorn 0.52.4 WebSocket transport](https://github.com/Kludex/uvicorn/blob/0.52.4/uvicorn/protocols/websockets/websockets_sansio_impl.py)
+contracts. A close before acceptance rejects the HTTP upgrade with 403; no
+WebSocket close frame can be delivered before the upgrade.
+
+```bash
+scripts/test.sh backend tests/test_platform_workload_oauth.py tests/test_smoke.py
+```
+
+Done: slow admin provider I/O and real PostgreSQL pool contention leave
+deployment control and concurrent nested snapshots usable, both
+WebSocket timeout paths close without HTTP ASGI messages, and the command exits 0.
+
 Admin endpoints are disabled by default. The local setup and key-minting flow is
 in [`AGENTS.md`](../AGENTS.md#local-end-to-end). To exercise admin endpoints
 locally, set `ADMIN_API_KEY` in `backend/.env` to your own local-only random

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -355,13 +355,21 @@ Every migration must therefore remain expand/contract compatible with the old
 API during this window. Operators must use the release workflow rather than
 running Alembic independently.
 
-The two-worker `web` role owns two `5 + 5` PostgreSQL pools, while
-`channels-worker` owns one `10 + 10` pool. Both roles use a 5-second acquisition
-timeout; `embedding-worker` does not import the database engine and owns no
-pool. Steady state therefore reserves 40 connections. The production workflow
-rolls database-owning roles sequentially, so a bounded-pool release normally
-reserves at most 60 of PostgreSQL's 100 connections and leaves at least 40 for
-migrations, operators, and transient database work.
+Each of the two `web` workers owns a `5 + 3` ordinary PostgreSQL pool and a
+two separate `1 + 0` internal pools (control transactions and nested consistent
+runtime-source snapshots). `channels-worker` uses only its
+`10 + 10` ordinary pool. All pools use a 5-second acquisition timeout;
+`embedding-worker` does not import the database engine and owns no pool.
+The control pools are lazy and are never checked out by background workers.
+
+Steady pooled capacity is `2 * (5 + 3 + 2) + 20 = 40`. Each web worker and
+the channels worker also owns one independent LISTEN connection, giving
+`40 + 3 = 43` total client connections. Database-owning roles roll sequentially:
+web overlap is `2 * 22 + 21 = 65`, channels overlap is `22 + 2 * 21 = 64`.
+The previous web pool (`5 + 5`, without control) has the same total budget, so
+the transition does not increase it. PostgreSQL remains at 100 connections;
+subtracting 3 superuser-reserved slots leaves 97 ordinary slots and at least
+`97 - 65 = 32` for migrations, backups, operators, and transient client work.
 
 The deploy helper inspects the running roles before every release. It accepts
 only the known legacy and bounded pool contracts and fails closed on unknown or
@@ -376,7 +384,7 @@ rollout:
 scripts/deploy-backend.sh
 ```
 
-The helper checks for at least 20 currently available ordinary PostgreSQL
+The helper checks for at least 22 currently available ordinary PostgreSQL
 connection slots, after subtracting reserved slots, before migration and before
 each database-owning role deployment. It verifies that every role converged to
 the requested image, that database pools match their bounded contracts, that

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 readonly service="clawdi"
-readonly web_pool="5:5:5"
+readonly web_pool="5:3:5"
+readonly previous_web_pool="5:5:5"
 readonly channels_pool="10:10:5"
 readonly legacy_pool="20:20:45"
-readonly minimum_available_connections=20
+# New web role: 2 * (8 ordinary + 2 control + 1 LISTEN).
+readonly minimum_available_connections=22
 readonly backend_image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION:?}"
 
 [[ "${DEPLOY_IMAGE_VERSION}" =~ ^[0-9a-f]{40}$ ]] || {
@@ -55,7 +57,7 @@ validate_database_role_state() {
 	[[ "${state}" == missing ]] && return
 	IFS='|' read -r container image pool workers <<<"${state}"
 	case "${role}:${pool}" in
-		"web:${legacy_pool}"|"web:${channels_pool}"|"web:${web_pool}"|\
+		"web:${legacy_pool}"|"web:${channels_pool}"|"web:${previous_web_pool}"|"web:${web_pool}"|\
 			"channels-worker:${legacy_pool}"|"channels-worker:${channels_pool}") ;;
 		*) echo "Refusing unknown ${role} database pool: ${pool}" >&2; exit 1 ;;
 	esac

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -50,7 +50,7 @@ image="ghcr.io/clawdi-ai/clawdi-backend:${CURRENT_IMAGE}"
 if [[ -f "${FAKE_LOG}.${role}.deployed" ]]; then
 	image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION}"
 	case "${role}" in
-		web) pool=5:5:5; workers=2 ;;
+		web) pool=5:3:5; workers=2 ;;
 		channels-worker) pool=10:10:5 ;;
 		embedding-worker) pool=:: ;;
 	esac
@@ -109,7 +109,7 @@ if run invalid 12:12:5 10:10:5 >/dev/null 2>&1; then
 	exit 1
 fi
 
-if run saturated 10:10:5 10:10:5 19 >/dev/null 2>&1; then
+if run saturated 10:10:5 10:10:5 21 >/dev/null 2>&1; then
 	echo "Expected insufficient PostgreSQL headroom to fail" >&2
 	exit 1
 fi

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -145,7 +145,7 @@ web = config.role("web")
 expected_web_env = {
   "WEB_CONCURRENCY" => 2,
   "DB_POOL_SIZE" => 5,
-  "DB_MAX_OVERFLOW" => 5,
+  "DB_MAX_OVERFLOW" => 3,
   "DB_POOL_TIMEOUT" => 5,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
 }
@@ -154,7 +154,7 @@ unless web.specialized_env.clear == expected_web_env
 end
 raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 5, 5, 5 ]
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 5, 3, 5 ]
   raise "web role database pool drifted"
 end
 embedding_worker = config.role("embedding-worker")
@@ -194,8 +194,9 @@ end
 if channels_worker_env.key?("PROMETHEUS_MULTIPROC_DIR")
   raise "channels-worker unexpectedly enabled multiprocess metrics"
 end
+# core/database.py reserves one control and one nested snapshot connection per API worker.
 web_connections = web_env.fetch("WEB_CONCURRENCY") *
-  (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW"))
+  (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW") + 2)
 worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
   channels_worker_env.fetch("DB_MAX_OVERFLOW")
 steady_connections = web_connections + worker_connections
@@ -205,6 +206,14 @@ rolling_connections = [
 ].max
 raise "steady database connection budget drifted" unless steady_connections == 40
 raise "rolling database connection budget drifted" unless rolling_connections == 60
+web_listeners = web_env.fetch("WEB_CONCURRENCY")
+worker_listeners = 1
+rolling_clients = [
+  2 * (web_connections + web_listeners) + worker_connections + worker_listeners,
+  web_connections + web_listeners + 2 * (worker_connections + worker_listeners),
+].max
+raise "rolling client budget drifted" unless rolling_clients == 65
+raise "rolling client reserve exhausted" unless 100 - 3 - rolling_clients >= 22
 shared_env = config.raw_config.env.clear
 if shared_env.keys.any? { |key| key.start_with?("DB_POOL_") }
   raise "database pool ownership escaped the web and channels roles"


### PR DESCRIPTION
## Summary
- isolate deployment and recovery transactions from ordinary API database-pool pressure
- reserve a separate snapshot slot for nested runtime-source reads
- fail control-plane row-lock contention within 5 seconds with a retryable, sanitized 503
- handle WebSocket pool exhaustion correctly before and after accept

## Capacity
- steady state: 43 PostgreSQL connections
- worst rolling generation: 65 of 97 ordinary-client slots
- remaining headroom: 32 connections

## Verification
- Docker focused regression: 71 passed after the final lock-timeout change
- earlier full focused isolation regression: 193 passed
- Ruff, formatting, type checks, compile, dependency/lock governance, Kamal release contracts, and diff checks passed

## Scope
No Incus capacity changes, feature flags, migrations, new queues, production operations, or KMS behavior changes.