### PR TITLE
perf(backend): retain web connections within the existing pool budget

### DIFF
--- a/backend/tests/test_runtime_manifest_pool.py
+++ b/backend/tests/test_runtime_manifest_pool.py
@@ -132,6 +132,13 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
     assert isinstance(pool, QueuePool)
     rendezvous = asyncio.Barrier(4)
     pairs = asynccontextmanager(database.get_runtime_manifest_sessions)
+    connections_created = 0
+
+    def on_connect(_connection, _record):
+        nonlocal connections_created
+        connections_created += 1
+
+    event.listen(pool, "connect", on_connect)
 
     async def read_pair():
         async with pairs() as pair:
@@ -161,6 +168,9 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
     try:
         async with asyncio.timeout(5):
             await asyncio.gather(*(read_pair() for _ in range(4)))
+            assert connections_created == 8
+            await asyncio.gather(*(read_pair() for _ in range(4)))
+            assert connections_created == 8
         assert pool.checkedout() == 0
         async with AsyncExitStack() as stack:
             for _ in range(7):
@@ -192,6 +202,7 @@ async def test_manifest_pairs_allow_four_snapshots_and_clean_up_partial_acquisit
                 await dependency.aclose()
         assert pool.checkedout() == 0
     finally:
+        event.remove(pool, "connect", on_connect)
         await ordinary.dispose()
 
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,11 +59,12 @@ servers:
         # This is the smallest measured capacity step. The local ONNX model is
         # isolated below, so two API workers no longer duplicate its RSS.
         WEB_CONCURRENCY: 2
-        # Per worker: 5+3 ordinary + 2 reserved control = 10 pooled connections.
+        # Retain all 8 ordinary slots to avoid overflow connection churn.
+        # Per worker: 8+0 ordinary + 2 reserved control = 10 pooled connections.
         # Both workers total 20; channels totals 20. Sequential role rolls peak
         # at 60 pooled + 5 LISTEN = 65 of 97 ordinary PostgreSQL client slots.
-        DB_POOL_SIZE: 5
-        DB_MAX_OVERFLOW: 3
+        DB_POOL_SIZE: 8
+        DB_MAX_OVERFLOW: 0
         DB_POOL_TIMEOUT: 5
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
   embedding-worker:

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -422,7 +422,11 @@ failure or cancellation; existing cleanup returns all reserved connections.
 Renders run concurrently. Connections stay reserved across commits and repairs,
 so no manifest can hold auth while competing for a second checkout.
 The shared eight-slot web pool still supports four concurrent manifests and
-remains fully available to other traffic when manifests are idle. Neither
+retains all eight connections after bursts (pool size 8, overflow 0), rather
+than discarding overflow connections and repeatedly initializing replacements.
+Connections remain lazy; this changes retention, not the maximum connection
+budget. The pool remains fully available to other traffic when manifests are
+idle. Neither
 control slot is borrowed. Signed Project Skill downloads retain only immutable
 file metadata and close their read-only lookup before object storage I/O.
 JWT signature/JWKS verification precedes pair acquisition; principal authority

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -128,6 +128,13 @@ publication. Unsigned preview artifacts must remain outside that feed.
 
 ## Merge And Release
 
+The web pool retains eight ordinary connections per worker (`8+0`) without
+increasing its maximum connection budget. Deployment preflight accepts the
+previous `5+3` shape for this transition. To reverse the retention policy, use
+a reviewed forward revert that accepts both pool shapes during preflight;
+an older workflow ref that only recognizes `5+3` will reject a running `8+0`
+role. Do not bypass that state check or edit the running container environment.
+
 1. Merge the PR into `main` after required checks are green.
 2. Watch Actions for these workflows:
    - `Backend CI` is the sole automatic backend-image change gate. Its

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 readonly service="clawdi"
-readonly web_pool="5:3:5"
+readonly web_pool="8:0:5"
+readonly overflow_web_pool="5:3:5"
 readonly previous_web_pool="5:5:5"
 readonly channels_pool="10:10:5"
 readonly legacy_pool="20:20:45"
