### PR TITLE
perf(backend): overlap runtime manifest pair checkouts

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -232,16 +232,30 @@ async def _reserved_connection() -> AsyncGenerator[AsyncConnection, None]:
 async def get_runtime_manifest_sessions() -> AsyncGenerator[RuntimeManifestSessions, None]:
     """Acquire a complete pair before auth so manifest readers cannot deadlock.
 
-    Only acquisition is serialized. Both connections stay reserved across
-    commits, allowing repairs and fresh RR snapshots without another checkout.
-    Other requests continue sharing the entire ordinary pool.
+    Pair admission is serialized, but its two checkouts overlap connection
+    setup and pre-ping I/O. Both connections stay reserved across commits,
+    allowing repairs and fresh RR snapshots without another checkout. Other
+    requests continue sharing the entire ordinary pool.
     """
     async with AsyncExitStack() as stack:
         acquisition = asyncio.timeout(settings.db_pool_timeout)
         try:
             async with acquisition, _manifest_checkout_lock:
-                auth_connection = await stack.enter_async_context(_reserved_connection())
-                snapshot_connection = await stack.enter_async_context(_reserved_connection())
+                try:
+                    async with asyncio.TaskGroup() as checkouts:
+                        auth_checkout = checkouts.create_task(
+                            stack.enter_async_context(_reserved_connection())
+                        )
+                        snapshot_checkout = checkouts.create_task(
+                            stack.enter_async_context(_reserved_connection())
+                        )
+                except* SQLAlchemyTimeoutError:
+                    # Keep the existing retryable pool-exhaustion response.
+                    raise SQLAlchemyTimeoutError(
+                        "Runtime manifest connection acquisition timed out"
+                    ) from None
+                auth_connection = auth_checkout.result()
+                snapshot_connection = snapshot_checkout.result()
         except TimeoutError:
             if not acquisition.expired():
                 raise

