### PR TITLE
perf(connectors): prevent concurrent catalog refreshes

### DIFF
--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -1515,46 +1515,48 @@ def _titleize_slug(slug: str) -> str:
 
 _toolkits_cache: list[_Toolkit] | None = None
 _toolkits_cache_at: datetime | None = None
+_toolkits_cache_lock = asyncio.Lock()
 
 
 async def _get_all_toolkits() -> list[_Toolkit]:
     """Fetch and cache the Composio toolkit catalog."""
     global _toolkits_cache, _toolkits_cache_at
-    now = datetime.now(UTC)
-    if _toolkits_cache is not None and _toolkits_cache_at is not None:
-        if (now - _toolkits_cache_at) < _COMPOSIO_METADATA_CACHE_TTL:
-            return _toolkits_cache
+    async with _toolkits_cache_lock:
+        now = datetime.now(UTC)
+        if _toolkits_cache is not None and _toolkits_cache_at is not None:
+            if (now - _toolkits_cache_at) < _COMPOSIO_METADATA_CACHE_TTL:
+                return _toolkits_cache
 
-    client = get_composio_client()
-    toolkits: list[_Toolkit] = []
-    cursor: str | None = None
-    while True:
-        if cursor:
-            raw_response = await _call_generated_sdk(
-                client.toolkits.list(
-                    managed_by="composio",
-                    sort_by="usage",
-                    limit=1000,
-                    cursor=cursor,
+        client = get_composio_client()
+        toolkits: list[_Toolkit] = []
+        cursor: str | None = None
+        while True:
+            if cursor:
+                raw_response = await _call_generated_sdk(
+                    client.toolkits.list(
+                        managed_by="composio",
+                        sort_by="usage",
+                        limit=1000,
+                        cursor=cursor,
+                    )
                 )
-            )
-        else:
-            raw_response = await _call_generated_sdk(
-                client.toolkits.list(
-                    managed_by="composio",
-                    sort_by="usage",
-                    limit=1000,
+            else:
+                raw_response = await _call_generated_sdk(
+                    client.toolkits.list(
+                        managed_by="composio",
+                        sort_by="usage",
+                        limit=1000,
+                    )
                 )
-            )
-        response = _normalize_sdk_response(raw_response, _ToolkitPage)
-        toolkits.extend(response.items)
-        cursor = response.next_cursor
-        if not cursor:
-            break
+            response = _normalize_sdk_response(raw_response, _ToolkitPage)
+            toolkits.extend(response.items)
+            cursor = response.next_cursor
+            if not cursor:
+                break
 
-    _toolkits_cache = toolkits
-    _toolkits_cache_at = now
-    return toolkits
+        _toolkits_cache = toolkits
+        _toolkits_cache_at = now
+        return toolkits
 
 
 async def get_app_by_name(name: str) -> ConnectorAvailableAppResponse | None:
@@ -1562,8 +1564,7 @@ async def get_app_by_name(name: str) -> ConnectorAvailableAppResponse | None:
     client = get_composio_client()
     toolkits = await _get_all_toolkits()
     for toolkit in toolkits:
-        app = _serialize_app(toolkit, allow_unknown_auth_type=True)
-        if app.name == name:
+        if toolkit.slug == name:
             detail = await _get_toolkit_detail(name)
             return await _annotate_connect_status(client, detail, _serialize_app(detail))
     return None

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -442,6 +442,7 @@ def _composio_client_status_error(
 
 @pytest.fixture(autouse=True)
 def _reset_composio_app_cache(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(composio, "_toolkits_cache_lock", asyncio.Lock())
     monkeypatch.setattr(composio, "_toolkits_cache", None)
     monkeypatch.setattr(composio, "_toolkits_cache_at", None)
     monkeypatch.setattr(composio, "_custom_auth_config_index", None)
@@ -452,6 +453,14 @@ def _reset_composio_app_cache(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.asyncio
 async def test_connector_detail_uses_toolkit_auth_config_details(monkeypatch: pytest.MonkeyPatch):
     fake = FakeClient()
+    serialized: list[str] = []
+    serialize = composio._serialize_app
+
+    def record_serialization(toolkit, **kwargs):
+        serialized.append(toolkit.slug)
+        return serialize(toolkit, **kwargs)
+
+    monkeypatch.setattr(composio, "_serialize_app", record_serialization)
     monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
     monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
 
@@ -460,6 +469,79 @@ async def test_connector_detail_uses_toolkit_auth_config_details(monkeypatch: py
     assert app is not None
     assert app.name == "posthog"
     assert app.auth_type == "api_key"
+    assert serialized == ["posthog"]
+
+
+async def test_catalog_refresh_is_shared_and_expires(monkeypatch: pytest.MonkeyPatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls: list[str | None] = []
+    fake = FakeClient()
+
+    async def list_page(**kwargs):
+        cursor = kwargs.get("cursor")
+        calls.append(cursor)
+        if cursor is None:
+            started.set()
+            await release.wait()
+        return _FakePage[_FakeToolkit](
+            items=[_posthog_list_toolkit()], next_cursor="next" if cursor is None else None
+        )
+
+    monkeypatch.setattr(fake.toolkits, "list", list_page)
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+    first = asyncio.create_task(composio._get_all_toolkits())
+    second = asyncio.create_task(composio._get_all_toolkits())
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            await asyncio.sleep(0)
+            assert calls == [None]
+            release.set()
+            first_result, second_result = await asyncio.gather(first, second)
+        assert first_result is second_result
+        assert len(first_result) == 2
+        assert calls == [None, "next"]
+        assert await composio._get_all_toolkits() is first_result
+        monkeypatch.setattr(
+            composio, "_toolkits_cache_at", datetime.now(UTC) - timedelta(minutes=6)
+        )
+        assert await composio._get_all_toolkits() == first_result
+        assert calls == [None, "next", None, "next"]
+    finally:
+        release.set()
+        for task in (first, second):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(first, second, return_exceptions=True)
+
+
+async def test_cancelled_catalog_refresh_releases_lock_without_publishing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    started = asyncio.Event()
+    fake = FakeClient()
+    list_page = fake.toolkits.list
+
+    async def blocked_page(**kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(fake.toolkits, "list", blocked_page)
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+    first = asyncio.create_task(composio._get_all_toolkits())
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+    finally:
+        first.cancel()
+        await asyncio.gather(first, return_exceptions=True)
+    assert first.cancelled()
+    assert composio._toolkits_cache is None
+    assert composio._toolkits_cache_at is None
+    monkeypatch.setattr(fake.toolkits, "list", list_page)
+    async with asyncio.timeout(3):
+        assert len(await composio._get_all_toolkits()) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Use one asyncio.Lock around the existing per-process toolkit cache check and refresh. Concurrent misses share the completed result instead of independently downloading and validating all catalog pages.
- Preserve TTL, pagination, strict validation and error propagation. No detached task, added retries, new cache layer or stale fallback.
- Match detail requests against toolkit.slug directly instead of serializing every preceding catalog entry.

## Verification
- Isolated Docker/PostgreSQL: 70 connector, MCP and session-cleanup tests passed.
- Ruff lint/format, basedpyright for composio.py and diff check passed.
- Two focused cases cover shared paginated refresh/expiry and cancellation with no partial publication followed by recovery. Existing detail test asserts one serialization.
- Negative control replaces the lock with a null context only during the test: concurrent first-page call count becomes 2 instead of 1 and the test fails.
- Local lefthook unavailable; gates ran independently. Temporary script and test resources cleaned.

## Boundaries
This removes reproducible redundant work, not proof that the entire observed web CPU load is caused by catalog refresh. Production CPU improvement remains unmeasured. No production mutation, pool-size changes or healthcheck changes; embedding probe optimization remains a separate PR.