### PR TITLE
fix(cli): exclude generated bytecode from npm and native releases

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -100,7 +100,7 @@ jobs:
           install_dir="$RUNNER_TEMP/clawdi-cli-install"
           mkdir -p "$release_dir" "$install_dir"
           pack_json=$(npm pack --json --ignore-scripts --pack-destination "$release_dir")
-          tarball=$(node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); console.log(data[0].filename)" <<< "$pack_json")
+          tarball=$(node scripts/check-publish-manifest.mjs --pack-json <<< "$pack_json")
           tarball_path="$release_dir/$tarball"
           tarball_sha=$(sha256sum "$tarball_path" | cut -d' ' -f1)
           printf '%s  %s\n' "$tarball_sha" "$tarball" > "$release_dir/$tarball.sha256"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
-- CLI 0.14.53 ships only the Python egress addon source in its npm package and
-  rejects generated Python caches and bytecode before publication.
+- CLI 0.14.53 ships only the Python egress addon source in npm and native packages,
+  rejecting generated Python caches and bytecode before publication.
 - CLI 0.14.52 avoids redundant managed service restarts when the watcher inherits
   a PATH already prepared during startup.
 - CLI 0.14.50 avoids a misleading missing-database warning when Files starts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- CLI 0.14.53 ships only the Python egress addon source in its npm package and
