### PR TITLE
release(cli): publish 0.14.50 Files startup path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- CLI 0.14.50 avoids a misleading missing-database warning when Files starts
+  with its existing database; genuine missing-database warnings remain enabled.
 - Managed CLI installations now create protected directories independently of
   the parent process's umask, without relaxing verification of existing paths.
 - Managed runtime egress no longer emits raw request URLs or WebSocket control

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.49",
+      "version": "0.14.50",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.49",
+	"version": "0.14.50",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary
- Bump CLI package and matching workspace lock to 0.14.50.
- Add user-facing release note for the merged native Files database-path fix.
- No dependency, image or runtime behavior changes in this release-input PR.

## Verification
- npm exact-version query returned 404 before preparation.
- Isolated Docker CLI typecheck and manifest reconciliation: 176 passed, 0 failed.
- git diff --check passed. Local lefthook unavailable; focused checks ran independently.

Merging triggers the existing immutable CLI publish workflow. Tenant rollout remains owner-scoped.