@@ -57,7 +58,7 @@ validate_database_role_state() {
 	[[ "${state}" == missing ]] && return
 	IFS='|' read -r container image pool workers <<<"${state}"
 	case "${role}:${pool}" in
-		"web:${legacy_pool}"|"web:${channels_pool}"|"web:${previous_web_pool}"|"web:${web_pool}"|\
+		"web:${legacy_pool}"|"web:${channels_pool}"|"web:${previous_web_pool}"|"web:${overflow_web_pool}"|"web:${web_pool}"|\
 			"channels-worker:${legacy_pool}"|"channels-worker:${channels_pool}") ;;
 		*) echo "Refusing unknown ${role} database pool: ${pool}" >&2; exit 1 ;;
 	esac

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -50,7 +50,7 @@ image="ghcr.io/clawdi-ai/clawdi-backend:${CURRENT_IMAGE}"
 if [[ -f "${FAKE_LOG}.${role}.deployed" ]]; then
 	image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION}"
 	case "${role}" in
-		web) pool=5:3:5; workers=2 ;;
+		web) pool=8:0:5; workers=2 ;;
 		channels-worker) pool=10:10:5 ;;
 		embedding-worker) pool=:: ;;
 	esac
@@ -103,6 +103,9 @@ grep -q 'deploy -P --roles web' "${bounded}"
 resumed="$(run resumed 5:5:5 10:10:5 80 present 0 0 2)"
 ! grep -q 'app stop' "${resumed}"
 grep -q 'python -m app.workers.embedding healthcheck' "${resumed}"
+
+run retained 5:3:5 10:10:5 80 present 0 0 2 >/dev/null
+run retained-redeploy 8:0:5 10:10:5 80 present 0 0 2 >/dev/null
 
 if run invalid 12:12:5 10:10:5 >/dev/null 2>&1; then
 	echo "Expected an unknown pool configuration to fail" >&2

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -144,8 +144,8 @@ end
 web = config.role("web")
 expected_web_env = {
   "WEB_CONCURRENCY" => 2,
-  "DB_POOL_SIZE" => 5,
-  "DB_MAX_OVERFLOW" => 3,
+  "DB_POOL_SIZE" => 8,
+  "DB_MAX_OVERFLOW" => 0,
   "DB_POOL_TIMEOUT" => 5,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
 }
@@ -154,7 +154,7 @@ unless web.specialized_env.clear == expected_web_env
 end
 raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 5, 3, 5 ]
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 8, 0, 5 ]
   raise "web role database pool drifted"
 end
 embedding_worker = config.role("embedding-worker")


### PR DESCRIPTION
## Summary
- Change the deployed web pool from 5 retained + 3 overflow to 8 retained + 0 overflow. The eight-slot ordinary maximum, two control reserves, two workers, timeouts and rolling connection budget are unchanged.
- Keep lazy connection establishment; retain burst-created connections instead of discarding them and paying authentication/asyncpg setup repeatedly.
- Accept the existing 5:3:5 deployment state, update render/rollout contracts and document forward-revert requirements. Do not bypass historical deployment preflight to roll back.
- Extend the existing four-manifest pool test with a second wave and physical-connect counts; no new runtime abstraction or background task.

## Evidence
Live read-only observation found 24 new DB sessions over about 21 seconds and recent connections concentrated in the web role. This suggests churn but does not attribute every production CPU spike.

Isolated PostgreSQL with pre-ping, four concurrent manifest session pairs, 20 measured waves after full pool warmup:
- 5+3: 60 new connections, mean wave 155-161ms, Python CPU 2425-2586ms.
- 8+0: 0 new connections, mean wave 16-17ms, Python CPU 278-286ms.

Real ASGI manifest requests with API-key auth and 304 responses, four concurrency, 40 measured responses per variant in alternating order:
- 5+3: 10 new connections, mean wave 124-141ms, Python CPU 853-1025ms.
- 8+0: 2 additional lazy connections, mean wave 60-62ms, Python CPU 527-530ms.
These are isolated short-path benchmarks, not production latency predictions.

## Verification
315 focused/regression tests passed; separate HTTP benchmark test passed. Ruff, diff checks, mock deployment lifecycle and real Kamal 2.12 configuration rendering passed in isolated containers. Render assertions retain the 40 pooled steady / 60 pooled rolling budget, plus existing listeners. Test artifacts and containers cleaned. Local lefthook unavailable; gates ran independently.

## Risks
After demand, two web workers can retain six more idle DB connections than before, while maximum connection capacity is unchanged. Production CPU/latency and connection-churn deltas need post-release verification. Reverting retention requires a reviewed forward change whose preflight accepts the deployed 8+0 shape; old workflow refs may reject it. No production mutation performed.