+  rejects generated Python caches and bytecode before publication.
 - CLI 0.14.52 avoids redundant managed service restarts when the watcher inherits
   a PATH already prepared during startup.
 - CLI 0.14.50 avoids a misleading missing-database warning when Files starts

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.52",
+      "version": "0.14.53",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.52",
+	"version": "0.14.53",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",
@@ -11,7 +11,7 @@
 	"files": [
 		"bin",
 		"dist",
-		"egress-addon",
+		"egress-addon/clawdi_egress_addon.py",
 		"skills",
 		"LICENSE",
 		"README.md"

--- a/packages/cli/scripts/build-native.mjs
+++ b/packages/cli/scripts/build-native.mjs
@@ -47,9 +47,11 @@ if (!result.success) {
 
 console.log(`built ${outfile} (${targetEntry.bunTarget})`);
 
-cpSync(resolve(cliRoot, "egress-addon"), resolve(outputDirectory, "egress-addon"), {
-	recursive: true,
-});
+mkdirSync(resolve(outputDirectory, "egress-addon"), { recursive: true });
+cpSync(
+	resolve(cliRoot, "egress-addon", "clawdi_egress_addon.py"),
+	resolve(outputDirectory, "egress-addon", "clawdi_egress_addon.py"),
+);
 console.log(`copied egress addon to ${resolve(outputDirectory, "egress-addon")}`);
 
 cpSync(resolve(cliRoot, "skills"), resolve(outputDirectory, "skills"), {

--- a/packages/cli/scripts/check-native-release.mjs
+++ b/packages/cli/scripts/check-native-release.mjs
@@ -2,11 +2,11 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { validateNativeArchive } from "../src/lib/native-activation.ts";
 import {
 	NATIVE_RELEASE_MANIFEST_NAME,
 	parseNativeReleaseManifest,
 } from "../src/lib/native-release-manifest.ts";
+import { validateNativePublicationArchive } from "./native-publication.mjs";
 
 const releaseDir = resolve(process.argv[2] || "dist-release");
 const expectedVersion = process.argv[3] || JSON.parse(readFileSync("package.json", "utf8")).version;
@@ -17,9 +17,10 @@ if (manifest.version !== expectedVersion) throw new Error("native release versio
 
 for (const artifact of manifest.artifacts) {
 	const path = resolve(releaseDir, artifact.asset);
-	const actual = createHash("sha256").update(readFileSync(path)).digest("hex");
+	const archive = readFileSync(path);
+	const actual = createHash("sha256").update(archive).digest("hex");
 	if (actual !== artifact.sha256) throw new Error(`checksum mismatch for ${artifact.asset}`);
-	await validateNativeArchive(readFileSync(path));
+	await validateNativePublicationArchive(archive);
 }
 
 console.log(`verified native release ${manifest.version} (${manifest.artifacts.length} targets)`);

--- a/packages/cli/scripts/check-publish-manifest.mjs
+++ b/packages/cli/scripts/check-publish-manifest.mjs
@@ -3,8 +3,15 @@ import { readFileSync } from "node:fs";
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const forbiddenProtocols = /^(catalog|workspace):/;
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+const addonSource = "egress-addon/clawdi_egress_addon.py";
+const checkPack = process.argv[2] === "--pack-json";
+if (process.argv.length > 3 || (process.argv[2] && !checkPack)) {
+	console.error("Usage: check-publish-manifest.mjs [--pack-json < npm-pack.json]");
+	process.exit(2);
+}
 
 const problems = [];
+let tarball;
 if (Object.hasOwn(packageJson.publishConfig ?? {}, "tag")) {
 	problems.push("published CLI package must not declare publishConfig.tag");
 }
@@ -22,17 +29,55 @@ for (const field of dependencyFields) {
 }
 
 const packageFiles = Array.isArray(packageJson.files) ? packageJson.files : [];
-if (!packageFiles.includes("egress-addon")) {
-	problems.push('package.json files must include "egress-addon"');
+const addonEntries = packageFiles.filter(
+	(entry) =>
+		typeof entry === "string" && (entry === "egress-addon" || entry.startsWith("egress-addon/")),
+);
+if (addonEntries.length !== 1 || addonEntries[0] !== addonSource) {
+	problems.push(`package.json files must include only the exact addon source "${addonSource}"`);
 }
 if (!packageFiles.includes("skills")) {
 	problems.push('package.json files must include "skills"');
 }
 
+if (checkPack) {
+	try {
+		const inventory = JSON.parse(readFileSync(0, "utf8"));
+		const packed = Array.isArray(inventory) && inventory.length === 1 ? inventory[0] : null;
+		if (
+			!packed ||
+			packed.name !== packageJson.name ||
+			packed.version !== packageJson.version ||
+			packed.filename !== `${packageJson.name}-${packageJson.version}.tgz` ||
+			!Array.isArray(packed.files) ||
+			packed.files.some((file) => !file || typeof file.path !== "string" || !file.path)
+		) {
+			problems.push("npm pack inventory must describe one exact CLI package with file paths");
+		} else {
+			const paths = packed.files.map((file) => file.path);
+			if (!paths.includes(addonSource))
+				problems.push(`npm pack inventory is missing ${addonSource}`);
+			for (const path of paths) {
+				if (
+					path.split("/").includes("__pycache__") ||
+					path.endsWith(".pyc") ||
+					path.endsWith(".pyo")
+				) {
+					problems.push(`npm pack inventory contains Python cache or bytecode: ${path}`);
+				}
+			}
+			tarball = packed.filename;
+		}
+	} catch {
+		problems.push("could not read valid npm pack JSON inventory from stdin");
+	}
+}
+
 if (problems.length > 0) {
-	console.error("The published CLI package manifest is not ready:");
+	console.error("The CLI package is not ready to publish:");
 	for (const problem of problems) {
 		console.error(`- ${problem}`);
 	}
 	process.exit(1);
 }
+if (checkPack) console.log(tarball);

--- a/packages/cli/scripts/native-publication.mjs
+++ b/packages/cli/scripts/native-publication.mjs
@@ -1,0 +1,33 @@
+import * as tar from "tar";
+import { validateNativeArchive } from "../src/lib/native-activation.ts";
+
+// Publication policy is stricter than installation of existing releases.
+export async function validateNativePublicationArchive(archive) {
+	await validateNativeArchive(archive);
+	let forbiddenPath;
+	await new Promise((resolve, reject) => {
+		const stream = tar.list({
+			gzip: true,
+			strict: true,
+			onReadEntry(entry) {
+				const path = entry.path;
+				if (
+					path.split("/").includes("__pycache__") ||
+					path.endsWith(".pyc") ||
+					path.endsWith(".pyo")
+				) {
+					forbiddenPath ??= path;
+				}
+				entry.resume();
+			},
+		});
+		stream.on("end", resolve);
+		stream.on("error", reject);
+		stream.end(archive);
+	});
+	if (forbiddenPath) {
+		throw new Error(
+			`native publication archive contains Python cache or bytecode: ${forbiddenPath}`,
+		);
+	}
+}

--- a/packages/cli/scripts/package-native-release.mjs
+++ b/packages/cli/scripts/package-native-release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -8,6 +8,7 @@ import {
 	nativeAssetName,
 	nativeTargetForPlatform,
 } from "../src/lib/native-release-manifest.ts";
+import { validateNativePublicationArchive } from "./native-publication.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const cliRoot = resolve(scriptDir, "..");
@@ -36,9 +37,10 @@ run("tar", [
 	"-czf",
 	assetPath,
 	"clawdi",
-	"egress-addon",
+	"egress-addon/clawdi_egress_addon.py",
 	"skills",
 ]);
+await validateNativePublicationArchive(readFileSync(assetPath));
 
 console.log(`packaged ${assetPath}`);
 

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse } from "yaml";
@@ -26,10 +27,11 @@ const cliDevelopmentDoc = readFileSync(
 	resolve(import.meta.dir, "../../../docs/cli-development.md"),
 	"utf8",
 );
-const publishManifestChecker = readFileSync(
-	resolve(import.meta.dir, "../scripts/check-publish-manifest.mjs"),
-	"utf8",
+const publishManifestCheckerPath = resolve(
+	import.meta.dir,
+	"../scripts/check-publish-manifest.mjs",
 );
+const publishManifestChecker = readFileSync(publishManifestCheckerPath, "utf8");
 const manifestContract = readFileSync(
 	resolve(import.meta.dir, "../src/runtime/manifest-contract.ts"),
 	"utf8",
@@ -37,8 +39,60 @@ const manifestContract = readFileSync(
 const cliPackage = JSON.parse(
 	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
 ) as {
+	name: string;
+	version: string;
 	publishConfig?: { access?: string; tag?: unknown };
 };
+
+describe("CLI pack inventory", () => {
+	const packed = {
+		name: cliPackage.name,
+		version: cliPackage.version,
+		filename: `${cliPackage.name}-${cliPackage.version}.tgz`,
+		files: [
+			{ path: "package.json" },
+			{ path: "egress-addon/clawdi_egress_addon.py" },
+			{ path: "skills/future-skill/SKILL.md" },
+		],
+	};
+	const check = (inventory: unknown) =>
+		spawnSync("node", [publishManifestCheckerPath, "--pack-json"], {
+			input: JSON.stringify(inventory),
+			encoding: "utf8",
+		});
+
+	test("accepts the exact source and additional intentional skill files", () => {
+		const result = check([packed]);
+		expect(result.status).toBe(0);
+		expect(result.stdout.trim()).toBe(packed.filename);
+	});
+
+	test("rejects Python cache directories and bytecode anywhere in the package", () => {
+		for (const path of [
+			"egress-addon/__pycache__/cache.json",
+			"egress-addon/addon.pyc",
+			"skills/future-skill/cache.pyo",
+		]) {
+			const result = check([{ ...packed, files: [...packed.files, { path }] }]);
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain(path);
+			expect(result.stdout).toBe("");
+		}
+	});
+
+	test("fails closed for invalid inventory, identity or missing addon source", () => {
+		for (const inventory of [
+			[],
+			[{ ...packed, version: "unreviewed" }],
+			[{ ...packed, files: [{ path: 1 }] }],
+			[{ ...packed, files: [{ path: "package.json" }] }],
+		]) {
+			const result = check(inventory);
+			expect(result.status).toBe(1);
+			expect(result.stdout).toBe("");
+		}
+	});
+});
 
 describe("CLI publish workflow contract", () => {
 	test("keeps current-run release decisions inside the protected publish topology", () => {
@@ -138,6 +192,9 @@ describe("CLI publish workflow contract", () => {
 			"published CLI package must not declare publishConfig.tag",
 		);
 		expect(workflow).toContain("node scripts/check-publish-manifest.mjs");
+		expect(build.steps?.find((step) => step.id === "pack_release")?.run).toContain(
+			'tarball=$(node scripts/check-publish-manifest.mjs --pack-json <<< "$pack_json")',
+		);
 		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
 		expect(workflow).toContain(
 			`CLI_TARBALL_FILENAME: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,

--- a/packages/cli/tests/native-publication.test.ts
+++ b/packages/cli/tests/native-publication.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import * as tar from "tar";
+import { validateNativePublicationArchive } from "../scripts/native-publication.mjs";
+import { validateNativeArchive } from "../src/lib/native-activation";
+
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function payload(): string {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-native-publication-"));
+	roots.push(root);
+	for (const path of [
+		"clawdi",
+		"egress-addon/clawdi_egress_addon.py",
+		"skills/clawdi/SKILL.md",
+		"skills/hosted-versions/1/clawdi/SKILL.md",
+		"skills/future-skill/SKILL.md",
+	]) {
+		mkdirSync(dirname(join(root, path)), { recursive: true });
+		writeFileSync(join(root, path), "fixture\n");
+	}
+	return root;
+}
+
+async function archive(root: string): Promise<Buffer> {
+	const file = join(root, "artifact.tar.gz");
+	await tar.create({ file, cwd: root, gzip: true }, ["clawdi", "egress-addon", "skills"]);
+	return readFileSync(file);
+}
+
+describe("native publication inventory", () => {
+	test("accepts required resources and additional intentional skill files", async () => {
+		expect(await validateNativePublicationArchive(await archive(payload()))).toBeUndefined();
+	});
+
+	test("rejects Python caches without changing legacy installation compatibility", async () => {
+		for (const path of [
+			"egress-addon/__pycache__/cache.json",
+			"egress-addon/addon.pyc",
+			"skills/future-skill/cache.pyo",
+		]) {
+			const root = payload();
+			mkdirSync(dirname(join(root, path)), { recursive: true });
+			writeFileSync(join(root, path), "cache\n");
+			const bytes = await archive(root);
+			expect(await validateNativeArchive(bytes)).toBeUndefined();
+			await expect(validateNativePublicationArchive(bytes)).rejects.toThrow(
+				"Python cache or bytecode",
+			);
+		}
+	});
+
+	test("retains the required addon source check", async () => {
+		const root = payload();
+		rmSync(join(root, "egress-addon", "clawdi_egress_addon.py"));
+		await expect(validateNativePublicationArchive(await archive(root))).rejects.toThrow(
+			"native archive is missing egress-addon/clawdi_egress_addon.py",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Prepare CLI0.14.53 without changing runtime behavior or dependencies; retain the PATH idempotence fix already released in0.14.52.
- Select only the egress addon Python source in npm, native copying and native archive creation.
- Validate structured npm pack inventory and native tar inventory at publication boundaries; reject Python caches/bytecode while retaining native checksums, required resources and path-safety validation.
- Preserve installation compatibility with existing published native archives; no runtime validator change.

## Verification
- Isolated red: generated Python bytecode contaminates the original52 package.
- Isolated green: source caches remain but npm/native artifacts exclude them; required source and intentional skills retained.
- Exact local npm install and real extracted Linux x64 native binary both report0.14.53.
- Injected artifact contamination is rejected by actual publication checks.
- Focused tests20pass, typecheck/Biome/diff checks passed. Independent root verification of npm15 and native9 saved evidence checksums passed.
- Native host archive preflightSHA256111efe9e1548703a2d9445fd9337bab50df255cdf235288355da06feb40b5edb; local npm preflightSHA256de32f56364d1283d813369214dfa26cb40a26286ea10b3eed2d4592d0860ba9b. Neither is a published artifact claim.

## Release Boundary
0.14.52 stays immutable;0.14.53 remains unpublished. Protected release owns full CLI suite, six-platform native matrix, lifecycle checks and OIDC publication. No global tooling/config change, deployment settings or rollout. All task resources cleaned; unrelated latest-main UI work preserved.