### PR TITLE
fix(backend): protect explicit session close from cancellation

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 
@@ -129,9 +129,9 @@ for observed_engine in (engine, control_engine, control_snapshot_engine):
     event.listen(observed_engine.sync_engine.pool, "checkin", _connection_checkin)
 
 
-async def _close_resource(resource: AsyncSession | AsyncConnection) -> None:
+async def _close_resource(close: Callable[[], Coroutine[object, object, None]]) -> None:
     """Return the connection before propagating request cancellation."""
-    close_task = asyncio.create_task(resource.close())
+    close_task = asyncio.create_task(close())
     cancellation: asyncio.CancelledError | None = None
 
     with anyio.CancelScope(shield=True):
@@ -161,8 +161,11 @@ async def _close_resource(resource: AsyncSession | AsyncConnection) -> None:
 
 
 class _CancellationSafeAsyncSession(AsyncSession):
+    async def close(self) -> None:
+        await _close_resource(super().close)
+
     async def __aexit__(self, type_: object, value: object, traceback: object) -> None:
-        await _close_resource(self)
+        await self.close()
 
 
 async_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
@@ -208,7 +211,7 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     try:
         yield session
     finally:
-        await _close_resource(session)
+        await session.close()
 
 
 @dataclass(frozen=True, slots=True)
@@ -226,7 +229,7 @@ async def _reserved_connection() -> AsyncGenerator[AsyncConnection, None]:
     try:
         yield connection
     finally:
-        await _close_resource(connection)
+        await _close_resource(connection.close)
 
 
 async def get_runtime_manifest_sessions() -> AsyncGenerator[RuntimeManifestSessions, None]:
@@ -298,7 +301,7 @@ async def runtime_snapshot_session(
         await _configure_runtime_snapshot(session)
         yield session
     finally:
-        await _close_resource(session)
+        await _close_resource(session.close)
 
 
 async def _configure_runtime_snapshot(session: AsyncSession) -> None:

--- a/backend/tests/test_database_session_cleanup.py
+++ b/backend/tests/test_database_session_cleanup.py
@@ -69,7 +69,8 @@ async def test_externally_cancelled_dependency_waits_for_session_close() -> None
     assert pool.checkedout() == checked_out_before
 
 
-async def test_anyio_level_cancellation_still_returns_connection() -> None:
+@pytest.mark.parametrize("early_close", [False, True])
+async def test_anyio_level_cancellation_still_returns_connection(early_close: bool) -> None:
     pool = _database_pool()
     checked_out_before = pool.checkedout()
     rollback_started = asyncio.Event()
@@ -83,10 +84,19 @@ async def test_anyio_level_cancellation_still_returns_connection() -> None:
         await session.execute(text("SELECT 1"))
         assert pool.checkedout() == checked_out_before + 1
 
-        with anyio.CancelScope() as cancel_scope:
-            cancel_scope.cancel()
+        close_completed = False
+        try:
+            with anyio.CancelScope() as cancel_scope:
+                cancel_scope.cancel()
+                if early_close:
+                    await session.close()
+                else:
+                    await dependency.aclose()
+                close_completed = True
+                assert pool.checkedout() == checked_out_before
+            assert close_completed
+        finally:
             await dependency.aclose()
-            assert pool.checkedout() == checked_out_before
 
     event.listen(database.engine.sync_engine, "rollback", mark_rollback)
     try:


### PR DESCRIPTION
## Summary
- Apply the existing cancellation-safe cleanup to AsyncSession.close(), including early close before signed Skill object-store I/O.
- Reuse the same cleanup implementation for context exits and reserved connections. Preserve shielding for caller-provided snapshot factories.
- Extend the existing PostgreSQL cancellation test with explicit early close and assert cleanup actually completes.

## Verification
- Isolated Docker/PostgreSQL 18.4: 299 focused and regression tests passed (cleanup, manifest, pool, MCP, lock timeouts).
- Ruff lint/format and basedpyright for database.py passed.
- Negative control: removing the close override makes the new test fail and reproduces CancelledError during connection termination plus the non-checked-in connection GC warning.
- git diff --check passed. Local lefthook is unavailable; checks ran independently.

## Boundaries
No pool expansion, API change, migration, mutation replay or production operation. This proves an explicit-close cancellation defect; production request attribution and post-release validation remain outstanding. Composio latency is not changed in this PR.