### PR TITLE
perf(auth): reuse parameterized API key authority statements

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -13,7 +13,7 @@ import jwt
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, bindparam, or_, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -105,6 +105,29 @@ _clerk_jwks_client = (
 # long ago. Every authenticated CLI request used to write+commit the row,
 # which becomes write-lock contention on a hot key at scale.
 LAST_USED_THROTTLE = timedelta(minutes=1)
+
+# Reuse only the query structure; authority is read anew after acquiring its lock.
+_USER_AUTHORITY_SQL = user_authority_sql_expressions()
+_API_KEY_AUTHORITY_QUERY = (
+    select(
+        ApiKey,
+        User,
+        AgentEnvironment.default_project_id,
+        _USER_AUTHORITY_SQL.suspended.label("principal_suspended"),
+        _USER_AUTHORITY_SQL.disabled.label("principal_disabled"),
+    )
+    .outerjoin(User, User.id == ApiKey.user_id)
+    .outerjoin(
+        AgentEnvironment,
+        and_(
+            AgentEnvironment.id == ApiKey.environment_id,
+            AgentEnvironment.user_id == ApiKey.user_id,
+            AgentEnvironment.archived_at.is_(None),
+        ),
+    )
+    .where(ApiKey.key_hash == bindparam("key_hash"))
+    .execution_options(populate_existing=True)
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,29 +225,7 @@ async def _load_api_key_authority(
     db: AsyncSession,
     key_hash: str,
 ) -> _ApiKeyAuthority | None:
-    expressions = user_authority_sql_expressions()
-    row = (
-        await db.execute(
-            select(
-                ApiKey,
-                User,
-                AgentEnvironment.default_project_id,
-                expressions.suspended.label("principal_suspended"),
-                expressions.disabled.label("principal_disabled"),
-            )
-            .outerjoin(User, User.id == ApiKey.user_id)
-            .outerjoin(
-                AgentEnvironment,
-                and_(
-                    AgentEnvironment.id == ApiKey.environment_id,
-                    AgentEnvironment.user_id == ApiKey.user_id,
-                    AgentEnvironment.archived_at.is_(None),
-                ),
-            )
-            .where(ApiKey.key_hash == key_hash)
-            .execution_options(populate_existing=True)
-        )
-    ).one_or_none()
+    row = (await db.execute(_API_KEY_AUTHORITY_QUERY, {"key_hash": key_hash})).one_or_none()
     if row is None:
         return None
     api_key, user, api_key_project_id, suspended, disabled = row

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy import and_, bindparam, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -87,6 +87,12 @@ class PrincipalCleanupClaimLostError(RuntimeError):
 PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS = 60
 PRINCIPAL_CLEANUP_BACKOFF_CAP_SECONDS = 15 * 60
 _USER_AUTHORITY_LOCK_PREFIX = "user-authority:"
+_API_KEY_USER_AUTHORITY_LOCK = select(
+    ApiKey.user_id,
+    func.pg_advisory_xact_lock_shared(
+        func.hashtextextended(func.concat(_USER_AUTHORITY_LOCK_PREFIX, ApiKey.user_id), 0)
+    ),
+).where(ApiKey.key_hash == bindparam("key_hash"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,19 +193,7 @@ async def lock_api_key_user_authority_shared(
 ) -> UUID | None:
     """Resolve an API key's user and acquire its shared authority lock."""
 
-    row = (
-        await db.execute(
-            select(
-                ApiKey.user_id,
-                func.pg_advisory_xact_lock_shared(
-                    func.hashtextextended(
-                        func.concat(_USER_AUTHORITY_LOCK_PREFIX, ApiKey.user_id),
-                        0,
-                    )
-                ),
-            ).where(ApiKey.key_hash == key_hash)
-        )
-    ).first()
+    row = (await db.execute(_API_KEY_USER_AUTHORITY_LOCK, {"key_hash": key_hash})).first()
     return row[0] if row is not None else None
 
 

--- a/backend/tests/test_auth_keys.py
+++ b/backend/tests/test_auth_keys.py
@@ -175,7 +175,14 @@ async def test_unbound_api_key_auth_reloads_committed_scope_and_revocation(
         label="durable authority key",
         scopes=["vault:read", "vault:write"],
     )
+    other_key = await mint_api_key(
+        db_session, user_id=seed_user.id, label="other authority key", scopes=["skills:read"]
+    )
     assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    other_auth = await _auth_via_api_key(other_key.raw_key, db_session)
+    assert other_auth is not None and other_auth.api_key is not None
+    assert other_auth.api_key.id == other_key.api_key.id
+    assert other_auth.api_key.scopes == ["skills:read"]
     await db_session.commit()
 
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)


### PR DESCRIPTION
## Summary
- Build the two fixed API-key authority statements once and pass key_hash through SQLAlchemy bindparam on every execution.
- Reuse only SQL structure, never auth results. Keep the shared-authority lock and subsequent READ COMMITTED authority read as separate statements, populate_existing, last-used commit/revalidation and all lifecycle checks.
- Extend the existing durable-authority test to alternate distinct keys/scopes before checking updates and revocation. No new cache framework, flag, dependency, migration or API change.

## Verification
- Isolated Docker/PostgreSQL: 339 auth, lifecycle, manifest, pool and cleanup regression tests passed. After two formatting-only changes, 17 auth/benchmark tests passed.
- Ruff lint/format, basedpyright for both production modules and diff check passed.
- Alternating rebuilt/reused/reused/rebuilt variants, 200 real API-key authentications each, two keys, warm connections and full session cleanup: rebuilt CPU 941-998ms / wall 1196-1272ms; reused CPU 609-695ms / wall 828-877ms. The rebuilt control uses the former statement construction; this is not an end-to-end HTTP or production benchmark.
- Tests and temporary benchmarks cleaned up. Local lefthook unavailable; gates ran independently.

## Boundaries
No production change performed. SQL execution count and authorization freshness are intentionally unchanged. Production CPU and latency still require post-release observation; the short stack sample alone does not establish that query construction dominates the entire workload.