### PR TITLE
fix(backend): prevent runtime manifest pool starvation

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -535,7 +535,13 @@ def _decode_clerk_oauth_access_jwt(
     return payload
 
 
-async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | None:
+@dataclass(frozen=True, slots=True)
+class VerifiedClerkJwt:
+    payload: _JwtClaims
+    oauth_setting: ClerkCliOAuthSetting | None
+
+
+async def verify_clerk_jwt(token: str, db: AsyncSession) -> VerifiedClerkJwt | None:
     oauth_setting: ClerkCliOAuthSetting | None = None
     if _is_oauth_access_jwt(token):
         try:
@@ -562,6 +568,21 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
         payload = _decode_clerk_oauth_access_jwt(token, signing_key, oauth_setting)
     if payload is None:
         return None
+    return VerifiedClerkJwt(payload=payload, oauth_setting=oauth_setting)
+
+
+async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | None:
+    verified = await verify_clerk_jwt(token, db)
+    if verified is None:
+        return None
+    return await auth_via_verified_clerk_jwt(verified, db)
+
+
+async def auth_via_verified_clerk_jwt(
+    verified: VerifiedClerkJwt, db: AsyncSession
+) -> AuthContext | None:
+    payload = verified.payload
+    oauth_setting = verified.oauth_setting
 
     clerk_id = payload.get("sub")
     if not isinstance(clerk_id, str) or not clerk_id:

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -2,14 +2,17 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
 
 import anyio
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, ExceptionContext
 from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
@@ -126,9 +129,9 @@ for observed_engine in (engine, control_engine, control_snapshot_engine):
     event.listen(observed_engine.sync_engine.pool, "checkin", _connection_checkin)
 
 
-async def _close_session(session: AsyncSession) -> None:
+async def _close_resource(resource: AsyncSession | AsyncConnection) -> None:
     """Return the connection before propagating request cancellation."""
-    close_task = asyncio.create_task(session.close())
+    close_task = asyncio.create_task(resource.close())
     cancellation: asyncio.CancelledError | None = None
 
     with anyio.CancelScope(shield=True):
@@ -141,7 +144,7 @@ async def _close_session(session: AsyncSession) -> None:
                 if cancellation is None:
                     raise
 
-                log.exception("Database session cleanup failed during request cancellation")
+                log.exception("Database resource cleanup failed during request cancellation")
                 raise cancellation from exc
 
     try:
@@ -150,7 +153,7 @@ async def _close_session(session: AsyncSession) -> None:
         if cancellation is None:
             raise
 
-        log.exception("Database session cleanup failed during request cancellation")
+        log.exception("Database resource cleanup failed during request cancellation")
         raise cancellation from exc
 
     if cancellation is not None:
@@ -159,7 +162,7 @@ async def _close_session(session: AsyncSession) -> None:
 
 class _CancellationSafeAsyncSession(AsyncSession):
     async def __aexit__(self, type_: object, value: object, traceback: object) -> None:
-        await _close_session(self)
+        await _close_resource(self)
 
 
 async_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
@@ -205,7 +208,56 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     try:
         yield session
     finally:
-        await _close_session(session)
+        await _close_resource(session)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeManifestSessions:
+    auth: AsyncSession
+    snapshots: async_sessionmaker[AsyncSession]
+
+
+_manifest_checkout_lock = asyncio.Lock()
+
+
+@asynccontextmanager
+async def _reserved_connection() -> AsyncGenerator[AsyncConnection, None]:
+    connection = await engine.connect()
+    try:
+        yield connection
+    finally:
+        await _close_resource(connection)
+
+
+async def get_runtime_manifest_sessions() -> AsyncGenerator[RuntimeManifestSessions, None]:
+    """Acquire a complete pair before auth so manifest readers cannot deadlock.
+
+    Only acquisition is serialized. Both connections stay reserved across
+    commits, allowing repairs and fresh RR snapshots without another checkout.
+    Other requests continue sharing the entire ordinary pool.
+    """
+    async with AsyncExitStack() as stack:
+        acquisition = asyncio.timeout(settings.db_pool_timeout)
+        try:
+            async with acquisition, _manifest_checkout_lock:
+                auth_connection = await stack.enter_async_context(_reserved_connection())
+                snapshot_connection = await stack.enter_async_context(_reserved_connection())
+        except TimeoutError:
+            if not acquisition.expired():
+                raise
+            raise SQLAlchemyTimeoutError(
+                "Runtime manifest connection acquisition timed out"
+            ) from None
+
+        async with async_session_factory(bind=auth_connection) as auth_session:
+            yield RuntimeManifestSessions(
+                auth=auth_session,
+                snapshots=async_sessionmaker(
+                    snapshot_connection,
+                    class_=_CancellationSafeAsyncSession,
+                    expire_on_commit=False,
+                ),
+            )
 
 
 async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None]:
