### PR TITLE
fix(runtime): select current drift observation head

### DIFF
--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -421,6 +421,9 @@ class RuntimeObservationReadResponse(RuntimeObservationResponseModel):
 class RuntimeDriftBindingRequest(RuntimeObservationRequestModel):
     environment_id: UUID = Field(alias="environmentId")
     deployment_id: str = Field(alias="deploymentId", min_length=1, max_length=200)
+    expected_apply_identity: RuntimeApplyIdentityRequest | None = Field(
+        default=None, alias="expectedApplyIdentity"
+    )
 
 
 class RuntimeDriftSummaryReadRequest(RuntimeObservationRequestModel):

--- a/backend/app/services/runtime_drift_summary.py
+++ b/backend/app/services/runtime_drift_summary.py
@@ -4,8 +4,9 @@ from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
 
-from sqlalchemy import func, select, tuple_
+from sqlalchemy import and_, func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.runtime_observation import (
@@ -33,6 +34,7 @@ async def read_runtime_drift_summaries(
     body: RuntimeDriftSummaryReadRequest,
 ) -> RuntimeDriftSummaryReadResponse:
     """Read persisted drift evidence without writes in the caller's RR snapshot."""
+    observed_at = datetime.now(UTC)
     environment_ids = [binding.environment_id for binding in body.bindings]
     rows = (
         await db.execute(
@@ -58,6 +60,8 @@ async def read_runtime_drift_summaries(
     by_environment = {row.environment_id: row for row in rows}
     binding_states: dict[UUID, Literal["active", "retired", "missing", "binding_mismatch"]] = {}
     active: list[tuple[UUID, str]] = []
+    expected: list[tuple[UUID, str, int, str, str, str]] = []
+    legacy: list[tuple[UUID, str]] = []
     for requested in body.bindings:
         row = by_environment.get(requested.environment_id)
         if row is None:
@@ -72,85 +76,129 @@ async def read_runtime_drift_summaries(
         else:
             binding = "active"
             active.append((requested.environment_id, requested.deployment_id))
+            identity = requested.expected_apply_identity
+            if identity is None:
+                legacy.append((requested.environment_id, requested.deployment_id))
+            else:
+                expected.append(
+                    (
+                        requested.environment_id,
+                        requested.deployment_id,
+                        identity.generation,
+                        identity.manifest_etag,
+                        identity.apply_receipt_id,
+                        identity.boot_nonce,
+                    )
+                )
         binding_states[requested.environment_id] = binding
 
     heads: dict[UUID, RuntimeDriftObservationHead | None] = {}
     if active:
-        head_counts = (
-            select(
-                V2RuntimeObservationHead.environment_id,
-                V2RuntimeObservationHead.deployment_id,
-                func.count().label("active_head_count"),
-            )
-            .where(
+        fresh = and_(
+            V2RuntimeObservationHead.captured_at <= observed_at,
+            V2RuntimeObservationHead.freshness_deadline > observed_at,
+        )
+        predicates: list[ColumnElement[bool]] = []
+        if expected:
+            predicates.append(
                 tuple_(
                     V2RuntimeObservationHead.environment_id,
                     V2RuntimeObservationHead.deployment_id,
-                ).in_(active),
-                V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE,
+                    V2RuntimeObservationHead.generation,
+                    V2RuntimeObservationHead.manifest_etag,
+                    V2RuntimeObservationHead.apply_receipt_id,
+                    V2RuntimeObservationHead.boot_nonce,
+                ).in_(expected)
             )
-            .group_by(
-                V2RuntimeObservationHead.environment_id,
-                V2RuntimeObservationHead.deployment_id,
+        if legacy:
+            predicates.append(
+                tuple_(
+                    V2RuntimeObservationHead.environment_id,
+                    V2RuntimeObservationHead.deployment_id,
+                ).in_(legacy)
+            )
+        ranked_heads = (
+            select(
+                *V2RuntimeObservationHead.__table__.c,
+                func.count()
+                .over(partition_by=V2RuntimeObservationHead.environment_id)
+                .label("active_head_count"),
+                func.count()
+                .filter(fresh)
+                .over(partition_by=V2RuntimeObservationHead.environment_id)
+                .label("fresh_head_count"),
+                func.row_number()
+                .over(
+                    partition_by=V2RuntimeObservationHead.environment_id,
+                    order_by=(
+                        fresh.desc(),
+                        V2RuntimeObservationHead.captured_at.desc(),
+                        V2RuntimeObservationHead.freshness_deadline.desc(),
+                        V2RuntimeObservationHead.boot_session_id.desc(),
+                        V2RuntimeObservationHead.highest_sequence.desc(),
+                        V2RuntimeObservationHead.latest_event_id.desc(),
+                    ),
+                )
+                .label("head_rank"),
+            )
+            .where(
+                V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE,
+                or_(*predicates),
             )
             .subquery()
         )
-        # Only singleton groups join a head: ambiguous bindings return one count
-        # row with no head or diagnostics, regardless of how many boots exist.
         head_rows = (
             await db.execute(
                 select(
-                    head_counts.c.environment_id,
-                    head_counts.c.active_head_count,
-                    V2RuntimeObservationHead,
-                    V2RuntimeObservationInbox.diagnostics["activeCliVersion"],
-                    V2RuntimeObservationInbox.diagnostics["applied"],
-                    V2RuntimeObservationInbox.diagnostics["agentPlugins"],
-                    V2RuntimeObservationInbox.diagnostics["userActivity"],
-                )
-                .select_from(head_counts)
-                .outerjoin(
-                    V2RuntimeObservationHead,
-                    (head_counts.c.active_head_count == 1)
-                    & (V2RuntimeObservationHead.environment_id == head_counts.c.environment_id)
-                    & (V2RuntimeObservationHead.deployment_id == head_counts.c.deployment_id)
-                    & (V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE),
+                    ranked_heads,
+                    V2RuntimeObservationInbox.diagnostics["activeCliVersion"].label(
+                        "active_cli_version"
+                    ),
+                    V2RuntimeObservationInbox.diagnostics["applied"].label("applied_diagnostics"),
+                    V2RuntimeObservationInbox.diagnostics["agentPlugins"].label("agent_plugins"),
+                    V2RuntimeObservationInbox.diagnostics["userActivity"].label("user_activity"),
                 )
                 .outerjoin(
                     V2RuntimeObservationInbox,
-                    (V2RuntimeObservationInbox.id == V2RuntimeObservationHead.latest_inbox_id)
-                    & (V2RuntimeObservationInbox.environment_id == head_counts.c.environment_id)
-                    & (V2RuntimeObservationInbox.deployment_id == head_counts.c.deployment_id),
+                    (V2RuntimeObservationInbox.id == ranked_heads.c.latest_inbox_id)
+                    & (V2RuntimeObservationInbox.environment_id == ranked_heads.c.environment_id)
+                    & (V2RuntimeObservationInbox.deployment_id == ranked_heads.c.deployment_id),
                 )
+                .where(ranked_heads.c.head_rank == 1)
             )
         ).all()
-        for environment_id, count, head, cli_version, applied, plugins, activity in head_rows:
-            if count > 1:
-                heads[environment_id] = None
+        legacy_environments = {environment_id for environment_id, _ in legacy}
+        for row in head_rows:
+            ambiguous = (
+                row.active_head_count > 1
+                if row.environment_id in legacy_environments
+                else row.fresh_head_count > 1
+            )
+            if ambiguous:
+                heads[row.environment_id] = None
                 continue
             # Coalescing advances head metadata, not inbox diagnostic timestamps.
-            heads[environment_id] = RuntimeDriftObservationHead.model_validate(
+            heads[row.environment_id] = RuntimeDriftObservationHead.model_validate(
                 {
                     "runtimeIdentity": {
-                        "generation": head.generation,
-                        "manifestETag": head.manifest_etag,
-                        "applyReceiptId": head.apply_receipt_id,
-                        "bootNonce": head.boot_nonce,
-                        "bootSessionId": head.boot_session_id,
+                        "generation": row.generation,
+                        "manifestETag": row.manifest_etag,
+                        "applyReceiptId": row.apply_receipt_id,
+                        "bootNonce": row.boot_nonce,
+                        "bootSessionId": row.boot_session_id,
                     },
-                    "capturedAt": head.captured_at,
-                    "freshnessDeadline": head.freshness_deadline,
-                    "health": head.health,
+                    "capturedAt": row.captured_at,
+                    "freshnessDeadline": row.freshness_deadline,
+                    "health": row.health,
                     "diagnostics": {
-                        "activeCliVersion": cli_version,
-                        "applied": applied,
-                        "agentPlugins": plugins,
-                        "userActivity": activity,
+                        "activeCliVersion": row.active_cli_version,
+                        "applied": row.applied_diagnostics,
+                        "agentPlugins": row.agent_plugins,
+                        "userActivity": row.user_activity,
                     },
                 }
             )
 
-    observed_at = datetime.now(UTC)
     contract = runtime_source_contract_revision()
     items: list[RuntimeDriftSummary] = []
     for requested in body.bindings:

--- a/backend/tests/test_runtime_drift_summary.py
+++ b/backend/tests/test_runtime_drift_summary.py
@@ -31,6 +31,16 @@ from tests.conftest import create_env_with_project
 pytestmark = pytest.mark.committed_db
 ENDPOINT = "/v2/runtime/environments/drift-summary:batchRead"
 REVISION = "a" * 64
+EXPECTED_APPLY_IDENTITY = {
+    "generation": 1,
+    "manifestETag": f'"sha256:{REVISION}"',
+    "applyReceiptId": "apply-receipt-0001",
+    "bootNonce": "boot-nonce-000001",
+}
+
+
+def expected_binding(binding):
+    return {**binding, "expectedApplyIdentity": EXPECTED_APPLY_IDENTITY}
 
 
 @pytest_asyncio.fixture
@@ -86,7 +96,17 @@ async def runtime(db_session, seed_user):
     return create
 
 
-async def observe(db, binding, captured_at, *, boot="boot-1", sequence=1, activity=None):
+async def observe(
+    db,
+    binding,
+    captured_at,
+    *,
+    boot="boot-1",
+    sequence=1,
+    activity=None,
+    apply_receipt_id="apply-receipt-0001",
+    boot_nonce="boot-nonce-000001",
+):
     payload = RuntimeObservationEventV2.model_validate(
         {
             "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
@@ -105,8 +125,8 @@ async def observe(db, binding, captured_at, *, boot="boot-1", sequence=1, activi
             "boot": None,
             "cli": None,
             "agentPlugins": {"schemaVersion": 1, "installations": []},
-            "applyReceiptId": "apply-receipt-0001",
-            "bootNonce": "boot-nonce-000001",
+            "applyReceiptId": apply_receipt_id,
+            "bootNonce": boot_nonce,
             "bootSessionId": boot,
             "sequence": sequence,
             "eventId": str(uuid.uuid4()),
@@ -251,7 +271,12 @@ async def test_fresh_expired_ambiguous_heads_and_coalesced_user_activity(
 ):
     now = datetime.now(UTC) - timedelta(seconds=2)
     old = now - timedelta(seconds=settings.runtime_observation_freshness_seconds + 10)
-    fresh, expired, ambiguous = await runtime(), await runtime(), await runtime()
+    fresh, expired, ambiguous, selected = (
+        await runtime(),
+        await runtime(),
+        await runtime(),
+        await runtime(),
+    )
     activity = {
         "schemaVersion": 1,
         "classifierVersion": 1,
@@ -265,21 +290,43 @@ async def test_fresh_expired_ambiguous_heads_and_coalesced_user_activity(
     first = await observe(db_session, fresh, old, activity=activity)
     coalesced = await observe(db_session, fresh, now, sequence=2, activity=activity)
     assert first.stream_position == coalesced.stream_position
-    await observe(db_session, expired, old)
+    await observe(db_session, expired, old - timedelta(seconds=1), boot="boot-older")
+    await observe(db_session, expired, old, boot="boot-expired")
     await db_session.execute(
         update(V2RuntimeObservationInbox)
         .where(V2RuntimeObservationInbox.environment_id == uuid.UUID(expired["environmentId"]))
         .values(diagnostics={}, payload_purged_at=now)
     )
     await db_session.commit()
-    await observe(db_session, ambiguous, old, boot="boot-old")
-    await observe(db_session, ambiguous, now, boot="boot-new")
-    bindings = [ambiguous, expired, fresh]
+    await observe(db_session, ambiguous, now, boot="boot-one")
+    await observe(db_session, ambiguous, now, boot="boot-two")
+    await observe(db_session, selected, old, boot="boot-stale")
+    await observe(db_session, selected, now, boot="boot-current")
+    await observe(
+        db_session,
+        selected,
+        now,
+        boot="boot-other-identity",
+        apply_receipt_id="apply-receipt-0002",
+        boot_nonce="boot-nonce-000002",
+    )
+    bindings = [
+        expected_binding(ambiguous),
+        expected_binding(expired),
+        expected_binding(fresh),
+        expected_binding(selected),
+    ]
     response = await summary_client.post(ENDPOINT, json={"bindings": bindings})
     assert response.status_code == 200, response.text
     observations = [item["observation"] for item in response.json()["items"]]
-    assert [item["status"] for item in observations] == ["ambiguous", "expired", "fresh"]
+    assert [item["status"] for item in observations] == [
+        "ambiguous",
+        "expired",
+        "fresh",
+        "fresh",
+    ]
     assert observations[0] == {"status": "ambiguous", "head": None}
+    assert observations[1]["head"]["runtimeIdentity"]["bootSessionId"] == "boot-expired"
     head = observations[2]["head"]
     assert set(head) == {
         "runtimeIdentity",
@@ -311,6 +358,13 @@ async def test_fresh_expired_ambiguous_heads_and_coalesced_user_activity(
         **activity,
         "observedAt": old.isoformat().replace("+00:00", "Z"),
         "completeAt": old.isoformat().replace("+00:00", "Z"),
+    }
+    assert observations[3]["head"]["runtimeIdentity"]["bootSessionId"] == "boot-current"
+    legacy = await summary_client.post(ENDPOINT, json={"bindings": [selected]})
+    assert legacy.status_code == 200, legacy.text
+    assert legacy.json()["items"][0]["observation"] == {
+        "status": "ambiguous",
+        "head": None,
     }
     for invalid in (
         {"activeCliVersion": 123},

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -112,12 +112,15 @@ data-plane path.
 
 `POST /v2/runtime/environments/drift-summary:batchRead` is an admin-key-only,
 read-only batch using the shared runtime observation RR session dependency.
-Send `{"bindings":[{"environmentId":"<uuid>","deploymentId":"<id>"}]}`
-with 1-100 distinct environment IDs and distinct deployment IDs. Invalid or
-duplicate bindings return 422. `items` preserves request order and echoes
-every requested pair, including missing entries; `observedAt` is the server's
-freshness evaluation time. This endpoint never registers consumers, ACKs,
-resets cursors, renders sources, or repairs persisted revisions.
+Send 1-100 bindings with distinct environment and deployment IDs. Current
+callers include `expectedApplyIdentity` (`generation`, `manifestETag`,
+`applyReceiptId`, and `bootNonce`) so head selection uses the same authority as
+the full observation reader. The field is optional only for rolling compatibility;
+legacy requests retain the original all-active-head behavior. Invalid or duplicate
+bindings return 422. `items` preserves request order and echoes every requested
+pair, including missing entries; `observedAt` is the server's freshness evaluation
+time. This endpoint never registers consumers, ACKs, resets cursors, renders
+sources, or repairs persisted revisions.
 
 Each result reports `binding` (`active`, `retired`, `missing`, or
 `binding_mismatch`). A missing fence is `missing`; a fence or available runtime
@@ -129,13 +132,14 @@ unarchived environment/runtime state is available. Present authority requires
 all three fields; missing authority requires all three to be null; unavailable
 authority permits only a known instance ID. There is no legacy render fallback.
 
-`observation.head` contains the sole active boot head's apply identity,
-health, `capturedAt`, and `freshnessDeadline`. Zero heads is `missing`
-with a null head; one is `fresh` strictly before its deadline, otherwise
-`expired`; multiple heads is always `ambiguous` with a null head, even if only
-one is fresh. Two set-based SELECTs suffice: the second counts active heads by
-explicit environment/deployment binding and joins evidence only for singleton
-groups, returning at most one row per binding. The head's `diagnostics` contains
+`observation.head` contains the selected active boot head's apply identity,
+health, `capturedAt`, and `freshnessDeadline`. For current requests, heads must
+match the expected apply identity. One fresh matching boot is selected even when
+stale or unrelated active heads remain; multiple fresh matching boot sessions are
+`ambiguous`; otherwise the most recent expired matching head is returned. Zero
+matching heads is `missing`. Legacy requests remain ambiguous when more than one
+active head exists. Two set-based SELECTs suffice and return at most one row per
+binding. The head's `diagnostics` contains
 only `activeCliVersion`, `applied`, `agentPlugins`, and `userActivity`, strictly
 validated with the existing v2 semantic schemas and plugin/apply identity rules.
 Absent or retention-scrubbed fields are null; raw payloads, logs and secrets are

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7375,6 +7375,7 @@ export interface components {
             environmentId: string;
             /** Deploymentid */
             deploymentId: string;
+            expectedApplyIdentity?: components["schemas"]["RuntimeApplyIdentityRequest"] | null;
         };
         /** RuntimeDriftObservationDiagnostics */
         RuntimeDriftObservationDiagnostics: {


### PR DESCRIPTION
## Summary
- accept the current expected apply identity in drift-summary batch bindings
- select the sole fresh matching boot head, or the newest matching expired head
- preserve legacy multi-head behavior during the Cloud-first rolling rollout
- regenerate the shared API client and document the selection contract

## Why
Production has one fresh current head plus stale active heads for 158 running bindings. Treating every multi-head binding as ambiguous continuously re-enqueues already converged deployments.

## Verification
- `tests/test_runtime_drift_summary.py`: 9 passed in isolated PostgreSQL Docker
- Ruff and BasedPyright: passed
- generated OpenAPI client check: passed
- full `js` suite: passed, including all 5 workspace typechecks
