### PR TITLE
perf(mcp): share session-bound tool lists across bridge endpoints

### DIFF
--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -57,7 +57,7 @@ from app.services.composio import (
     get_connected_account_identities,
     get_tool_router_mcp_session,
     get_tool_router_mcp_tools,
-    list_tool_router_mcp_tools,
+    get_tool_router_mcp_tools_result,
     verify_mcp_bridge_token,
 )
 from app.services.file_store import get_file_store
@@ -671,9 +671,8 @@ async def mcp_composio_post(request: Request) -> JsonObject:
         return _mcp_error(rpc_id, -32601, "Method not found")
 
     try:
-        session = await get_tool_router_mcp_session(user_id)
         if method == "tools/list":
-            result = await list_tool_router_mcp_tools(session)
+            result = await get_tool_router_mcp_tools_result(user_id)
         else:
             params = body.get("params")
             if not isinstance(params, dict):
@@ -682,6 +681,7 @@ async def mcp_composio_post(request: Request) -> JsonObject:
             arguments = params.get("arguments") or {}
             if not isinstance(name, str) or not isinstance(arguments, dict):
                 return _mcp_error(rpc_id, -32602, "Invalid params")
+            session = await get_tool_router_mcp_session(user_id)
             result = await call_tool_router_mcp_tool(session, name, arguments)
     except (ComposioMcpUpstreamError, ComposioRouteError) as exc:
         logger.error(

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -248,8 +248,8 @@ class ConnectorAppPage(TypedDict):
 _client: AsyncComposio | None = None
 _sdk_client: Composio[OpenAITool, OpenAIToolCollection] | None = None
 _tool_router_session_cache: dict[str, ComposioMcpSession] = {}
-_tool_router_tools_cache: dict[str, tuple[ComposioMcpSession, list[JsonObject]]] = {}
-_tool_router_tools_inflight: dict[str, asyncio.Task[list[JsonObject]]] = {}
+_tool_router_tools_cache: dict[str, tuple[ComposioMcpSession, ListToolsResult]] = {}
+_tool_router_tools_inflight: dict[str, asyncio.Task[ListToolsResult]] = {}
 
 _REDIRECT_AUTH_TYPES = {"oauth", "oauth1", "oauth2", "dcr_oauth", "composio_link"}
 _INSTANT_AUTH_TYPES = {"none", "no_auth"}
@@ -601,6 +601,19 @@ async def invalidate_tool_router_mcp_session(user_id: str) -> None:
 
 
 async def get_tool_router_mcp_tools(user_id: str) -> list[JsonObject]:
+    result = await get_tool_router_mcp_tools_result(user_id)
+    serialized = _JSON_OBJECT_ADAPTER.validate_json(
+        result.model_dump_json(by_alias=True, exclude_none=True)
+    )
+    raw_tools = serialized.get("tools")
+    return (
+        [tool for tool in raw_tools if isinstance(tool, dict)]
+        if isinstance(raw_tools, list)
+        else []
+    )
+
+
+async def get_tool_router_mcp_tools_result(user_id: str) -> ListToolsResult:
     """Return session-bound tools through a cancellation-safe per-user load."""
     task = _tool_router_tools_inflight.get(user_id)
     if task is None:
@@ -612,7 +625,7 @@ async def get_tool_router_mcp_tools(user_id: str) -> list[JsonObject]:
     return await asyncio.shield(task)
 
 
-async def _load_tool_router_mcp_tools(user_id: str) -> list[JsonObject]:
+async def _load_tool_router_mcp_tools(user_id: str) -> ListToolsResult:
     while True:
         session = await get_tool_router_mcp_session(user_id)
         cached = _tool_router_tools_cache.get(user_id)
@@ -623,20 +636,11 @@ async def _load_tool_router_mcp_tools(user_id: str) -> list[JsonObject]:
         if _tool_router_session_cache.get(user_id) is not session:
             continue
 
-        serialized = _JSON_OBJECT_ADAPTER.validate_json(
-            result.model_dump_json(by_alias=True, exclude_none=True)
-        )
-        raw_tools = serialized.get("tools")
-        tools = (
-            [tool for tool in raw_tools if isinstance(tool, dict)]
-            if isinstance(raw_tools, list)
-            else []
-        )
-        _tool_router_tools_cache[user_id] = (session, tools)
-        return tools
+        _tool_router_tools_cache[user_id] = (session, result)
+        return result
 
 
-def _finish_tool_router_mcp_tools_load(user_id: str, task: asyncio.Task[list[JsonObject]]) -> None:
+def _finish_tool_router_mcp_tools_load(user_id: str, task: asyncio.Task[ListToolsResult]) -> None:
     if _tool_router_tools_inflight.get(user_id) is task:
         _tool_router_tools_inflight.pop(user_id, None)
     if not task.cancelled():

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -254,13 +254,14 @@ async def test_legacy_composio_bridge_rejects_unknown_methods_without_upstream_s
 
 
 @pytest.mark.asyncio
-async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
+async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch, tool_router_cache):
     from mcp.types import CallToolResult, ListToolsResult
 
     from app.core.config import settings
     from app.routes import mcp_bridge
     from app.services.composio import ComposioMcpSession, create_mcp_bridge_token
 
