### PR TITLE
perf(embedding): avoid server imports in periodic healthcheck

### DIFF
--- a/backend/app/workers/embedding.py
+++ b/backend/app/workers/embedding.py
@@ -10,12 +10,10 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import httpx
-import uvicorn
 from anyio import CapacityLimiter, WouldBlock
-from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError
 
 from app.core.config import settings
@@ -29,6 +27,9 @@ from app.services.embedding import (
 )
 
 configure_application_logging()
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 
 class EmbeddingWorkerHealthResponse(BaseModel):
@@ -79,6 +80,8 @@ def create_embedding_worker_app(
     instance_id: str,
     max_concurrency: int,
 ) -> FastAPI:
+    from fastapi import FastAPI, HTTPException, status
+
     limiter = CapacityLimiter(max_concurrency)
     app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
 
@@ -210,6 +213,8 @@ def stage_embedding_socket(socket_path: str) -> Generator[StagedEmbeddingSocket,
 
 
 async def run() -> None:
+    import uvicorn
+
     instance_id = current_worker_instance_id()
     embedder = LocalEmbedder.get()
     await embedder.initialize()

--- a/backend/tests/test_embedding_worker.py
+++ b/backend/tests/test_embedding_worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -185,6 +186,31 @@ async def test_embedding_healthcheck_requires_published_instance_identity(
             new_generation.publish()
             assert await check_embedding_worker_health(str(socket_path), "new-instance")
             assert not await check_embedding_worker_health(str(socket_path), "old-instance")
+
+
+async def test_healthcheck_cli_does_not_load_server_dependencies(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    socket_path = tmp_path_factory.mktemp("health-cli") / "embedding.sock"
+    async with _running_generation(socket_path, _RecordingEmbedder(1.0), socket.gethostname()):
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import sys; from app.workers.embedding import main; "
+            "assert not {'fastapi', 'uvicorn'} & sys.modules.keys(); main()",
+            "healthcheck",
+            env={**os.environ, "MEMORY_EMBEDDING_SERVICE_SOCKET_PATH": str(socket_path)},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            async with asyncio.timeout(10):
+                stdout, stderr = await process.communicate()
+            assert process.returncode == 0, (stdout, stderr)
+        finally:
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
 
 
 def test_embedding_socket_rollover_does_not_let_old_owner_remove_new_socket(


### PR DESCRIPTION
## Summary
- Defer FastAPI imports to app construction and Uvicorn to worker startup. The periodic healthcheck does not need either server dependency.
- Preserve the existing command, interval, timeout, schema validation, Unix socket and exact-instance identity checks. No new health implementation, flag or dependency.
- Add one real subprocess probe test against the existing test Unix-socket server; retain inference, capacity, failure and socket-rollover contracts.

## Evidence and verification
- Live process sampling identified the short-lived healthcheck Python process reaching about one CPU core while the main embedding process was nearly idle. This is not evidence of total-host saturation.
- Isolated Docker/PostgreSQL: 7 worker tests passed; Ruff lint/format, basedpyright and diff check passed.
- Five alternating cold subprocess runs per variant, probing a real test socket: lazy server imports averaged 1131.85ms CPU / 1136.60ms wall; an eager-import control averaged 1459.80ms CPU / 1466.61ms wall. This is roughly 22% less probe CPU, not a production fleet benchmark or a claim that all CPU spikes disappear.
- Temporary test/benchmark resources removed. Local lefthook unavailable; checks ran independently.

## Limits
Python, HTTP client and settings initialization still cost CPU. This change does not optimize API-worker CPU or model inference. Production operations were read-only inspection; the patch is not deployed.