### PR TITLE
feat(runtime): add read-only batch drift summaries

### DIFF
--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -25,6 +25,8 @@ from app.schemas.platform import PlatformOwner
 from app.schemas.runtime_observation import (
     RUNTIME_OBSERVATION_WRITE_SCOPE,
     RuntimeDeploymentKeyCreate,
+    RuntimeDriftSummaryReadRequest,
+    RuntimeDriftSummaryReadResponse,
     RuntimeEnvironmentRetirementReceipt,
     RuntimeEnvironmentRetireRequest,
     RuntimeObservationConsumerAckRequest,
@@ -59,6 +61,7 @@ from app.services.principal_lifecycle import (
     load_clerk_user_for_issuer,
     resolve_clerk_owner_issuer,
 )
+from app.services.runtime_drift_summary import read_runtime_drift_summaries
 from app.services.runtime_observation import (
     RuntimeApplyIdentity,
     RuntimeObservationProtocolError,
@@ -715,6 +718,20 @@ async def cleanup_retired_runtime_state_endpoint(
         await db.rollback()
         raise
     return _CanonicalJSONResponse(status_code=status.HTTP_200_OK, content=response_body)
+
+
+@router.post(
+    "/environments/drift-summary:batchRead",
+    response_model=RuntimeDriftSummaryReadResponse,
+    operation_id="read_runtime_drift_summaries",
+)
+async def read_runtime_drift_summaries_endpoint(
+    body: RuntimeDriftSummaryReadRequest,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_runtime_observation_session),
+) -> RuntimeDriftSummaryReadResponse:
+    """Read ordered, persisted drift evidence without consuming the observation stream."""
+    return await read_runtime_drift_summaries(db, body)
 
 
 async def _commit_cursor_expiry_or_rollback(

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -418,6 +418,87 @@ class RuntimeObservationReadResponse(RuntimeObservationResponseModel):
     has_more: bool = Field(alias="hasMore")
 
 
+class RuntimeDriftBindingRequest(RuntimeObservationRequestModel):
+    environment_id: UUID = Field(alias="environmentId")
+    deployment_id: str = Field(alias="deploymentId", min_length=1, max_length=200)
+
+
+class RuntimeDriftSummaryReadRequest(RuntimeObservationRequestModel):
+    bindings: list[RuntimeDriftBindingRequest] = Field(min_length=1, max_length=100)
+
+    @field_validator("bindings")
+    @classmethod
+    def validate_unique_bindings(
+        cls, bindings: list[RuntimeDriftBindingRequest]
+    ) -> list[RuntimeDriftBindingRequest]:
+        if len({binding.environment_id for binding in bindings}) != len(bindings):
+            raise ValueError("environmentId must be unique within the batch")
+        if len({binding.deployment_id for binding in bindings}) != len(bindings):
+            raise ValueError("deploymentId must be unique within the batch")
+        return bindings
+
+
+class RuntimeDriftSourceAuthority(RuntimeObservationResponseModel):
+    status: Literal["present", "missing", "unavailable"]
+    instance_id: str | None = Field(alias="instanceId", min_length=1, max_length=200)
+    source_revision: str | None = Field(alias="sourceRevision", pattern=r"^[0-9a-f]{64}$")
+    etag: str | None = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def validate_authority_status(self) -> RuntimeDriftSourceAuthority:
+        if self.status == "present":
+            if self.instance_id is None or self.source_revision is None or self.etag is None:
+                raise ValueError("present authority requires instanceId, sourceRevision and etag")
+        elif self.source_revision is not None or self.etag is not None:
+            raise ValueError("non-present authority cannot include sourceRevision or etag")
+        if self.status == "missing" and self.instance_id is not None:
+            raise ValueError("missing authority cannot include instanceId")
+        return self
+
+
+class RuntimeDriftObservationDiagnostics(RuntimeObservationResponseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+    active_cli_version: str | None = Field(alias="activeCliVersion", min_length=1, max_length=200)
+    applied: HostedRuntimeObservedAppliedV2 | None
+    agent_plugins: HostedRuntimeObservedAgentPluginsV1 | None = Field(alias="agentPlugins")
+    user_activity: HostedRuntimeObservedUserActivityV1 | None = Field(alias="userActivity")
+
+    @model_validator(mode="after")
+    def validate_plugin_identity(self) -> RuntimeDriftObservationDiagnostics:
+        if self.agent_plugins is not None:
+            if self.applied is None:
+                raise ValueError("Agent Plugin diagnostics require applied identity")
+            self.agent_plugins.validate_applied_identity(self.applied)
+        return self
+
+
+class RuntimeDriftObservationHead(RuntimeObservationResponseModel):
+    runtime_identity: RuntimeObservationIdentityResponse = Field(alias="runtimeIdentity")
+    captured_at: datetime = Field(alias="capturedAt")
+    freshness_deadline: datetime = Field(alias="freshnessDeadline")
+    health: RuntimeObservedStatus
+    diagnostics: RuntimeDriftObservationDiagnostics
+
+
+class RuntimeDriftObservationSummary(RuntimeObservationResponseModel):
+    status: Literal["missing", "fresh", "expired", "ambiguous"]
+    head: RuntimeDriftObservationHead | None
+
+
+class RuntimeDriftSummary(RuntimeObservationResponseModel):
+    environment_id: UUID = Field(alias="environmentId")
+    deployment_id: str = Field(alias="deploymentId")
+    binding: Literal["active", "retired", "missing", "binding_mismatch"]
+    source_authority: RuntimeDriftSourceAuthority = Field(alias="sourceAuthority")
+    observation: RuntimeDriftObservationSummary
+
+
+class RuntimeDriftSummaryReadResponse(RuntimeObservationResponseModel):
+    observed_at: datetime = Field(alias="observedAt")
+    items: list[RuntimeDriftSummary] = Field(min_length=1, max_length=100)
+
+
 class RuntimeObservationConsumerResponse(RuntimeObservationResponseModel):
     environment_id: str = Field(alias="environmentId")
     deployment_id: str = Field(alias="deploymentId")

--- a/backend/app/services/runtime_drift_summary.py
+++ b/backend/app/services/runtime_drift_summary.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy import func, select, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.runtime_observation import (
+    RUNTIME_ENVIRONMENT_ACTIVE,
+    RUNTIME_OBSERVATION_HEAD_ACTIVE,
+    V2RuntimeEnvironmentFence,
+    V2RuntimeObservationHead,
+    V2RuntimeObservationInbox,
+)
+from app.models.session import AgentEnvironment
+from app.schemas.runtime_observation import (
+    RuntimeDriftObservationHead,
+    RuntimeDriftObservationSummary,
+    RuntimeDriftSourceAuthority,
+    RuntimeDriftSummary,
+    RuntimeDriftSummaryReadRequest,
+    RuntimeDriftSummaryReadResponse,
+)
+from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import runtime_source_contract_revision
+
+
+async def read_runtime_drift_summaries(
+    db: AsyncSession,
+    body: RuntimeDriftSummaryReadRequest,
+) -> RuntimeDriftSummaryReadResponse:
+    """Read persisted drift evidence without writes in the caller's RR snapshot."""
+    environment_ids = [binding.environment_id for binding in body.bindings]
+    rows = (
+        await db.execute(
+            select(
+                V2RuntimeEnvironmentFence.environment_id,
+                V2RuntimeEnvironmentFence.deployment_id,
+                V2RuntimeEnvironmentFence.state,
+                HostedRuntimeState.deployment_id.label("source_deployment_id"),
+                HostedRuntimeState.instance_id,
+                HostedRuntimeState.source_revision,
+                HostedRuntimeState.source_revision_contract,
+            )
+            .outerjoin(
+                AgentEnvironment,
+                (AgentEnvironment.id == V2RuntimeEnvironmentFence.environment_id)
+                & (AgentEnvironment.user_id == V2RuntimeEnvironmentFence.owner_id)
+                & AgentEnvironment.archived_at.is_(None),
+            )
+            .outerjoin(HostedRuntimeState, HostedRuntimeState.environment_id == AgentEnvironment.id)
+            .where(V2RuntimeEnvironmentFence.environment_id.in_(environment_ids))
+        )
+    ).all()
+    by_environment = {row.environment_id: row for row in rows}
+    binding_states: dict[UUID, Literal["active", "retired", "missing", "binding_mismatch"]] = {}
+    active: list[tuple[UUID, str]] = []
+    for requested in body.bindings:
+        row = by_environment.get(requested.environment_id)
+        if row is None:
+            binding = "missing"
+        elif row.deployment_id != requested.deployment_id or (
+            row.source_deployment_id is not None
+            and row.source_deployment_id != requested.deployment_id
+        ):
+            binding = "binding_mismatch"
+        elif row.state != RUNTIME_ENVIRONMENT_ACTIVE:
+            binding = "retired"
+        else:
+            binding = "active"
+            active.append((requested.environment_id, requested.deployment_id))
+        binding_states[requested.environment_id] = binding
+
+    heads: dict[UUID, RuntimeDriftObservationHead | None] = {}
+    if active:
+        head_counts = (
+            select(
+                V2RuntimeObservationHead.environment_id,
+                V2RuntimeObservationHead.deployment_id,
+                func.count().label("active_head_count"),
+            )
+            .where(
+                tuple_(
+                    V2RuntimeObservationHead.environment_id,
+                    V2RuntimeObservationHead.deployment_id,
+                ).in_(active),
+                V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE,
+            )
+            .group_by(
+                V2RuntimeObservationHead.environment_id,
+                V2RuntimeObservationHead.deployment_id,
+            )
+            .subquery()
+        )
+        # Only singleton groups join a head: ambiguous bindings return one count
+        # row with no head or diagnostics, regardless of how many boots exist.
+        head_rows = (
+            await db.execute(
+                select(
+                    head_counts.c.environment_id,
+                    head_counts.c.active_head_count,
+                    V2RuntimeObservationHead,
+                    V2RuntimeObservationInbox.diagnostics["activeCliVersion"],
+                    V2RuntimeObservationInbox.diagnostics["applied"],
+                    V2RuntimeObservationInbox.diagnostics["agentPlugins"],
+                    V2RuntimeObservationInbox.diagnostics["userActivity"],
+                )
+                .select_from(head_counts)
+                .outerjoin(
+                    V2RuntimeObservationHead,
+                    (head_counts.c.active_head_count == 1)
+                    & (V2RuntimeObservationHead.environment_id == head_counts.c.environment_id)
+                    & (V2RuntimeObservationHead.deployment_id == head_counts.c.deployment_id)
+                    & (V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE),
+                )
+                .outerjoin(
+                    V2RuntimeObservationInbox,
+                    (V2RuntimeObservationInbox.id == V2RuntimeObservationHead.latest_inbox_id)
+                    & (V2RuntimeObservationInbox.environment_id == head_counts.c.environment_id)
+                    & (V2RuntimeObservationInbox.deployment_id == head_counts.c.deployment_id),
+                )
+            )
+        ).all()
+        for environment_id, count, head, cli_version, applied, plugins, activity in head_rows:
+            if count > 1:
+                heads[environment_id] = None
+                continue
+            # Coalescing advances head metadata, not inbox diagnostic timestamps.
+            heads[environment_id] = RuntimeDriftObservationHead.model_validate(
+                {
+                    "runtimeIdentity": {
+                        "generation": head.generation,
+                        "manifestETag": head.manifest_etag,
+                        "applyReceiptId": head.apply_receipt_id,
+                        "bootNonce": head.boot_nonce,
+                        "bootSessionId": head.boot_session_id,
+                    },
+                    "capturedAt": head.captured_at,
+                    "freshnessDeadline": head.freshness_deadline,
+                    "health": head.health,
+                    "diagnostics": {
+                        "activeCliVersion": cli_version,
+                        "applied": applied,
+                        "agentPlugins": plugins,
+                        "userActivity": activity,
+                    },
+                }
+            )
+
+    observed_at = datetime.now(UTC)
+    contract = runtime_source_contract_revision()
+    items: list[RuntimeDriftSummary] = []
+    for requested in body.bindings:
+        binding = binding_states[requested.environment_id]
+        row = by_environment.get(requested.environment_id)
+        if binding == "active" and row is not None and row.source_deployment_id is not None:
+            revision = row.source_revision if row.source_revision_contract == contract else None
+            source = RuntimeDriftSourceAuthority(
+                status="present" if revision is not None else "unavailable",
+                instanceId=row.instance_id,
+                sourceRevision=revision,
+                etag=expected_runtime_bundle_v2_etag(revision) if revision is not None else None,
+            )
+        else:
+            source = RuntimeDriftSourceAuthority(
+                status="missing", instanceId=None, sourceRevision=None, etag=None
+            )
+        head = heads.get(requested.environment_id)
+        if head is None:
+            observation_status = "ambiguous" if requested.environment_id in heads else "missing"
+        else:
+            observation_status = "fresh" if head.freshness_deadline > observed_at else "expired"
+        items.append(
+            RuntimeDriftSummary(
+                environmentId=requested.environment_id,
+                deploymentId=requested.deployment_id,
+                binding=binding,
+                sourceAuthority=source,
+                observation=RuntimeDriftObservationSummary(status=observation_status, head=head),
+            )
+        )
+    return RuntimeDriftSummaryReadResponse(observedAt=observed_at, items=items)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -284,6 +284,7 @@ strict = [
     "app/services/private_ip.py",
     "app/services/project_runtime_skills.py",
     "app/services/rate_limiter.py",
+    "app/services/runtime_drift_summary.py",
     "app/services/runtime_generation.py",
     "app/services/runtime_manifest_resources.py",
     "app/services/runtime_observation.py",

--- a/backend/tests/test_runtime_drift_summary.py
+++ b/backend/tests/test_runtime_drift_summary.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import pytest_asyncio
+from pydantic import ValidationError
+from sqlalchemy import delete, event, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import app.core.database as database
+from app.core.config import settings
+from app.main import app
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.runtime_observation import V2RuntimeObservationInbox
+from app.schemas.runtime_observation import (
+    RuntimeDriftObservationHead,
+    RuntimeDriftSourceAuthority,
+    RuntimeObservationEventV2,
+)
+from app.services.runtime_observation import (
+    ingest_runtime_observation,
+    provision_runtime_environment_fence,
+    retire_runtime_environment,
+)
+from app.services.runtime_source_revision import runtime_source_contract_revision
+from tests.conftest import create_env_with_project
+
+pytestmark = pytest.mark.committed_db
+ENDPOINT = "/v2/runtime/environments/drift-summary:batchRead"
+REVISION = "a" * 64
+
+
+@pytest_asyncio.fixture
+async def summary_client(engine, monkeypatch):
+    monkeypatch.setattr(settings, "admin_api_key", "drift-summary-test")
+    monkeypatch.setattr(
+        database, "control_session_factory", async_sessionmaker(engine, expire_on_commit=False)
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"X-Admin-Key": "drift-summary-test"},
+    ) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def runtime(db_session, seed_user):
+    async def create():
+        env = await create_env_with_project(
+            db_session,
+            user_id=seed_user.id,
+            machine_id=str(uuid.uuid4()),
+            machine_name="Drift summary",
+        )
+        deployment_id = f"deployment-{env.id}"
+        await provision_runtime_environment_fence(
+            db_session,
+            environment_id=env.id,
+            owner_id=seed_user.id,
+            deployment_id=deployment_id,
+        )
+        db_session.add(
+            HostedRuntimeState(
+                environment_id=env.id,
+                deployment_id=deployment_id,
+                instance_id=f"instance-{env.id}",
+                generation=1,
+                source_revision=REVISION,
+                source_revision_contract=runtime_source_contract_revision(),
+                cli_package_spec="clawdi@1.2.3",
+                locale={},
+                system={},
+                runtimes={},
+                live_sync={},
+                recovery={},
+            )
+        )
+        await db_session.commit()
+        return {"environmentId": str(env.id), "deploymentId": deployment_id}
+
+    # Permanent protocol rows live until the runner destroys its throwaway database.
+    return create
+
+
+async def observe(db, binding, captured_at, *, boot="boot-1", sequence=1, activity=None):
+    payload = RuntimeObservationEventV2.model_validate(
+        {
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": captured_at,
+            "capturedAt": captured_at,
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": "1.2.3",
+            "applied": {
+                "etag": f'"sha256:{REVISION}"',
+                "sourceRevision": REVISION,
+                "generation": 1,
+                "instanceId": f"instance-{binding['environmentId']}",
+                "appliedProviderIds": [],
+            },
+            "boot": None,
+            "cli": None,
+            "agentPlugins": {"schemaVersion": 1, "installations": []},
+            "applyReceiptId": "apply-receipt-0001",
+            "bootNonce": "boot-nonce-000001",
+            "bootSessionId": boot,
+            "sequence": sequence,
+            "eventId": str(uuid.uuid4()),
+            "userActivity": activity,
+        }
+    )
+    result = await ingest_runtime_observation(
+        db,
+        environment_id=uuid.UUID(binding["environmentId"]),
+        credential_deployment_id=binding["deploymentId"],
+        value=payload,
+        received_at=captured_at,
+    )
+    await db.commit()
+    return result
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["auth", "empty", "oversize", "uuid", "deployment", "duplicate_env", "duplicate_deployment"],
+)
+async def test_batch_boundary_and_auth(summary_client, case):
+    bindings = [
+        {"environmentId": str(uuid.uuid4()), "deploymentId": f"deployment-{i}"} for i in range(101)
+    ]
+    if case == "empty":
+        bindings = []
+    elif case != "oversize":
+        bindings = bindings[:2]
+        if case == "auth":
+            summary_client.headers.pop("X-Admin-Key")
+        elif case == "uuid":
+            bindings[0]["environmentId"] = "invalid"
+        elif case == "deployment":
+            bindings[0].pop("deploymentId")
+        elif case == "duplicate_env":
+            bindings[1]["environmentId"] = bindings[0]["environmentId"]
+        else:
+            bindings[1]["deploymentId"] = bindings[0]["deploymentId"]
+    response = await summary_client.post(ENDPOINT, json={"bindings": bindings})
+    assert response.status_code == (401 if case == "auth" else 422)
+
+
+async def test_order_binding_source_and_read_only_batch(
+    summary_client, runtime, db_session, seed_user, engine
+):
+    active = await runtime()
+    retired = await runtime()
+    await observe(db_session, retired, datetime.now(UTC))
+    await retire_runtime_environment(
+        db_session,
+        environment_id=uuid.UUID(retired["environmentId"]),
+        owner_id=seed_user.id,
+        expected_deployment_id=retired["deploymentId"],
+        retirement_id="retirement-drift-test",
+    )
+    fence_mismatch = {**await runtime(), "deploymentId": "wrong-deployment"}
+    state_mismatch = await runtime()
+    missing_source = await runtime()
+    await db_session.execute(
+        update(HostedRuntimeState)
+        .where(HostedRuntimeState.environment_id == uuid.UUID(state_mismatch["environmentId"]))
+        .values(deployment_id="wrong-runtime-deployment")
+    )
+    await db_session.execute(
+        delete(HostedRuntimeState).where(
+            HostedRuntimeState.environment_id == uuid.UUID(missing_source["environmentId"])
+        )
+    )
+    unavailable = []
+    for revision, contract in (
+        (None, runtime_source_contract_revision()),
+        (REVISION, None),
+        (REVISION, "outdated-contract"),
+    ):
+        binding = await runtime()
+        unavailable.append(binding)
+        await db_session.execute(
+            update(HostedRuntimeState)
+            .where(HostedRuntimeState.environment_id == uuid.UUID(binding["environmentId"]))
+            .values(source_revision=revision, source_revision_contract=contract)
+        )
+    await db_session.commit()
+    bindings = [retired, fence_mismatch, *unavailable, active, state_mismatch, missing_source]
+    bindings.extend(
+        {"environmentId": str(uuid.uuid4()), "deploymentId": f"missing-{i}"}
+        for i in range(100 - len(bindings))
+    )
+    statements = []
+
+    def capture(connection, _cursor, statement, _parameters, _context, _executemany):
+        assert connection.get_execution_options()["isolation_level"] == "REPEATABLE READ"
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture)
+    try:
+        response = await summary_client.post(ENDPOINT, json={"bindings": bindings})
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture)
+    assert response.status_code == 200, response.text
+    items = response.json()["items"]
+    assert [(r["environmentId"], r["deploymentId"]) for r in items] == [
+        (b["environmentId"], b["deploymentId"]) for b in bindings
+    ]
+    assert [(r["binding"], r["sourceAuthority"]["status"]) for r in items] == [
+        ("retired", "missing"),
+        ("binding_mismatch", "missing"),
+        *([("active", "unavailable")] * 3),
+        ("active", "present"),
+        ("binding_mismatch", "missing"),
+        ("active", "missing"),
+        *([("missing", "missing")] * 92),
+    ]
+    authority = items[5]["sourceAuthority"]
+    assert authority == {
+        "status": "present",
+        "instanceId": f"instance-{active['environmentId']}",
+        "sourceRevision": REVISION,
+        "etag": f'"sha256:{REVISION}"',
+    }
+    for result in items[2:5]:
+        assert result["sourceAuthority"]["instanceId"] == f"instance-{result['environmentId']}"
+        assert result["sourceAuthority"]["sourceRevision"] is None
+        assert result["sourceAuthority"]["etag"] is None
+    for invalid in (
+        {"instanceId": None},
+        {"sourceRevision": None},
+        {"etag": None},
+        {"status": "missing"},
+        {"status": "unavailable"},
+    ):
+        with pytest.raises(ValidationError):
+            RuntimeDriftSourceAuthority.model_validate({**authority, **invalid})
+    assert all(r["observation"] == {"status": "missing", "head": None} for r in items)
+    assert len(statements) == 2
+    assert all(query.startswith("SELECT ") and "FOR UPDATE" not in query for query in statements)
+    assert all("consumer_cursors" not in query for query in statements)
+
+
+async def test_fresh_expired_ambiguous_heads_and_coalesced_user_activity(
+    summary_client, runtime, db_session
+):
+    now = datetime.now(UTC) - timedelta(seconds=2)
+    old = now - timedelta(seconds=settings.runtime_observation_freshness_seconds + 10)
+    fresh, expired, ambiguous = await runtime(), await runtime(), await runtime()
+    activity = {
+        "schemaVersion": 1,
+        "classifierVersion": 1,
+        "classification": "known_no_user_input",
+        "lastUserInputAt": None,
+        "observedAt": old.isoformat(),
+        "completeAt": old.isoformat(),
+        "enabledRuntimes": ["openclaw"],
+        "error": None,
+    }
+    first = await observe(db_session, fresh, old, activity=activity)
+    coalesced = await observe(db_session, fresh, now, sequence=2, activity=activity)
+    assert first.stream_position == coalesced.stream_position
+    await observe(db_session, expired, old)
+    await db_session.execute(
+        update(V2RuntimeObservationInbox)
+        .where(V2RuntimeObservationInbox.environment_id == uuid.UUID(expired["environmentId"]))
+        .values(diagnostics={}, payload_purged_at=now)
+    )
+    await db_session.commit()
+    await observe(db_session, ambiguous, old, boot="boot-old")
+    await observe(db_session, ambiguous, now, boot="boot-new")
+    bindings = [ambiguous, expired, fresh]
+    response = await summary_client.post(ENDPOINT, json={"bindings": bindings})
+    assert response.status_code == 200, response.text
+    observations = [item["observation"] for item in response.json()["items"]]
+    assert [item["status"] for item in observations] == ["ambiguous", "expired", "fresh"]
+    assert observations[0] == {"status": "ambiguous", "head": None}
+    head = observations[2]["head"]
+    assert set(head) == {
+        "runtimeIdentity",
+        "capturedAt",
+        "freshnessDeadline",
+        "health",
+        "diagnostics",
+    }
+    assert datetime.fromisoformat(head["capturedAt"]) == now
+    assert datetime.fromisoformat(head["freshnessDeadline"]) == now + timedelta(
+        seconds=settings.runtime_observation_freshness_seconds
+    )
+    assert head["runtimeIdentity"] == {
+        "generation": 1,
+        "manifestETag": f'"sha256:{REVISION}"',
+        "applyReceiptId": "apply-receipt-0001",
+        "bootNonce": "boot-nonce-000001",
+        "bootSessionId": "boot-1",
+    }
+    assert head["health"] == "ok"
+    diagnostics = head["diagnostics"]
+    assert set(diagnostics) == {"activeCliVersion", "applied", "agentPlugins", "userActivity"}
+    assert observations[1]["head"]["diagnostics"] == dict.fromkeys(diagnostics)
+    assert diagnostics["activeCliVersion"] == "1.2.3"
+    assert diagnostics["agentPlugins"] == {"schemaVersion": 1, "installations": []}
+    assert diagnostics["applied"]["sourceRevision"] == REVISION
+    assert diagnostics["applied"]["instanceId"] == f"instance-{fresh['environmentId']}"
+    assert diagnostics["userActivity"] == {
+        **activity,
+        "observedAt": old.isoformat().replace("+00:00", "Z"),
+        "completeAt": old.isoformat().replace("+00:00", "Z"),
+    }
+    for invalid in (
+        {"activeCliVersion": 123},
+        {"applied": {}},
+        {"agentPlugins": {}},
+        {"userActivity": {}},
+        {"rawPayload": {}},
+    ):
+        with pytest.raises(ValidationError):
+            RuntimeDriftObservationHead.model_validate(
+                {**head, "diagnostics": {**diagnostics, **invalid}}
+            )

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -110,6 +110,44 @@ environments. Platform workload OAuth remains separate, default-closed
 infrastructure for the future resale platform surface; it is not on this v2
 data-plane path.
 
+`POST /v2/runtime/environments/drift-summary:batchRead` is an admin-key-only,
+read-only batch using the shared runtime observation RR session dependency.
+Send `{"bindings":[{"environmentId":"<uuid>","deploymentId":"<id>"}]}`
+with 1-100 distinct environment IDs and distinct deployment IDs. Invalid or
+duplicate bindings return 422. `items` preserves request order and echoes
+every requested pair, including missing entries; `observedAt` is the server's
+freshness evaluation time. This endpoint never registers consumers, ACKs,
+resets cursors, renders sources, or repairs persisted revisions.
+
+Each result reports `binding` (`active`, `retired`, `missing`, or
+`binding_mismatch`). A missing fence is `missing`; a fence or available runtime
+state bound to another deployment is `binding_mismatch`. Only active matching
+bindings expose evidence. `sourceAuthority.status` is `present` for a current
+persisted revision/contract, `unavailable` for an unbackfilled or stale contract
+(retaining the known `instanceId`), and `missing` when no owner-matching,
+unarchived environment/runtime state is available. Present authority requires
+all three fields; missing authority requires all three to be null; unavailable
+authority permits only a known instance ID. There is no legacy render fallback.
+
+`observation.head` contains the sole active boot head's apply identity,
+health, `capturedAt`, and `freshnessDeadline`. Zero heads is `missing`
+with a null head; one is `fresh` strictly before its deadline, otherwise
+`expired`; multiple heads is always `ambiguous` with a null head, even if only
+one is fresh. Two set-based SELECTs suffice: the second counts active heads by
+explicit environment/deployment binding and joins evidence only for singleton
+groups, returning at most one row per binding. The head's `diagnostics` contains
+only `activeCliVersion`, `applied`, `agentPlugins`, and `userActivity`, strictly
+validated with the existing v2 semantic schemas and plugin/apply identity rules.
+Absent or retention-scrubbed fields are null; raw payloads, logs and secrets are
+never returned. Coalescing advances head timestamps, not diagnostic timestamps.
+Semantic drift compares diagnostics; sequence, cursor and payload hash are not returned.
+Freshness is not health, and activity classification, coverage and
+its own timestamps still require consumer-side idle-reclaim checks. Invalid
+persisted diagnostics and database failures fail the request, not a partial batch.
+
+Verification: `scripts/test.sh backend tests/test_runtime_drift_summary.py`.
+Done: the focused contracts pass against the runner's throwaway PostgreSQL.
+
 Ingestion locks the permanent environment fence and rejects a retired binding
 before it inspects or creates a boot-session head. Retirement uses the same
 fence lock, freezes all session high-waters, persists the final cursor and

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3427,6 +3427,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/runtime/environments/drift-summary:batchRead": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Read Runtime Drift Summaries Endpoint
+         * @description Read ordered, persisted drift evidence without consuming the observation stream.
+         */
+        post: operations["read_runtime_drift_summaries"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/runtime/environments/{environment_id}/observation-consumers/register": {
         parameters: {
             query?: never;
@@ -7345,6 +7365,99 @@ export interface components {
             environmentId: string;
             /** Deploymentid */
             deploymentId: string;
+        };
+        /** RuntimeDriftBindingRequest */
+        RuntimeDriftBindingRequest: {
+            /**
+             * Environmentid
+             * Format: uuid
+             */
+            environmentId: string;
+            /** Deploymentid */
+            deploymentId: string;
+        };
+        /** RuntimeDriftObservationDiagnostics */
+        RuntimeDriftObservationDiagnostics: {
+            /** Activecliversion */
+            activeCliVersion: string | null;
+            applied: components["schemas"]["HostedRuntimeObservedAppliedV2"] | null;
+            agentPlugins: components["schemas"]["HostedRuntimeObservedAgentPluginsV1"] | null;
+            userActivity: components["schemas"]["HostedRuntimeObservedUserActivityV1"] | null;
+        };
+        /** RuntimeDriftObservationHead */
+        RuntimeDriftObservationHead: {
+            runtimeIdentity: components["schemas"]["RuntimeObservationIdentityResponse"];
+            /**
+             * Capturedat
+             * Format: date-time
+             */
+            capturedAt: string;
+            /**
+             * Freshnessdeadline
+             * Format: date-time
+             */
+            freshnessDeadline: string;
+            /**
+             * Health
+             * @enum {string}
+             */
+            health: "ok" | "error" | "unknown";
+            diagnostics: components["schemas"]["RuntimeDriftObservationDiagnostics"];
+        };
+        /** RuntimeDriftObservationSummary */
+        RuntimeDriftObservationSummary: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "missing" | "fresh" | "expired" | "ambiguous";
+            head: components["schemas"]["RuntimeDriftObservationHead"] | null;
+        };
+        /** RuntimeDriftSourceAuthority */
+        RuntimeDriftSourceAuthority: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "present" | "missing" | "unavailable";
+            /** Instanceid */
+            instanceId: string | null;
+            /** Sourcerevision */
+            sourceRevision: string | null;
+            /** Etag */
+            etag: string | null;
+        };
+        /** RuntimeDriftSummary */
+        RuntimeDriftSummary: {
+            /**
+             * Environmentid
+             * Format: uuid
+             */
+            environmentId: string;
+            /** Deploymentid */
+            deploymentId: string;
+            /**
+             * Binding
+             * @enum {string}
+             */
+            binding: "active" | "retired" | "missing" | "binding_mismatch";
+            sourceAuthority: components["schemas"]["RuntimeDriftSourceAuthority"];
+            observation: components["schemas"]["RuntimeDriftObservationSummary"];
+        };
+        /** RuntimeDriftSummaryReadRequest */
+        RuntimeDriftSummaryReadRequest: {
+            /** Bindings */
+            bindings: components["schemas"]["RuntimeDriftBindingRequest"][];
+        };
+        /** RuntimeDriftSummaryReadResponse */
+        RuntimeDriftSummaryReadResponse: {
+            /**
+             * Observedat
+             * Format: date-time
+             */
+            observedAt: string;
+            /** Items */
+            items: components["schemas"]["RuntimeDriftSummary"][];
         };
         /** RuntimeEnvironmentRetireRequest */
         RuntimeEnvironmentRetireRequest: {
@@ -16254,6 +16367,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RuntimeStateCleanupReceipt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_runtime_drift_summaries: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeDriftSummaryReadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeDriftSummaryReadResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- add an admin-only ordered batch endpoint for persisted runtime drift evidence
- return bounded source authority and at most one active observation head per binding
- expose only validated apply, CLI, plugin, and user-activity diagnostics
- execute in the reserved repeatable-read control session with at most two set-based SELECTs

## Safety
- no render fallback, cursor mutation, consumer registration, ACK, repair, migration, flag, or new queue
- ambiguous/unavailable evidence remains explicit and fail-closed
- no sequence, cursor, payload hash, raw payload, log, or secret in the response

## Verification
- isolated Docker focused/regression: 49 passed
- Ruff, strict typing, OpenAPI consistency, five TypeScript workspaces, and diff checks passed

This is the Cloud half of the bounded Hosted fleet observer; it does not change Hosted scheduling by itself.