@@ -232,7 +284,7 @@ async def runtime_snapshot_session(
         await _configure_runtime_snapshot(session)
         yield session
     finally:
-        await _close_session(session)
+        await _close_resource(session)
 
 
 async def _configure_runtime_snapshot(session: AsyncSession) -> None:

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -11,17 +11,30 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response, status
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import exists, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.auth import (
+    API_KEY_PREFIX,
     AuthContext,
+    VerifiedClerkJwt,
+    auth_via_verified_clerk_jwt,
+    bearer_scheme,
+    get_auth,
     is_connected_agent_principal,
     require_auth_scopes,
     require_cli_auth,
+    verify_clerk_jwt,
 )
 from app.core.config import settings
-from app.core.database import get_session, runtime_snapshot_session
+from app.core.database import (
+    RuntimeManifestSessions,
+    async_session_factory,
+    get_runtime_manifest_sessions,
+    get_session,
+    runtime_snapshot_session,
+)
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -112,13 +125,43 @@ class _RuntimeManifestSnapshot:
     repair_link_ids: tuple[UUID, ...]
 
 
+async def _manifest_credential(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> HTTPAuthorizationCredentials | VerifiedClerkJwt:
+    token = credentials.credentials
+    if token.startswith(API_KEY_PREFIX) or (
+        settings.dev_auth_bypass and token == settings.dev_auth_token
+    ):
+        return credentials
+    # Verify JWTs before reserving connections; JWKS can require network I/O.
+    async with async_session_factory() as db:
+        verified = await verify_clerk_jwt(token, db)
+    if verified is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid credentials")
+    return verified
+
+
+async def _get_runtime_manifest_auth(
+    credential: HTTPAuthorizationCredentials | VerifiedClerkJwt = Depends(_manifest_credential),
+    sessions: RuntimeManifestSessions = Depends(get_runtime_manifest_sessions),
+) -> AuthContext:
+    if isinstance(credential, HTTPAuthorizationCredentials):
+        return await get_auth(credential, sessions.auth)
+    auth = await auth_via_verified_clerk_jwt(credential, sessions.auth)
+    if auth is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid credentials")
+    return auth
+
+
 @router.get("/manifest")
 async def get_runtime_manifest(
     request: Request,
     requested_environment_id: UUID | None = Query(default=None, alias="environment_id"),
-    auth: AuthContext = Depends(require_cli_auth),
-    db: AsyncSession = Depends(get_session),
+    auth: AuthContext = Depends(_get_runtime_manifest_auth),
+    sessions: RuntimeManifestSessions = Depends(get_runtime_manifest_sessions),
 ) -> Response:
+    await require_cli_auth(auth)
+    db = sessions.auth
     environment_id = _authorized_environment_id(auth, requested_environment_id)
     if request.headers.get("accept") != RUNTIME_BUNDLE_V2_MEDIA_TYPE:
         raise HTTPException(
@@ -140,6 +183,7 @@ async def get_runtime_manifest(
     try:
         snapshot = await _render_runtime_source_snapshot(
             db=db,
+            snapshot_sessions=sessions.snapshots,
             environment_id=environment_id,
             owner_user_id=auth.user_id,
             if_none_match=if_none_match,
@@ -161,6 +205,7 @@ async def get_runtime_manifest(
             await db.commit()
             snapshot = await _render_runtime_source_snapshot(
                 db=db,
+                snapshot_sessions=sessions.snapshots,
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
                 if_none_match=if_none_match,
@@ -191,6 +236,7 @@ async def get_runtime_manifest(
 async def _render_runtime_source_snapshot(
     *,
     db: AsyncSession,
+    snapshot_sessions: async_sessionmaker[AsyncSession],
     environment_id: UUID,
     owner_user_id: UUID,
     if_none_match: str | None,
@@ -199,7 +245,7 @@ async def _render_runtime_source_snapshot(
 ) -> _RuntimeManifestSnapshot:
     canonical_projection = project_agent_plugins and project_agent_plugin_github_release_sources
     if if_none_match is not None:
-        async with runtime_snapshot_session() as source_db:
+        async with runtime_snapshot_session(session_factory=snapshot_sessions) as source_db:
             authority = await load_persisted_runtime_source_authority(
                 source_db,
                 environment_id=environment_id,
@@ -221,7 +267,7 @@ async def _render_runtime_source_snapshot(
                 repair_link_ids=(),
             )
 
-    async with runtime_snapshot_session() as source_db:
+    async with runtime_snapshot_session(session_factory=snapshot_sessions) as source_db:
         batch = await load_runtime_source_batch(
             source_db,
             environment_ids=[environment_id],
@@ -522,6 +568,7 @@ async def get_project_skill_archive(
         skill.skill_key,
         skill.name,
     ).local_skill_key
+    await db.close()
     try:
         stored = await file_store.get(skill.file_key)
         stored = await _prepare_project_skill_archive(
@@ -567,6 +614,7 @@ async def get_project_skill_file(
     )
     if not skill.file_key:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill file not found")
+    await db.close()
     try:
         stored = await file_store.get(skill.file_key)
     except Exception:
@@ -603,6 +651,13 @@ def _assert_project_skill_signature(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill file not found")
 
 
+@dataclass(frozen=True, slots=True)
+class _ProjectSkillSource:
+    file_key: str | None
+    skill_key: str
+    name: str
+
+
 async def _linked_project_skill(
     db: AsyncSession,
     *,
@@ -611,7 +666,7 @@ async def _linked_project_skill(
     content_hash: str,
     project_id: UUID | None = None,
     local_skill_key: str | None = None,
-) -> Skill:
+) -> _ProjectSkillSource:
     membership = ProjectMembership.__table__.alias("signed_project_skill_membership")
     filters = [
         Skill.id == skill_id,
@@ -626,9 +681,9 @@ async def _linked_project_skill(
     ]
     if project_id is not None:
         filters.append(Project.id == project_id)
-    skill = (
+    row = (
         await db.execute(
-            select(Skill)
+            select(Skill.file_key, Skill.skill_key, Skill.name)
             .join(Project, Project.id == Skill.project_id)
             .join(
                 AgentProjectBinding,
@@ -643,8 +698,12 @@ async def _linked_project_skill(
             )
             .where(*filters)
         )
-    ).scalar_one_or_none()
-    if skill is None or (
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill file not found")
+    file_key, stored_skill_key, name = row
+    skill = _ProjectSkillSource(file_key=file_key, skill_key=stored_skill_key, name=name)
+    if (
         local_skill_key is not None
         and project_skill_runtime_identity(
             skill.skill_key,
@@ -673,7 +732,9 @@ def _validated_project_skill_file_path(value: str) -> str:
     return value
 
 
-def _extract_project_skill_file(data: bytes, skill: Skill, relative_path: str) -> bytes:
+def _extract_project_skill_file(
+    data: bytes, skill: _ProjectSkillSource, relative_path: str
+) -> bytes:
     if skill.file_key and skill.file_key.endswith(".md"):
         if relative_path != "SKILL.md" or len(data) > _MAX_PROJECT_SKILL_FILE_BYTES:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill file not found")

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -19,8 +19,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
+from app.core.database import (
+    RuntimeManifestSessions,
+    get_control_session,
+    get_runtime_manifest_sessions,
+    get_session,
+)
 from app.core.database import engine as runtime_engine
-from app.core.database import get_control_session, get_session
 from app.main import app
 from app.models.agent_plugin import (
     AgentPluginInstallation,
@@ -492,9 +497,17 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
     async def _override_get_auth():
         return AuthContext(user=seed_user, api_key=api_key)
 
+    async def _override_manifest_sessions():
+        yield RuntimeManifestSessions(
+            auth=db_session,
+            snapshots=async_sessionmaker(runtime_engine, expire_on_commit=False),
+        )
+
     app.dependency_overrides[get_control_session] = _override_get_session
     app.dependency_overrides[get_session] = _override_get_session
     app.dependency_overrides[get_auth] = _override_get_auth
+    app.dependency_overrides[runtime_routes._get_runtime_manifest_auth] = _override_get_auth
+    app.dependency_overrides[get_runtime_manifest_sessions] = _override_manifest_sessions
     transport = ASGITransport(app=app)
     return httpx.AsyncClient(
         transport=transport,
@@ -5318,8 +5331,9 @@ async def test_admin_runtime_state_rejects_hosted_control_plane_authority(
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_requires_environment_bound_cli_key(client):
-    clerk_response = await client.get("/v1/runtime/manifest")
+async def test_runtime_manifest_requires_environment_bound_cli_key(db_session, seed_user):
+    async with await _runtime_client(db_session, seed_user, None) as client:
+        clerk_response = await client.get("/v1/runtime/manifest")
     assert clerk_response.status_code == 403
 
 

--- a/backend/tests/test_runtime_manifest_pool.py
+++ b/backend/tests/test_runtime_manifest_pool.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import AsyncExitStack, asynccontextmanager
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from sqlalchemy import event, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from app.core import auth, database
+from app.core.config import settings
+from app.main import app
+from app.models.agent_project_binding import AgentProjectBinding
+from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
+from app.routes import runtime
+from app.services.api_key import mint_api_key
+from app.services.project_runtime_skills import project_skill_file_signature
+from app.services.runtime_source import (
+    RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
+    RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
+    RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+    RUNTIME_CAPABILITIES_HEADER,
+    vault_key_identity,
+)
+from tests.conftest import create_env_with_project, create_test_hosted_runtime_state
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOLS,
+    ensure_canonical_codex_tool_provider,
+)
+
+
+@pytest.mark.committed_db
+@pytest.mark.parametrize("conditional", [False, True], ids=["render", "etag"])
+async def test_manifest_fanout_preserves_auth_without_nested_pool_starvation(
+    db_session, seed_user, monkeypatch, conditional
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"manifest-pool-{seed_user.id}",
+        machine_name="Manifest pool",
+        agent_type="openclaw",
+    )
+    state = await create_test_hosted_runtime_state(db_session, env, runtime_name="openclaw")
+    await ensure_canonical_codex_tool_provider(db_session, seed_user)
+    state.tools = CANONICAL_CODEX_TOOLS
+    minted = await mint_api_key(
+        db_session, user_id=seed_user.id, environment_id=env.id, label="manifest-pool"
+    )
+    minted.api_key.last_used_at = datetime.now(UTC)
+    await db_session.commit()
+
+    monkeypatch.setattr(settings, "db_pool_timeout", 1.0)
+    ordinary = database._create_engine(pool_size=2, max_overflow=0)
+    monkeypatch.setattr(database, "engine", ordinary)
+    monkeypatch.setattr(
+        database,
+        "async_session_factory",
+        async_sessionmaker(
+            ordinary, class_=database.async_session_factory.class_, expire_on_commit=False
+        ),
+    )
+    pool = ordinary.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    headers = {
+        "Authorization": f"Bearer {minted.raw_key}",
+        "Accept": RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+        RUNTIME_CAPABILITIES_HEADER: ",".join(
+            (
+                RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
+                RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
+            )
+        ),
+    }
+    authenticate = auth._auth_via_api_key
+    pool_full = asyncio.Event()
+
+    def on_checkout(_connection, _record, _proxy):
+        if pool.checkedout() == 2:
+            pool_full.set()
+
+    async def synchronized_auth(token: str, db: AsyncSession) -> auth.AuthContext | None:
+        result = await authenticate(token, db)
+        assert result is not None
+        assert db.in_transaction()
+        await pool_full.wait()
+        assert pool.checkedout() == 2
+        return result
+
+    event.listen(pool, "checkout", on_checkout)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test", headers=headers
+        ) as client:
+            initial = await client.get("/v1/runtime/manifest")
+            assert initial.status_code == 200, initial.text
+            pool_full.clear()
+            monkeypatch.setattr(auth, "_auth_via_api_key", synchronized_auth)
+            async with asyncio.timeout(5):
+                responses = await asyncio.gather(
+                    *(
+                        client.get(
+                            "/v1/runtime/manifest",
+                            headers={"If-None-Match": initial.headers["etag"]}
+                            if conditional
+                            else {},
+                        )
+                        for _ in range(2)
+                    )
+                )
+            for response in responses:
+                assert response.status_code == (304 if conditional else 200), response.text
+                assert response.headers["etag"] == initial.headers["etag"]
+        assert pool.checkedout() == 0
+    finally:
+        event.remove(pool, "checkout", on_checkout)
+        await ordinary.dispose()
+
+
+async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisition(monkeypatch):
+    ordinary = database._create_engine(pool_size=8, max_overflow=0)
+    monkeypatch.setattr(database, "engine", ordinary)
+    pool = ordinary.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    rendezvous = asyncio.Barrier(4)
+    pairs = asynccontextmanager(database.get_runtime_manifest_sessions)
+
+    async def read_pair():
+        async with pairs() as pair:
+            await pair.auth.execute(text("SELECT 1"))
+            await pair.auth.commit()
+            async with database.runtime_snapshot_session(session_factory=pair.snapshots) as db:
+                configured = (
+                    await db.execute(
+                        text(
+                            "SELECT current_setting('transaction_isolation'), "
+                            "current_setting('transaction_read_only')"
+                        )
+                    )
+                ).one()
+                assert configured == ("repeatable read", "on")
+                await rendezvous.wait()
+                assert pool.checkedout() == 8
+
+    try:
+        async with asyncio.timeout(5):
+            await asyncio.gather(*(read_pair() for _ in range(4)))
+        assert pool.checkedout() == 0
+        async with AsyncExitStack() as stack:
+            for _ in range(7):
+                await stack.enter_async_context(ordinary.connect())
+            partial = asyncio.Event()
+
+            def on_checkout(_connection, _record, _proxy):
+                partial.set()
+
+            event.listen(pool, "checkout", on_checkout)
+            dependency = database.get_runtime_manifest_sessions()
+            acquire = asyncio.create_task(anext(dependency))
+            try:
+                await asyncio.wait_for(partial.wait(), timeout=5)
+                acquire.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await acquire
+                assert pool.checkedout() == 7
+                assert not database._manifest_checkout_lock.locked()
+            finally:
+                event.remove(pool, "checkout", on_checkout)
+                acquire.cancel()
+                await asyncio.gather(acquire, return_exceptions=True)
+                await dependency.aclose()
+        assert pool.checkedout() == 0
+    finally:
+        await ordinary.dispose()
+
+
+async def test_manifest_jwks_wait_does_not_reserve_database_connections(monkeypatch):
+    pool = database.engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    baseline = pool.checkedout()
+    lookup = asyncio.Event()
+
+    async def signing_key(_token: str):
+        lookup.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(auth, "_resolve_clerk_signing_key", signing_key)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        request = asyncio.create_task(
+            client.get("/v1/runtime/manifest", headers={"Authorization": "Bearer clerk-jwt"})
+        )
+        try:
+            await asyncio.wait_for(lookup.wait(), timeout=5)
+            assert pool.checkedout() == baseline
+        finally:
+            request.cancel()
+            await asyncio.gather(request, return_exceptions=True)
+
+
+@pytest.mark.committed_db
+@pytest.mark.parametrize("archive", [False, True], ids=["file", "archive"])
+async def test_signed_project_skill_download_releases_lookup_before_storage(
+    db_session, seed_user, monkeypatch, archive
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"skill-storage-{seed_user.id}",
+        machine_name="Skill storage",
+    )
+    project = Project(
+        user_id=seed_user.id,
+        name="Shared skills",
+        slug=f"shared-skills-{seed_user.id}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(project)
+    await db_session.flush()
+    skill = Skill(
+        user_id=seed_user.id,
+        project_id=project.id,
+        skill_key="example",
+        name="Example",
+        description="Example skill",
+        content_hash="a" * 64,
+        authority=SKILL_AUTHORITY_CLOUD,
+        file_key="example.md",
+    )
+    db_session.add_all(
+        [
+            skill,
+            AgentProjectBinding(
+                agent_id=env.id,
+                project_id=project.id,
+                binding_type="context",
+                priority=1,
+                created_by_user_id=seed_user.id,
+            ),
+        ]
+    )
+    await db_session.commit()
+    signature = project_skill_file_signature(
+        signing_key=vault_key_identity(settings.vault_encryption_key),
+        agent_id=env.id,
+        skill_id=skill.id,
+        content_hash=skill.content_hash,
+    )
+    path = (
+        f"project-skill-archives/{env.id}/{project.id}/{skill.id}/"
+        f"{skill.content_hash}/{signature}/example.tar.gz"
+        if archive
+        else f"project-skill-files/{env.id}/{skill.id}/{skill.content_hash}/{signature}/SKILL.md"
+    )
+    pool = database.engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    baseline = pool.checkedout()
+    storage_started = asyncio.Event()
+    release_storage = asyncio.Event()
+
+    async def read_storage(_key: str) -> bytes:
+        storage_started.set()
+        await release_storage.wait()
+        return b"# Example\n"
+
+    monkeypatch.setattr(runtime.file_store, "get", read_storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        request = asyncio.create_task(client.get(f"/v1/runtime/{path}"))
+        try:
+            await asyncio.wait_for(storage_started.wait(), timeout=5)
+            assert pool.checkedout() == baseline
+            release_storage.set()
+            response = await request
+            assert response.status_code == 200, response.text
+            assert response.content
+        finally:
+            request.cancel()
+            await asyncio.gather(request, return_exceptions=True)

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -413,6 +413,17 @@ control runtime-source snapshot connection, both without overflow. A source
 read holds its authorization transaction while opening a consistent snapshot;
 separate pools prevent nested checkout deadlocks between concurrent callers.
 Both use the ordinary pool's timeout, metrics, and cancellation-safe cleanup.
+Ordinary runtime manifests acquire a complete pair of ordinary connections
+before authentication: one for the unchanged authority transaction, one for
+read-only RR snapshots. Only pair acquisition is serialized, within the ordinary
+pool timeout; renders run concurrently. Connections stay reserved across commits
+and repairs, so no manifest can hold auth while competing for a second checkout.
+The shared eight-slot web pool still supports four concurrent manifests and
+remains fully available to other traffic when manifests are idle. Neither
+control slot is borrowed. Signed Project Skill downloads retain only immutable
+file metadata and close their read-only lookup before object storage I/O.
+JWT signature/JWKS verification precedes pair acquisition; principal authority
+is still resolved under the original transaction locks afterwards.
 Only control transactions additionally set a code-owned 5s `lock_timeout` per
 lock acquisition. PostgreSQL SQLSTATE `55P03` becomes a sanitized 503 with
 `Retry-After: 1`, counted by `clawdi_backend_db_control_lock_timeouts_total`,
@@ -437,12 +448,13 @@ contracts. A close before acceptance rejects the HTTP upgrade with 403; no
 WebSocket close frame can be delivered before the upgrade.
 
 ```bash
-scripts/test.sh backend tests/test_platform_workload_oauth.py tests/test_smoke.py
+scripts/test.sh backend tests/test_runtime_manifest_pool.py tests/test_platform_workload_oauth.py tests/test_smoke.py
 ```
 
 Done: slow admin provider I/O and real PostgreSQL pool contention leave
 deployment control and concurrent nested snapshots usable, both
-WebSocket timeout paths close without HTTP ASGI messages, and the command exits 0.
+WebSocket timeout paths close without HTTP ASGI messages, synchronized manifests
+complete without nested pool starvation, and the command exits 0.
 
 Admin endpoints are disabled by default. The local setup and key-minting flow is
 in [`AGENTS.md`](../AGENTS.md#local-end-to-end). To exercise admin endpoints


### PR DESCRIPTION
## Summary
- acquire runtime manifest auth and RR snapshot connections as a complete pair before authentication
- keep JWT/JWKS network verification outside reserved database connections
- release signed Project Skill lookup sessions before object storage I/O
- preserve the existing pool budget, authority locks, and independent RR snapshot semantics

## Verification
- 473 focused and regression tests passed in isolated Docker
- independent rerun: 53 tests passed (`test_runtime_manifest_pool.py`, `test_cli_oauth_auth.py`, `test_database_session_cleanup.py`)
- Ruff check and format check passed
- changed production files passed type and compile checks
- 201 manifest + 40 ordinary-request benchmark: 201/201 and 40/40 succeeded; ordinary-request p95 0.69s

## Production validation
After deployment and old safety-net task drainage, observe 24 hours with zero new ordinary pool timeouts, zero control lock timeouts, complete fleet observer rounds, and no request-latency regression.