--- a/backend/tests/test_runtime_manifest_pool.py
+++ b/backend/tests/test_runtime_manifest_pool.py
@@ -7,7 +7,8 @@ from datetime import UTC, datetime
 import httpx
 import pytest
 from sqlalchemy import event, text
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from app.core import auth, database
@@ -121,7 +122,10 @@ async def test_manifest_fanout_preserves_auth_without_nested_pool_starvation(
         await ordinary.dispose()
 
 
-async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisition(monkeypatch):
+@pytest.mark.parametrize("abort", ["cancel", "timeout"])
+async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisition(
+    monkeypatch, abort
+):
     ordinary = database._create_engine(pool_size=8, max_overflow=0)
     monkeypatch.setattr(database, "engine", ordinary)
     pool = ordinary.sync_engine.pool
@@ -131,7 +135,15 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
 
     async def read_pair():
         async with pairs() as pair:
-            await pair.auth.execute(text("SELECT 1"))
+            configured = (
+                await pair.auth.execute(
+                    text(
+                        "SELECT current_setting('transaction_isolation'), "
+                        "current_setting('transaction_read_only')"
+                    )
+                )
+            ).one()
+            assert configured == ("read committed", "off")
             await pair.auth.commit()
             async with database.runtime_snapshot_session(session_factory=pair.snapshots) as db:
                 configured = (
@@ -159,13 +171,18 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
                 partial.set()
 
             event.listen(pool, "checkout", on_checkout)
+            if abort == "timeout":
+                monkeypatch.setattr(settings, "db_pool_timeout", 1.0)
             dependency = database.get_runtime_manifest_sessions()
             acquire = asyncio.create_task(anext(dependency))
             try:
                 await asyncio.wait_for(partial.wait(), timeout=5)
-                acquire.cancel()
-                with pytest.raises(asyncio.CancelledError):
-                    await acquire
+                if abort == "cancel":
+                    acquire.cancel()
+                with pytest.raises(
+                    asyncio.CancelledError if abort == "cancel" else SQLAlchemyTimeoutError
+                ):
+                    await asyncio.wait_for(acquire, timeout=5)
                 assert pool.checkedout() == 7
                 assert not database._manifest_checkout_lock.locked()
             finally:
@@ -175,6 +192,159 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
                 await dependency.aclose()
         assert pool.checkedout() == 0
     finally:
+        await ordinary.dispose()
+
+
+async def test_manifest_checkouts_overlap_only_within_one_pair(monkeypatch):
+    ordinary = database._create_engine(pool_size=5, max_overflow=3)
+    monkeypatch.setattr(database, "engine", ordinary)
+    pool = ordinary.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    reserved = database._reserved_connection
+    both_started = asyncio.Event()
+    release_checkouts = asyncio.Event()
+    started = 0
+
+    @asynccontextmanager
+    async def delayed_checkout():
+        nonlocal started
+        async with reserved() as connection:
+            started += 1
+            if started == 2:
+                both_started.set()
+            await release_checkouts.wait()
+            yield connection
+
+    monkeypatch.setattr(database, "_reserved_connection", delayed_checkout)
+    first = database.get_runtime_manifest_sessions()
+    second = database.get_runtime_manifest_sessions()
+    acquire_first = asyncio.create_task(anext(first))
+    acquire_second = None
+    try:
+        await asyncio.wait_for(both_started.wait(), timeout=5)
+        assert pool.checkedout() == 2
+        assert database._manifest_checkout_lock.locked()
+        acquire_second = asyncio.create_task(anext(second))
+        # The second pair must reach the locked admission gate, not a checkout.
+        await asyncio.sleep(0)
+        assert started == 2
+        assert not acquire_first.done()
+        assert not acquire_second.done()
+        release_checkouts.set()
+        async with asyncio.timeout(5):
+            await acquire_first
+            await acquire_second
+        assert pool.checkedout() == 4
+        assert not database._manifest_checkout_lock.locked()
+    finally:
+        release_checkouts.set()
+        tasks = [acquire_first] + ([acquire_second] if acquire_second is not None else [])
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await first.aclose()
+        await second.aclose()
+        assert pool.checkedout() == 0
+        await ordinary.dispose()
+
+
+async def test_manifest_checkout_failure_cancels_sibling_and_remains_retryable(monkeypatch):
+    ordinary = database._create_engine(pool_size=5, max_overflow=3)
+    monkeypatch.setattr(database, "engine", ordinary)
+    pool = ordinary.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    reserved = database._reserved_connection
+    sibling_reserved = asyncio.Event()
+    started = 0
+
+    @asynccontextmanager
+    async def failing_checkout():
+        nonlocal started
+        started += 1
+        if started == 2:
+            await sibling_reserved.wait()
+            raise SQLAlchemyTimeoutError("checkout failed")
+        async with reserved() as connection:
+            sibling_reserved.set()
+            await asyncio.Event().wait()
+            yield connection
+
+    monkeypatch.setattr(database, "_reserved_connection", failing_checkout)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            async with asyncio.timeout(5):
+                response = await client.get(
+                    "/v1/runtime/manifest", headers={"Authorization": "Bearer clawdi_test"}
+                )
+            assert response.status_code == 503, response.text
+            assert response.json() == {"detail": "Database capacity temporarily unavailable"}
+            assert response.headers["Retry-After"] == "1"
+        assert pool.checkedout() == 0
+        assert not database._manifest_checkout_lock.locked()
+        monkeypatch.setattr(database, "_reserved_connection", reserved)
+        async with asynccontextmanager(database.get_runtime_manifest_sessions)() as pair:
+            assert await pair.auth.scalar(text("SELECT 1")) == 1
+    finally:
+        await ordinary.dispose()
+
+
+async def test_manifest_repeated_cancellation_joins_both_checkout_cleanups(monkeypatch):
+    ordinary = database._create_engine(pool_size=5, max_overflow=3)
+    monkeypatch.setattr(database, "engine", ordinary)
+    pool = ordinary.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    reserved = database._reserved_connection
+    both_reserved = asyncio.Event()
+    both_closing = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    started = 0
+    closing = 0
+
+    @asynccontextmanager
+    async def pending_checkout():
+        nonlocal started
+        async with reserved() as connection:
+            started += 1
+            if started == 2:
+                both_reserved.set()
+            await asyncio.Event().wait()
+            yield connection
+
+    close = AsyncConnection.close
+
+    async def delayed_close(connection):
+        nonlocal closing
+        closing += 1
+        if closing == 2:
+            both_closing.set()
+        await release_cleanup.wait()
+        await close(connection)
+
+    monkeypatch.setattr(database, "_reserved_connection", pending_checkout)
+    monkeypatch.setattr(AsyncConnection, "close", delayed_close)
+    dependency = database.get_runtime_manifest_sessions()
+    acquire = asyncio.create_task(anext(dependency))
+    try:
+        await asyncio.wait_for(both_reserved.wait(), timeout=5)
+        acquire.cancel("disconnect")
+        await asyncio.wait_for(both_closing.wait(), timeout=5)
+        acquire.cancel("disconnect-again")
+        await asyncio.sleep(0)
+        assert not acquire.done()
+        assert pool.checkedout() == 2
+        assert database._manifest_checkout_lock.locked()
+        release_cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(acquire, timeout=5)
+        assert pool.checkedout() == 0
+        assert not database._manifest_checkout_lock.locked()
+    finally:
+        release_cleanup.set()
+        acquire.cancel()
+        await asyncio.gather(acquire, return_exceptions=True)
+        await dependency.aclose()
         await ordinary.dispose()
 
 

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -415,9 +415,12 @@ separate pools prevent nested checkout deadlocks between concurrent callers.
 Both use the ordinary pool's timeout, metrics, and cancellation-safe cleanup.
 Ordinary runtime manifests acquire a complete pair of ordinary connections
 before authentication: one for the unchanged authority transaction, one for
-read-only RR snapshots. Only pair acquisition is serialized, within the ordinary
-pool timeout; renders run concurrently. Connections stay reserved across commits
-and repairs, so no manifest can hold auth while competing for a second checkout.
+read-only RR snapshots. Pair admission is serialized within the ordinary pool
+timeout, while the two checkouts in that pair overlap connection setup and
+pre-ping I/O. A bounded task group cancels and joins unfinished checkouts on
+failure or cancellation; existing cleanup returns all reserved connections.
+Renders run concurrently. Connections stay reserved across commits and repairs,
+so no manifest can hold auth while competing for a second checkout.
 The shared eight-slot web pool still supports four concurrent manifests and
 remains fully available to other traffic when manifests are idle. Neither
 control slot is borrowed. Signed Project Skill downloads retain only immutable


### PR DESCRIPTION
## Summary
- overlap the two ordinary-pool checkouts within one admitted runtime manifest pair
- preserve the existing pair admission lock, auth/shared-lock transaction, independent read-only RR snapshot, pool sizes, timeout mapping, and cancellation-safe cleanup
- document the latency tradeoff and add focused concurrency/failure/cancellation contracts

## Evidence
In isolated PostgreSQL 18.4 with real API-key manifest requests and 25 ms server-response-direction latency, 16 concurrent warmed 304 requests improved across two runs:

- response-header mean: 1689-1704 ms -> 1288-1304 ms
- response-header p95: 2956-2995 ms -> 1998-2047 ms
- full-request mean: 1720-1735 ms -> 1325-1343 ms
- pair acquisition mean: 161-164 ms -> 82-83 ms

Zero-injected-latency concurrent mean regressed about 3%-5%, so this is specifically a network checkout/pre-ping optimization and still requires production observation.

## Verification
- 400 related tests passed
- strict type gate: 210 files, zero diagnostics
- Ruff check and format check
- compileall
- OpenAPI/generated-client consistency
- diff check

No production operations or capacity changes were performed.