+    composio, sessions = tool_router_cache
     seen: list[tuple[str, object]] = []
     session = ComposioMcpSession(
         url="https://composio.example.test/mcp",
@@ -268,14 +269,17 @@ async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
         expires_at=datetime.now(UTC) + timedelta(minutes=30),
     )
 
-    async def fake_session(user_id: str) -> ComposioMcpSession:
-        seen.append(("session", user_id))
-        return session
+    sessions["clerk_user_123"] = [session]
 
     async def fake_list(value: ComposioMcpSession) -> ListToolsResult:
         assert value is session
+        seen.append(("list", "clerk_user_123"))
         return ListToolsResult.model_validate(
-            {"tools": [{"name": "COMPOSIO_SEARCH_TOOLS", "inputSchema": {"type": "object"}}]}
+            {
+                "tools": [{"name": "COMPOSIO_SEARCH_TOOLS", "inputSchema": {"type": "object"}}],
+                "_meta": {"upstream": "preserved"},
+                "nextCursor": "upstream-cursor",
+            }
         )
 
     async def fake_call(value: ComposioMcpSession, name: str, arguments: dict) -> CallToolResult:
@@ -286,8 +290,7 @@ async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
         )
 
     monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
-    monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_session", fake_session)
-    monkeypatch.setattr(mcp_bridge, "list_tool_router_mcp_tools", fake_list)
+    monkeypatch.setattr(composio, "list_tool_router_mcp_tools", fake_list)
     monkeypatch.setattr(mcp_bridge, "call_tool_router_mcp_tool", fake_call)
     token = create_mcp_bridge_token("clerk_user_123")
     headers = {"Authorization": f"Bearer {token}"}
@@ -311,11 +314,15 @@ async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
             )
             assert listed.status_code == 200, listed.text
             assert listed.json()["result"]["tools"][0]["name"] == "COMPOSIO_SEARCH_TOOLS"
+            assert listed.json()["result"]["_meta"] == {"upstream": "preserved"}
+            assert listed.json()["result"]["nextCursor"] == "upstream-cursor"
             assert called.status_code == 200, called.text
             assert called.json()["result"]["content"] == [{"type": "text", "text": "called"}]
             assert called.json()["result"]["isError"] is False
 
-    assert seen.count(("session", "clerk_user_123")) == 4
+    native_tools = await composio.get_tool_router_mcp_tools("clerk_user_123")
+    assert native_tools[0]["name"] == "COMPOSIO_SEARCH_TOOLS"
+    assert seen.count(("list", "clerk_user_123")) == 1
     assert seen.count(("COMPOSIO_SEARCH_TOOLS", {"query": "mail"})) == 2
 
 
@@ -901,7 +908,7 @@ async def test_connector_tool_cache_is_session_bound_and_user_scoped(
     composio._tool_router_session_cache["user-a"] = sessions["user-a"].pop(0)
     refreshed = await composio.get_tool_router_mcp_tools("user-a")
 
-    assert first is cached
+    assert first == cached
     assert first[0] == {
         "name": "user-a-1",
         "inputSchema": {"type": "object"},
@@ -946,7 +953,7 @@ async def test_connector_tool_load_is_single_flight(monkeypatch, tool_router_cac
     assert list_calls == 1
     release.set()
     first_result, second_result = await asyncio.gather(first, second)
-    assert first_result is second_result
+    assert first_result == second_result
 
 
 @pytest.mark.asyncio
@@ -982,7 +989,7 @@ async def test_connector_tool_load_restarts_after_inflight_invalidation(
         "https://composio.test/invalidation/1",
         "https://composio.test/invalidation/2",
     ]
-    assert composio._tool_router_tools_cache["invalidation"][1] is result
+    assert composio._tool_router_tools_cache["invalidation"][1].tools[0].name == result[0]["name"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reuse the existing per-user, session-bound, single-flight tools cache for the legacy Composio bridge instead of loading the upstream list on every request.
- Cache the complete MCP ListToolsResult to preserve _meta, nextCursor and extension fields. The native bridge retains its existing tools-only projection.
- Keep tools/call uncached, with no automatic retries. TTL, invalidation, user boundaries and shutdown ownership remain unchanged.

## Validation
- Isolated Docker/PostgreSQL: 73 tests passed covering MCP, connectors, session cleanup and capability parity.
- Ruff lint/format and basedpyright on both modified production modules passed.
- Existing alias test now verifies full metadata, shared native/legacy listing and both real tool calls. Upstream list count is 1; restoring the old uncached bridge makes the assertion fail with 3 calls.
- Existing single-flight, cancellation, user isolation and invalidation tests remain passing.
- Diff check passed. Local lefthook unavailable; gates ran independently. Task containers and temporary verification script removed.

## Limits
This removes redundant tool discovery I/O; it does not establish that all production slow requests are tools/list or improve upstream tool execution latency. No production mutation or Discord credential changes. No API schema, migration or generated-client changes.