### PR TITLE
fix(runtime): avoid inherited PATH restarts and release CLI 0.14.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Managed runtime services avoid redundant restarts when the watcher inherits
+  a PATH already prepared during startup.
 - CLI 0.14.50 avoids a misleading missing-database warning when Files starts
   with its existing database; genuine missing-database warnings remain enabled.
 - Managed CLI installations now create protected directories independently of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
-- Managed runtime services avoid redundant restarts when the watcher inherits
+- CLI 0.14.52 avoids redundant managed service restarts when the watcher inherits
   a PATH already prepared during startup.
 - CLI 0.14.50 avoids a misleading missing-database warning when Files starts
   with its existing database; genuine missing-database warnings remain enabled.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.51",
+      "version": "0.14.52",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.51",
+	"version": "0.14.52",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -261,10 +261,14 @@ function systemdUnitNameSegment(value: string): string {
 }
 
 function runtimeSystemdPath(paths: RuntimePaths): string {
+	const inheritedPath =
+		process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 	return [
-		paths.userLocalBin,
-		join(paths.userHome, ".openclaw", "bin"),
-		process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		...new Set([
+			paths.userLocalBin,
+			join(paths.userHome, ".openclaw", "bin"),
+			...inheritedPath.split(":"),
+		]),
 	].join(":");
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -18,6 +18,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseEnv } from "node:util";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import {
@@ -93,6 +94,7 @@ import {
 import { readHostedRuntimeObserved } from "../src/runtime/observed";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { buildRuntimeRunConfig } from "../src/runtime/run-config";
+import { runtimeSystemdCommonEnvironment } from "../src/runtime/runtime-systemd-reconciliation";
 import { canonicalSecretRefSchema, normalizeSecretValues } from "../src/runtime/secret-values";
 import {
 	buildRuntimeBootStatus,
@@ -6544,6 +6546,93 @@ exit 64
 			restore();
 			console.log = previousLog;
 			process.exitCode = previousExitCode;
+		}
+	});
+
+	it("keeps systemd activation unchanged when watch inherits its generated PATH", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const systemctlLog = join(root, "systemctl-path.log");
+		const inheritedPath = process.env.PATH;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		installSuccessfulSystemctlFixture(join(run, "egress", "systemd", "ca.pem"), systemctlLog);
+		writeHermesVersionBinary(home, "0.20.1");
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
+		const paths = getRuntimePaths();
+		const load = hostedHermesDashboardCapabilityLoad(home);
+		load.applyContext = explicitTestApplyContext(load.manifest);
+
+		try {
+			const bootstrap = convergeRuntimeManifest(load, paths);
+			expect(bootstrap.installErrors).toEqual([]);
+			const bootstrapUnits = readSystemdUnitSnapshot(paths);
+			const bootstrapActivation = applySystemdRuntimeUpdate(
+				paths,
+				{ system: new Map(), user: new Map() },
+				bootstrapUnits,
+				{},
+			);
+			expect(bootstrapActivation.applied).toBe(true);
+			writeTestRuntimeAppliedState(paths, load, bootstrap, {
+				activated: bootstrapActivation.activated,
+			});
+			const watchPath = parseEnv(readSystemdEnvFile(paths, "clawdi-runtime-watch")).PATH;
+			if (watchPath === undefined) throw new Error("watch environment has no PATH");
+			const dashboardRevision = systemdEnvDigest(
+				readSystemdEnvFile(paths, "clawdi-hermes-dashboard"),
+			);
+
+			// Bootstrap and watch are separate processes with the same desired state.
+			process.env.PATH = watchPath;
+			for (const phase of ["first-watch", "repeat-watch"]) {
+				writeFileSync(systemctlLog, "");
+				const before = readSystemdUnitSnapshot(paths);
+				const convergence = convergeRuntimeManifest(load, paths);
+				expect(convergence.installErrors).toEqual([]);
+				const after = readSystemdUnitSnapshot(paths);
+				const activation = applySystemdRuntimeUpdate(paths, before, after, {});
+				expect(activation.applied).toBe(true);
+				expect({
+					phase,
+					watchPath: parseEnv(readSystemdEnvFile(paths, "clawdi-runtime-watch")).PATH,
+					units: after,
+					dashboardRevision: systemdEnvDigest(readSystemdEnvFile(paths, "clawdi-hermes-dashboard")),
+					activated: activation.activated,
+					systemUnitsChanged: activation.systemUnitsChanged,
+					userUnitsChanged: activation.userUnitsChanged,
+					restarts: readFileSync(systemctlLog, "utf8")
+						.split("\n")
+						.filter((line) => /^(--user )?restart /.test(line)),
+				}).toEqual({
+					phase,
+					watchPath,
+					units: bootstrapUnits,
+					dashboardRevision,
+					activated: bootstrapActivation.activated,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+					restarts: [],
+				});
+				writeTestRuntimeAppliedState(paths, load, convergence, { activated: activation.activated });
+			}
+
+			const managed = `${paths.userLocalBin}:${join(home, ".openclaw", "bin")}`;
+			process.env.PATH = `/custom bin::./tools:${managed}:/usr/bin:`;
+			expect(runtimeSystemdCommonEnvironment(paths).PATH).toBe(
+				`${managed}:/custom bin::./tools:/usr/bin`,
+			);
+			delete process.env.PATH;
+			const fallback = `${managed}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`;
+			expect(runtimeSystemdCommonEnvironment(paths).PATH).toBe(fallback);
+			process.env.PATH = "";
+			expect(runtimeSystemdCommonEnvironment(paths).PATH).toBe(fallback);
+		} finally {
+			if (inheritedPath === undefined) delete process.env.PATH;
+			else process.env.PATH = inheritedPath;
 		}
 	});
 


### PR DESCRIPTION
## Summary
- Make managed systemd PATH composition idempotent with stable-order deduplication, preserving managed-bin precedence, inherited entries, empty components and fallback behavior.
- Add one integration regression: apply a fixed manifest, inherit the generated watcher PATH in a second process, then prove unchanged unit/environment fingerprints, dashboard revision and activation identity with no redundant restarts.
- Prepare CLI0.14.52; package/lock version only, no dependency changes.

## Verification
- Deterministic red: unfixed source grows PATH and restarts daemon, sidecar and Hermes dashboard.
- Green: runtime integration122 passed, service regression28 passed, focused final regression and Biome passed.
- Complete isolated CLI suite:1766 passed,0 failed,4 native-lifecycle skips across144 files; CLI typecheck, publish-manifest validation, installer shell syntax and build passed.
- Local pack/install preflight initially stopped because the standard test image has no npm. Completing that check in a task-only isolated runner; no shared tooling/config change.
- Root reviewed actual diff; preserved independent current-main backend changes. Broken cross-workspace pre-commit launcher was disabled per command only after equivalent isolated Biome checks; no hooks or global configuration changed.

## Release Boundary
Not published yet. Protected release workflow must build and validate the native matrix, publish one immutable npm artifact with OIDC provenance, and create the matching GitHub release. Runtime selection and rollout are separate operations; this PR does not change deployment settings.