### PR TITLE
fix(egress): handle encoded Telegram file credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ database migration, CI, and implementation details.
 - Hosted OpenClaw upgrades now retire the legacy Clawdi provider plugin even
   when OpenClaw requires capability consent before it can inspect the plugin.
 
+## Clawdi CLI v0.14.51
+
+Package: `clawdi@0.14.51`
+
+### Fixed
+
+- Restore managed Telegram photo and other media downloads when clients encode
+  the bot routing token in the file URL, avoiding misleading `InvalidToken`
+  errors while preserving channel authorization boundaries.
+- Preserve encoded credentials, file paths, and query parameters when managed
+  egress replaces credentials in request URLs.
+
 ## Clawdi CLI v0.14.48
 
 Package: `clawdi@0.14.48`

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 from uuid import UUID, uuid4
 
 import httpx
@@ -9772,9 +9772,11 @@ async def test_telegram_callback_query_answer_requires_recorded_reference(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("compact_encoded_path", [False, True], ids=["legacy", "sdk-encoded"])
 async def test_telegram_get_file_records_path_and_download_is_scoped(
     client: httpx.AsyncClient,
     monkeypatch,
+    compact_encoded_path: bool,
 ):
     _reset_fake_provider_client({"ok": True, "result": {"file_path": "photos/file_1.jpg"}})
     monkeypatch.setattr(
@@ -9819,10 +9821,15 @@ async def test_telegram_get_file_records_path_and_download_is_scoped(
         content=b"telegram-file",
         headers={"content-type": "text/plain"},
     )
-    download_path = f"/v1/channels/telegram/file/bot/{routing_id}/photos/file_1.jpg"
-    unowned_download_path = f"/v1/channels/telegram/file/bot/{routing_id}/photos/other.jpg"
+    route = quote(routing_id, safe="") if compact_encoded_path else f"/{routing_id}"
+    download_path = f"/v1/channels/telegram/file/bot{route}/photos/file_1.jpg"
+    unowned_download_path = f"/v1/channels/telegram/file/bot{route}/photos/other.jpg"
     download = await client.get(download_path, headers=managed_headers)
     unowned_download = await client.get(unowned_download_path, headers=managed_headers)
+    wrong_route = await client.get(
+        f"/v1/channels/telegram/file/bot{route}-other/photos/file_1.jpg",
+        headers=managed_headers,
+    )
     rejected_old_secret_path = await client.get(
         f"/v1/channels/telegram/file/bot/{created['agent_token']}/photos/file_1.jpg"
     )
@@ -9841,6 +9848,13 @@ async def test_telegram_get_file_records_path_and_download_is_scoped(
     )
     assert unowned_download.status_code == 403
     assert unowned_download.json()["description"] == "Forbidden: file_path is not bound to this bot"
+    assert wrong_route.status_code == 401
+    if compact_encoded_path:
+        double_encoded = await client.get(
+            f"/v1/channels/telegram/file/bot{quote(route, safe='')}/photos/file_1.jpg",
+            headers=managed_headers,
+        )
+        assert double_encoded.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.50",
+      "version": "0.14.51",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/egress-channel-transport-architecture.md
+++ b/docs/egress-channel-transport-architecture.md
@@ -35,6 +35,11 @@ path data, and preserves the trailing path and query. Public path equals/prefix
 matchers and headers remain literal; query values retain their existing single
 form-URL decode.
 
+The addon ships with the exact CLI artifact, independently of the mitmproxy
+engine pin. Convergence writes the packaged addon and includes its SHA256 in
+the sidecar unit revision, so an addon-only update requires sidecar activation
+through normal runtime reconciliation, not an engine upgrade or image rebuild.
+
 Only hosts from non-passthrough profiles enter the TLS interception set. Once a
 host is intercepted, an unmatched request on that host still uses the original
 request-level upstream. This is not byte-for-byte TCP passthrough because the

--- a/docs/egress-channel-transport-architecture.md
+++ b/docs/egress-channel-transport-architecture.md
@@ -25,6 +25,16 @@ no profile remains on its original upstream request path. A matching `deny`
 profile fails closed. Secrets are resolved only inside the egress process and
 must not be embedded in the profile bundle.
 
+Secret-backed path matchers and path replacement accept credential characters
+in raw or URL-quoted form, with case-insensitive percent escapes. Literal
+prefixes/suffixes, path separators, and unreserved characters stay exact; the
+request path is never decoded. A literal `%` in a credential can match `%25`,
+but a double-encoded colon cannot match `:`. Replacement uses the matched wire
+length (preferring the encoded form), URL-quotes replacement credentials as
+path data, and preserves the trailing path and query. Public path equals/prefix
+matchers and headers remain literal; query values retain their existing single
+form-URL decode.
+
 Only hosts from non-passthrough profiles enter the TLS interception set. Once a
 host is intercepted, an unmatched request on that host still uses the original
 request-level upstream. This is not byte-for-byte TCP passthrough because the
@@ -48,6 +58,8 @@ remain the authorization boundary.
 `packages/cli/tests/egress_addon/clawdi_egress_addon_test.py` runs all three
 profile shapes through the same matcher and rewrite functions and asserts that
 the addon source has no Telegram, Discord, or WhatsApp constants.
+Done: `scripts/test.sh cli tests/egress-addon.test.ts` exits 0 and reports the
+Python interpreter suite passing inside the isolated CLI runner.
 
 ## Backend Boundary
 

--- a/packages/cli/egress-addon/clawdi_egress_addon.py
+++ b/packages/cli/egress-addon/clawdi_egress_addon.py
@@ -13,7 +13,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, quote, urlsplit
 
 try:  # pragma: no cover - exercised only under mitmdump.
     from mitmproxy import ctx, http
@@ -408,11 +408,24 @@ def path_matcher_matches(path: str, matcher: dict[str, Any], secrets: dict[str, 
         secret = secrets.get(str(matcher.get("secretRef", "")))
         if secret is None:
             return False
-        expected = f"{matcher.get('prefix', '')}{secret}{matcher.get('suffix', '')}"
-        if matcher_type == "secretRefEquals":
-            return path == expected
-        return path.startswith(expected)
+        matched = match_secret_path_prefix(path, matcher, secret)
+        return matched is not None and (
+            matcher_type == "secretRefPrefix" or matched.end() == len(path)
+        )
     return False
+
+
+def match_secret_path_prefix(
+    path: str, matcher: dict[str, Any], secret: str
+) -> re.Match[str] | None:
+    # Encode only credential characters, never path structure or incoming escapes.
+    parts = [re.escape(str(matcher.get("prefix", "")))]
+    for char in secret:
+        encoded = quote(char, safe="/\\")
+        literal = re.escape(char)
+        parts.append(literal if encoded == char else f"(?:(?i:{encoded})|{literal})")
+    parts.append(re.escape(str(matcher.get("suffix", ""))))
+    return re.match("".join(parts), path)
 
 
 def matcher_matches(value: str | None, matcher: Any, secrets: dict[str, str]) -> bool:
@@ -523,10 +536,12 @@ def apply_path_replace(request_path: str, rewrite: dict[str, Any], secrets: dict
     split = urlsplit(request_path or "/")
     prefix = str(replacement.get("prefix", ""))
     suffix = str(replacement.get("suffix", ""))
-    expected = f"{prefix}{placeholder}{suffix}"
-    if not split.path.startswith(expected):
+    matched = match_secret_path_prefix(split.path, replacement, placeholder)
+    if matched is None:
         return request_path
-    replaced_path = f"{prefix}{actual}{suffix}{split.path[len(expected):]}"
+    # Keep path characters, but encode data that could start a query or fragment.
+    actual = quote(actual, safe="/:@!$&'()*+,;=")
+    replaced_path = f"{prefix}{actual}{suffix}{split.path[matched.end():]}"
     return f"{replaced_path}?{split.query}" if split.query else replaced_path
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.50",
+	"version": "0.14.51",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/runtime-impact-revision.test.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.test.ts
@@ -18,6 +18,33 @@ const sidecarManifest = {
 };
 
 describe("runtime impact revisions", () => {
+	test("changes sidecar revision for an addon-only update", () => {
+		const program = {
+			transparentPort: 8080,
+			profileBundlePath: "/run/clawdi/egress/profiles.json",
+			secretFilePath: "/run/clawdi/secrets/egress.json",
+			engine: {
+				status: "ready" as const,
+				version: "12.2.3",
+				url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+				sha256: "a".repeat(64),
+				cacheDir: "/var/cache/clawdi/mitmproxy",
+				binaryPath: "/var/cache/clawdi/mitmproxy/mitmdump",
+			},
+			addonSha256: "b".repeat(64),
+		};
+		const identity = { runtimeUid: 10001, runtimeGid: 10001, egressUid: 10002, egressGid: 10002 };
+		const revision = runtimeSidecarProgramRevision(sidecarManifest, program, identity);
+		expect(runtimeSidecarProgramRevision(sidecarManifest, { ...program }, identity)).toBe(revision);
+		expect(
+			runtimeSidecarProgramRevision(
+				sidecarManifest,
+				{ ...program, addonSha256: "c".repeat(64) },
+				identity,
+			),
+		).not.toBe(revision);
+	});
+
 	test("hashes canonical runtime program impact", () => {
 		const impact = {
 			renderedProjection: {

--- a/packages/cli/tests/egress-addon.test.ts
+++ b/packages/cli/tests/egress-addon.test.ts
@@ -1,0 +1,14 @@
+import { test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+test("generic egress addon interpreter", () => {
+	execFileSync(
+		"python3",
+		[
+			fileURLToPath(new URL("./egress_addon/clawdi_egress_addon_test.py", import.meta.url)),
+			"-v",
+		],
+		{ stdio: "inherit", timeout: 15_000 },
+	);
+});

--- a/packages/cli/tests/egress-addon.test.ts
+++ b/packages/cli/tests/egress-addon.test.ts
@@ -5,10 +5,7 @@ import { fileURLToPath } from "node:url";
 test("generic egress addon interpreter", () => {
 	execFileSync(
 		"python3",
-		[
-			fileURLToPath(new URL("./egress_addon/clawdi_egress_addon_test.py", import.meta.url)),
-			"-v",
-		],
+		[fileURLToPath(new URL("./egress_addon/clawdi_egress_addon_test.py", import.meta.url)), "-v"],
 		{ stdio: "inherit", timeout: 15_000 },
 	);
 });

--- a/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
+++ b/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import quote
 
 
 ADDON_PATH = (
@@ -351,22 +352,89 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                     "priority": 10,
                 }
             ],
-            {"secret://placeholder": "managed"},
+            {"secret://placeholder": "managed:token"},
         )
 
         matched = Flow(
             host="provider.test",
-            path="/v1/messages?identity=managed.gateway",
-            headers={"authorization": "Bearer managed.session"},
+            path="/v1/messages?identity=managed%3Atoken.gateway",
+            headers={"authorization": "Bearer managed:token.session"},
         )
         wrong_query = Flow(
             host="provider.test",
-            path="/v1/messages?identity=user-owned",
-            headers={"authorization": "Bearer managed.session"},
+            path="/v1/messages?identity=managed%253Atoken.gateway",
+            headers={"authorization": "Bearer managed:token.session"},
+        )
+        wrong_header = Flow(
+            host="provider.test",
+            path="/v1/messages?identity=managed%3Atoken.gateway",
+            headers={"authorization": "Bearer managed%3Atoken.session"},
         )
 
         self.assertEqual(egress.apply_to_flow(matched).profile_id, "generic-prefix-identity")
         self.assertIsNone(egress.apply_to_flow(wrong_query).profile)
+        self.assertIsNone(egress.apply_to_flow(wrong_header).profile)
+
+    def test_path_secret_encoding_preserves_literal_boundaries_and_matcher_semantics(self):
+        secrets = {"secret://placeholder": "id:token+value@host"}
+        for matcher_type in ("secretRefEquals", "secretRefPrefix"):
+            matcher = {
+                "type": matcher_type,
+                "secretRef": "secret://placeholder",
+                "prefix": "/key/",
+                "suffix": "/",
+            }
+            cases = (
+                ("/key/id:token+value@host/", True),
+                ("/key/id%3Atoken%2Bvalue%40host/", True),
+                ("/key/id%3atoken+value%40host/", True),
+                ("/key/id%3Atoken%2Bvalue%40host/file", matcher_type == "secretRefPrefix"),
+                ("/key/id%253Atoken%2Bvalue%40host/", False),
+                ("/key/id%3ATOKEN%2Bvalue%40host/", False),
+                ("/key/id%3Atoken%2Bvalue%40host-extra/", False),
+                ("/key/id%3Atoken%2Bvalue%40host", False),
+                ("/key/id%3Atoken%2Bvalue%40host%2Ffile", False),
+                ("/key/id%3Atoken%2Bvalue%40host%5Cfile", False),
+                ("/key/id%3Atoken%2Bvalue%40host%2F..%2Ffile", False),
+                ("/key%2Fid%3Atoken%2Bvalue%40host/", False),
+            )
+            for path, expected in cases:
+                with self.subTest(matcher_type=matcher_type, path=path):
+                    self.assertEqual(addon.path_matcher_matches(path, matcher, secrets), expected)
+
+        for matcher_type in ("equals", "prefix"):
+            self.assertFalse(
+                addon.path_matcher_matches(
+                    "/key/id%3Atoken/", {"type": matcher_type, "value": "/key/id:token/"}, {}
+                )
+            )
+        for secret, encoded, expected in (
+            ("a/b", "a%2Fb", False),
+            ("a\\b", "a%5Cb", False),
+            ("..", "%2E%2E", False),
+            (":", "%253A", False),
+            ("%", "%25", True),
+            ("value%3A", "value%253A", True),
+        ):
+            with self.subTest(secret=secret):
+                matcher = {"type": "secretRefEquals", "secretRef": "secret://placeholder"}
+                secrets = {"secret://placeholder": secret}
+                self.assertTrue(addon.path_matcher_matches(secret, matcher, secrets))
+                self.assertEqual(addon.path_matcher_matches(encoded, matcher, secrets), expected)
+
+        self.assertEqual(
+            addon.apply_path_replace(
+                "/key/value%25tail?x=1",
+                {"pathReplace": {
+                    "type": "secretRefPrefix",
+                    "secretRef": "secret://placeholder",
+                    "replacementSecretRef": "secret://actual",
+                    "prefix": "/key/",
+                }},
+                {"secret://placeholder": "value%", "secret://actual": "actual"},
+            ),
+            "/key/actualtail?x=1",
+        )
 
     def load(self, profiles, secrets=None):
         self.tmp = tempfile.TemporaryDirectory()
@@ -706,27 +774,32 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                 }
             ],
             {
-                "secret://placeholder": "placeholder-token",
-                "secret://real-token": "real-agent-token",
+                "secret://placeholder": "placeholder:token",
+                "secret://real-token": "real:agent?token#value%3A",
                 "secret://control-token": "control-token",
             },
         )
 
-        flow = Flow(host="provider.test", path="/botplaceholder-token/send?x=1")
-        decision = egress.apply_to_flow(flow)
+        tail = "send%2Fpart%253A?x=a%2Fb&x=c+d"
+        for placeholder in ("placeholder:token", "placeholder%3Atoken", "placeholder%3atoken"):
+            with self.subTest(placeholder=placeholder):
+                flow = Flow(host="provider.test", path=f"/bot{placeholder}/{tail}")
+                decision = egress.apply_to_flow(flow)
 
-        self.assertEqual(decision.action, "http")
-        self.assertIsNotNone(decision.profile)
-        self.assertEqual(flow.request.scheme, "https")
-        self.assertEqual(flow.request.host, "control.test")
-        self.assertEqual(flow.request.path, "/v1/relay/botreal-agent-token/send?x=1")
-        self.assertEqual(flow.request.headers["host"], "control.test")
-        self.assertEqual(flow.request.headers["authorization"], "Bearer control-token")
-        redacted = addon.redact_url(
-            "https://control.test/v1/relay/botreal-agent-token/send?x=1",
-            decision.profile,
-        )
-        self.assertNotIn("real-agent-token", redacted)
+                self.assertEqual(decision.action, "http")
+                self.assertIsNotNone(decision.profile)
+                self.assertEqual(flow.request.scheme, "https")
+                self.assertEqual(flow.request.host, "control.test")
+                self.assertEqual(
+                    flow.request.path,
+                    f"/v1/relay/botreal:agent%3Ftoken%23value%253A/{tail}",
+                )
+                self.assertEqual(flow.request.headers["host"], "control.test")
+                self.assertEqual(flow.request.headers["authorization"], "Bearer control-token")
+                redacted = addon.redact_url(
+                    f"https://control.test{flow.request.path}", decision.profile
+                )
+                self.assertEqual(redacted, f"https://control.test/v1/relay[redacted]/{tail}")
 
     def test_provider_profile_with_explicit_port_matches_exact_origin(self):
         egress = self.load(
@@ -788,16 +861,17 @@ class AddonProfileInterpreterTest(unittest.TestCase):
         egress = self.load(
             [
                 {
-                    "id": "managed-telegram",
+                    "id": profile_id,
                     "enabled": True,
                     "kind": "http",
                     "match": {
                         "scheme": "https",
                         "host": "api.telegram.org",
+                        "pathPrefix": prefix,
                         "path": {
                             "type": "secretRefPrefix",
                             "secretRef": "secret://placeholder",
-                            "prefix": "/bot",
+                            "prefix": prefix,
                             "suffix": "/",
                         },
                     },
@@ -815,26 +889,50 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                     "logging": {"redactHeaders": ["authorization"], "redactUrlPatterns": []},
                     "priority": 10,
                 }
+                for profile_id, prefix in (
+                    ("managed-telegram", "/bot"),
+                    ("managed-telegram-file", "/file/bot"),
+                )
             ],
             {
                 "secret://placeholder": "999999999:public-routing-id",
                 "secret://agent-token": "123456789:real-agent-token",
             },
         )
-        flow = Flow(
-            host="api.telegram.org",
-            path="/bot999999999:public-routing-id/sendMessage?chat_id=42",
-        )
+        for path in (
+            "/bot999999999:public-routing-id/sendMessage",
+            "/file/bot999999999:public-routing-id/photos/file 1.jpg",
+        ):
+            # python-telegram-bot File._get_encoded_url quotes the path, not the query.
+            for encoded in (
+                path.replace(" ", "%20"), quote(path), quote(path).replace("%3A", "%3a")
+            ):
+                with self.subTest(path=encoded):
+                    request_path = f"{encoded}?x=a%2Fb&x=c+d"
+                    flow = Flow(host="api.telegram.org", path=request_path)
+                    decision = egress.apply_to_flow(flow)
 
-        decision = egress.apply_to_flow(flow)
+                    self.assertEqual(decision.action, "http")
+                    self.assertEqual(flow.request.host, "cloud.test")
+                    self.assertEqual(flow.request.path, f"/v1/channels/telegram{request_path}")
+                    self.assertNotIn("real-agent-token", flow.request.path)
+                    self.assertEqual(
+                        flow.request.headers["authorization"], "Bearer 123456789:real-agent-token"
+                    )
 
-        self.assertEqual(decision.action, "http")
-        self.assertEqual(
-            flow.request.path,
-            "/v1/channels/telegram/bot999999999:public-routing-id/sendMessage?chat_id=42",
-        )
-        self.assertNotIn("real-agent-token", flow.request.path)
-        self.assertEqual(flow.request.headers["authorization"], "Bearer 123456789:real-agent-token")
+        for token in (
+            "999999999%253Apublic-routing-id",
+            "999999999%3Aother-account",
+            "999999999%3Apublic-routing-id-extra",
+            "999999999%3Apublic-routing-id%2F..",
+        ):
+            with self.subTest(token=token):
+                path = f"/file/bot{token}/photos/file_1.jpg"
+                flow = Flow(host="api.telegram.org", path=path)
+                self.assertEqual(egress.apply_to_flow(flow).action, "allow")
+                self.assertEqual(flow.request.host, "api.telegram.org")
+                self.assertEqual(flow.request.path, path)
+                self.assertNotIn("authorization", flow.request.headers)
 
     def test_websocket_profile_rewrites_upgrade_request(self):
         egress = self.load(


### PR DESCRIPTION
## Summary
- Fix managed Telegram media downloads when SDKs URL-encode the routing placeholder (notably `:` to `%3A`). Match only the credential representation without decoding route structure or changing header/query matching.
- Align generic path replacement with encoded match lengths and safely serialize replacement credentials containing `?`, `#`, or `%`; preserve the opaque trailing path and query.
- Wire the existing Python egress interpreter tests into the normal CLI suite and extend the existing backend scoped-download regression for the real compact encoded URL.

## Related Audit
- The same SDK file-download path covers photos, voice/audio, video, documents, and other downloaded media.
- Fixed the related generic `pathReplace` offset and replacement-serialization defects.
- Discord and WhatsApp use different credential transports; no equivalent path-placeholder issue found.
- Literal route boundaries and unreserved characters remain exact. Wrong-account markers, encoded separators, and double-encoded colons do not gain managed credentials.

## Verification
- Isolated Docker CLI runner: `bash scripts/test.sh cli tests/egress-addon.test.ts tests/runtime-egress-profiles.test.ts tests/runtime-transparent-egress.test.ts src/runtime/runtime-bundle-v2.test.ts` passed CLI typechecking, 71 Bun tests and 23 Python tests. Eleven failing subcases were reproduced before the fix.
- Isolated Docker PostgreSQL runner: `bash scripts/test.sh backend tests/test_channels.py -k telegram_get_file_records_path_and_download_is_scoped` passed 2 tests, including after rebasing onto current main.
- Root review of the actual diff and `git diff origin/main..HEAD --check` passed. Test containers and temporary databases cleaned up.
- Full CLI/backend suites, standalone Python lint, and real SDK/TLS end-to-end verification were not run.

## Release Boundary
No database/schema/Hosted source changes, customer credential changes, production repair, or deployment performed. This changes the CLI-packaged egress addon: an approved exact-version CLI release and controlled Hosted rollout are still required. This PR now bumps the exact CLI package and lockfile to 0.14.51 and adds user-facing release notes. Merging the approved head triggers the protected CLI publishing workflow. Publishing alone does not automatically restore existing Hosted customer runtimes.

## Egress Update Audit
- Confirmed the addon is packaged by the CLI, rewritten during convergence, and its SHA256 participates in the systemd sidecar revision. A supported runtime reconciliation activates changed sidecar units; no new engine version, CA change, or tenant image rebuild is needed for this fix.
- Added one addon-only revision regression and verified the existing changed-egress-unit activation case.
- Official mitmproxy latest release rechecked on 2026-09-07: v12.2.3, matching the existing pin. No dependency upgrade performed.
- Follow-up isolated Docker verification ran the normal CLI entrypoint for `tests/egress-addon.test.ts`, `src/runtime/runtime-impact-revision.test.ts`, and the relevant watch/egress test in `tests/runtime.test.ts`: CLI typecheck, 5 Bun tests and 23 Python tests passed. `bun run check` then passed all 1128 files in the same isolated container.
- Corrected the initial CI failure: Biome required a one-line argument array in the new test entrypoint. That correction passed Client CI and backend checks. The release head is now `7ae458785` (0.14.51 metadata); CI reruns and independent release review are required before merge.


## Release Authorization
Owner requested review, merge when ready, and publication of the new CLI on 2026-09-07. Target npm version 0.14.51 was verified absent (registry 404); current latest was 0.14.50. No direct npm publish, protection bypass, or Hosted rollout is authorized by this PR operation.
