### PR TITLE
perf: use live Clerk state for client route admission

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -267,6 +267,8 @@ jobs:
         # version then can't find.
         working-directory: apps/web
         run: bunx playwright install --with-deps chromium
+      - name: Auth route lifecycle contracts
+        run: bun run --cwd apps/web e2e --config=playwright.auth.config.ts
       - name: OSS web e2e
         run: bun run --cwd apps/web e2e
 

--- a/apps/web/e2e/auth/clerk-fixture.ts
+++ b/apps/web/e2e/auth/clerk-fixture.ts
@@ -25,7 +25,9 @@ export let signOutCalls = 0;
 
 export function emitSdk(update: Partial<SdkState>) {
 	state = { ...state, ...update };
-	for (const listener of resources) listener();
+	if (Object.keys(update).some((key) => key !== "status")) {
+		for (const listener of resources) listener();
+	}
 	for (const listener of statuses) listener();
 }
 
@@ -63,18 +65,24 @@ const clerk = {
 	get status() {
 		return state.status;
 	},
-	on(_event: "status", listener: () => void) {
-		statuses.add(listener);
-	},
-	off(_event: "status", listener: () => void) {
-		statuses.delete(listener);
-	},
 	signOut: async () => {
 		signOutCalls += 1;
 		emitSdk({ userId: null, sessionId: null });
 	},
 };
-export const useClerk = () => clerk;
+export function useClerk() {
+	// Native ClerkProvider subscribes to status and updates its context even
+	// without a resource emission. Model that separately from useAuth's store.
+	useSyncExternalStore(
+		(listener) => {
+			statuses.add(listener);
+			return () => statuses.delete(listener);
+		},
+		() => state.status,
+		() => initial.status,
+	);
+	return clerk;
+}
 export function useUser() {
 	const auth = useAuth();
 	return { ...auth, user: auth.userId ? { id: auth.userId } : null };

--- a/apps/web/e2e/auth/clerk-fixture.ts
+++ b/apps/web/e2e/auth/clerk-fixture.ts
@@ -1,0 +1,81 @@
+import { useSyncExternalStore } from "react";
+
+// SDK contract fixture: resource emissions and status events are independent.
+// No credentials or Clerk network requests are used by this browser suite.
+export type SdkState = {
+	status: "loading" | "ready" | "degraded" | "error";
+	isLoaded: boolean;
+	userId: string | null;
+	sessionId: string | null;
+	pending: boolean;
+	tokenFailure: boolean;
+};
+const initial: SdkState = {
+	status: "ready",
+	isLoaded: true,
+	userId: "user-a",
+	sessionId: "session-a",
+	pending: false,
+	tokenFailure: false,
+};
+let state = initial;
+const resources = new Set<() => void>();
+const statuses = new Set<() => void>();
+export let signOutCalls = 0;
+
+export function emitSdk(update: Partial<SdkState>) {
+	state = { ...state, ...update };
+	for (const listener of resources) listener();
+	for (const listener of statuses) listener();
+}
+
+const subscribe = (listener: () => void) => {
+	resources.add(listener);
+	return () => {
+		resources.delete(listener);
+	};
+};
+const getToken = async () => {
+	if (state.tokenFailure) throw new TypeError("Token refresh unavailable");
+	return state.userId && state.sessionId ? `${state.userId}:${state.sessionId}` : null;
+};
+
+export function useAuth({ treatPendingAsSignedOut = true } = {}) {
+	const snapshot = useSyncExternalStore(
+		subscribe,
+		() => state,
+		() => initial,
+	);
+	const signedIn =
+		snapshot.isLoaded &&
+		Boolean(snapshot.userId && snapshot.sessionId) &&
+		!(snapshot.pending && treatPendingAsSignedOut);
+	return {
+		isLoaded: snapshot.isLoaded,
+		isSignedIn: snapshot.isLoaded ? signedIn : undefined,
+		userId: signedIn ? snapshot.userId : null,
+		sessionId: signedIn ? snapshot.sessionId : null,
+		getToken,
+	};
+}
+
+const clerk = {
+	get status() {
+		return state.status;
+	},
+	on(_event: "status", listener: () => void) {
+		statuses.add(listener);
+	},
+	off(_event: "status", listener: () => void) {
+		statuses.delete(listener);
+	},
+	signOut: async () => {
+		signOutCalls += 1;
+		emitSdk({ userId: null, sessionId: null });
+	},
+};
+export const useClerk = () => clerk;
+export function useUser() {
+	const auth = useAuth();
+	return { ...auth, user: auth.userId ? { id: auth.userId } : null };
+}

--- a/apps/web/e2e/auth/hydration.browser.tsx
+++ b/apps/web/e2e/auth/hydration.browser.tsx
@@ -14,6 +14,7 @@ import { AuthRouterBridge } from "@/components/auth-router-bridge";
 import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
 import { useRouteAuth } from "@/lib/auth-client";
 import { type AppRouterContext, type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
+import { useHydrated } from "@/lib/use-hydrated";
 import { emitSdk } from "./clerk-fixture";
 
 const serverAuth: RouteAuth = { status: "signed-in", userId: "user-a", sessionId: "session-a" };
@@ -21,15 +22,20 @@ const observations: { status: RouteAuth["status"]; sameClient: boolean; cached: 
 const errors: string[] = [];
 let mounts = 0;
 let unmounts = 0;
+let hydrated = false;
+let originalClient: ReturnType<typeof useQueryClient> | undefined;
 
 function CacheProbe() {
 	const client = useQueryClient();
 	const auth = useRouteAuth();
+	const isHydrated = useHydrated();
 	const [firstClient] = useState(() => {
 		client.setQueryData(["hydration-probe"], "fixture-cache");
+		originalClient = client;
 		return client;
 	});
 	useLayoutEffect(() => {
+		hydrated = isHydrated;
 		observations.push({
 			status: auth.status,
 			sameClient: client === firstClient,
@@ -83,8 +89,13 @@ function createProbeRouter(isServer: boolean) {
 		path: "/",
 		component: DocumentProbe,
 	});
+	const signIn = createRoute({
+		getParentRoute: () => root,
+		path: "/sign-in",
+		component: () => <h1>Sign in</h1>,
+	});
 	const router = createRouter({
-		routeTree: root.addChildren([protectedRoute.addChildren([index])]),
+		routeTree: root.addChildren([protectedRoute.addChildren([index]), signIn]),
 		history: createMemoryHistory({ initialEntries: ["/"] }),
 		isServer,
 		context: { auth: isServer ? serverAuth : undefined },
@@ -117,6 +128,12 @@ if (typeof document !== "undefined") {
 		observations,
 		errors,
 		emitSdk,
+		get hydrated() {
+			return hydrated;
+		},
+		get originalCached() {
+			return originalClient?.getQueryData(["hydration-probe"]) === "fixture-cache";
+		},
 		get mounts() {
 			return mounts;
 		},
@@ -139,6 +156,8 @@ if (typeof document !== "undefined") {
 declare global {
 	interface Window {
 		hydrationTest: {
+			hydrated: boolean;
+			originalCached: boolean;
 			observations: typeof observations;
 			errors: string[];
 			mounts: number;

--- a/apps/web/e2e/auth/hydration.browser.tsx
+++ b/apps/web/e2e/auth/hydration.browser.tsx
@@ -1,0 +1,149 @@
+import { useQueryClient } from "@tanstack/react-query";
+import {
+	createMemoryHistory,
+	createRootRouteWithContext,
+	createRoute,
+	createRouter,
+	Outlet,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { hydrate } from "@tanstack/react-router/ssr/client";
+import { useEffect, useLayoutEffect, useState } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { AuthRouterBridge } from "@/components/auth-router-bridge";
+import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
+import { useRouteAuth } from "@/lib/auth-client";
+import { type AppRouterContext, type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
+import { emitSdk } from "./clerk-fixture";
+
+const serverAuth: RouteAuth = { status: "signed-in", userId: "user-a", sessionId: "session-a" };
+const observations: { status: RouteAuth["status"]; sameClient: boolean; cached: boolean }[] = [];
+const errors: string[] = [];
+let mounts = 0;
+let unmounts = 0;
+
+function CacheProbe() {
+	const client = useQueryClient();
+	const auth = useRouteAuth();
+	const [firstClient] = useState(() => {
+		client.setQueryData(["hydration-probe"], "fixture-cache");
+		return client;
+	});
+	useLayoutEffect(() => {
+		observations.push({
+			status: auth.status,
+			sameClient: client === firstClient,
+			cached: client.getQueryData(["hydration-probe"]) === "fixture-cache",
+		});
+	});
+	return <Outlet />;
+}
+
+function DocumentProbe() {
+	useEffect(() => {
+		mounts += 1;
+		return () => {
+			unmounts += 1;
+		};
+	}, []);
+	return (
+		<main data-hydration-private>
+			<h1>Server-admitted document</h1>
+			<iframe
+				title="SSR runtime"
+				srcDoc="<!doctype html><textarea aria-label='Runtime draft'></textarea>"
+			/>
+		</main>
+	);
+}
+
+function createProbeRouter(isServer: boolean) {
+	const root = createRootRouteWithContext<AppRouterContext>()({
+		component: () => (
+			<AuthRouterBridge>
+				<CacheProbe />
+			</AuthRouterBridge>
+		),
+	});
+	const protectedRoute = createRoute({
+		getParentRoute: () => root,
+		id: "_protected",
+		beforeLoad: ({ context, location }) => ({
+			authIdentity: requireRouteIdentity(context.auth, location.href),
+		}),
+		errorComponent: ProtectedRouteError,
+		component: () => (
+			<ProtectedAuthBoundary identity={protectedRoute.useRouteContext().authIdentity}>
+				<Outlet />
+			</ProtectedAuthBoundary>
+		),
+	});
+	const index = createRoute({
+		getParentRoute: () => protectedRoute,
+		path: "/",
+		component: DocumentProbe,
+	});
+	const router = createRouter({
+		routeTree: root.addChildren([protectedRoute.addChildren([index])]),
+		history: createMemoryHistory({ initialEntries: ["/"] }),
+		isServer,
+		context: { auth: isServer ? serverAuth : undefined },
+	});
+	return router;
+}
+
+export async function renderHydrationProbe() {
+	const { renderToString } = await import("react-dom/server");
+	const { attachRouterServerSsrUtils } = await import("@tanstack/react-router/ssr/server");
+	const router = createProbeRouter(true);
+	attachRouterServerSsrUtils({ router, manifest: undefined });
+	const ssr = router.serverSsr;
+	if (!ssr) throw new Error("Missing native SSR utilities");
+	try {
+		await router.load();
+		await ssr.dehydrate();
+		const markup = renderToString(<RouterProvider router={router} />);
+		ssr.setRenderFinished();
+		return { markup, bootstrap: ssr.takeBufferedHtml() ?? "" };
+	} finally {
+		ssr.cleanup();
+	}
+}
+
+if (typeof document !== "undefined") {
+	const element = document.getElementById("app");
+	if (!element) throw new Error("Missing hydration root");
+	window.hydrationTest = {
+		observations,
+		errors,
+		emitSdk,
+		get mounts() {
+			return mounts;
+		},
+		get unmounts() {
+			return unmounts;
+		},
+	};
+	if (new URLSearchParams(location.search).get("sdk") === "loading") emitSdk({ status: "loading" });
+	const router = createProbeRouter(false);
+	void hydrate(router)
+		.then(() => {
+			hydrateRoot(element, <RouterProvider router={router} />, {
+				onRecoverableError: (error) =>
+					errors.push(error instanceof Error ? error.message : String(error)),
+			});
+		})
+		.catch((error: unknown) => errors.push(error instanceof Error ? error.message : String(error)));
+}
+
+declare global {
+	interface Window {
+		hydrationTest: {
+			observations: typeof observations;
+			errors: string[];
+			mounts: number;
+			unmounts: number;
+			emitSdk: typeof emitSdk;
+		};
+	}
+}

--- a/apps/web/e2e/auth/hydration.pw.ts
+++ b/apps/web/e2e/auth/hydration.pw.ts
@@ -1,8 +1,20 @@
 import { expect, test } from "@playwright/test";
+import type { SdkState } from "./clerk-fixture";
 import type {} from "./hydration.browser";
 
-for (const sdk of ["ready", "loading"] as const) {
-	test(`SSR hydration with live SDK ${sdk}`, async ({ page }, info) => {
+const scenarios: { sdk: "ready" | "loading"; update?: Partial<SdkState> }[] = [
+	{ sdk: "ready" },
+	{ sdk: "loading" },
+	{ sdk: "loading", update: { userId: null, sessionId: null } },
+	{ sdk: "loading", update: { pending: true } },
+	{ sdk: "loading", update: { userId: "user-b", sessionId: "session-b" } },
+	{ sdk: "loading", update: { sessionId: "session-b" } },
+];
+
+for (const { sdk, update } of scenarios) {
+	test(`SSR hydration retains SDK ${sdk} until ${JSON.stringify(update) ?? "ready"}`, async ({
+		page,
+	}, info) => {
 		const entry = Promise.withResolvers<void>();
 		await page.route("**/e2e/auth/hydration.browser.tsx", async (route) => {
 			await entry.promise;
@@ -18,33 +30,53 @@ for (const sdk of ["ready", "loading"] as const) {
 			await expect
 				.poll(() => page.evaluate(() => window.hydrationTest?.observations.length ?? 0))
 				.toBeGreaterThan(0);
-			if (sdk === "loading") {
-				await expect(page.locator("iframe")).toHaveCount(0);
-				await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
-				await page.evaluate(() => window.hydrationTest.emitSdk({ status: "ready" }));
-				await expect(page.locator("iframe")).toBeVisible();
-				await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(2);
-				await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue("");
+			await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(1);
+			// Wait for the post-hydration client snapshot, not just getServerSnapshot.
+			await expect.poll(() => page.evaluate(() => window.hydrationTest.hydrated)).toBe(true);
+			await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue(
+				"before hydration",
+			);
+			expect(await frame.evaluate((node) => node === document.querySelector("iframe"))).toBe(true);
+			const retained = await page.evaluate(() => ({ ...window.hydrationTest, emitSdk: undefined }));
+			expect(retained.errors).toEqual([]);
+			expect(retained.unmounts).toBe(0);
+			expect(
+				retained.observations.every(
+					(row) => row.sameClient && row.cached && row.status === "signed-in",
+				),
+			).toBe(true);
+			await page.evaluate(
+				(update) => window.hydrationTest.emitSdk({ status: "ready", ...update }),
+				update,
+			);
+			if (update) {
+				await expect.poll(() => page.evaluate(() => window.hydrationTest.unmounts)).toBe(1);
 				expect(await frame.evaluate((node) => node.isConnected)).toBe(false);
+				await expect
+					.poll(() => page.evaluate(() => window.hydrationTest.originalCached))
+					.toBe(false);
+				if (update.pending || update.userId === null) {
+					await expect(page.locator("iframe")).toHaveCount(0);
+					await expect(page.getByRole("heading")).toHaveText("Sign in");
+				} else {
+					await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue("");
+					expect(
+						await page.evaluate(() =>
+							window.hydrationTest.observations.some((row) => !row.sameClient && !row.cached),
+						),
+					).toBe(true);
+				}
 			} else {
-				await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(1);
 				await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue(
 					"before hydration",
 				);
 				expect(await frame.evaluate((node) => node === document.querySelector("iframe"))).toBe(
 					true,
 				);
+				expect(await page.evaluate(() => window.hydrationTest.unmounts)).toBe(0);
 			}
 			const result = await page.evaluate(() => ({ ...window.hydrationTest, emitSdk: undefined }));
 			expect(result.errors).toEqual([]);
-			expect(result.unmounts).toBe(sdk === "ready" ? 0 : 1);
-			if (sdk === "ready")
-				expect(
-					result.observations.every(
-						(row) => row.sameClient && row.cached && row.status === "signed-in",
-					),
-				).toBe(true);
-			else expect(result.observations.some((row) => !row.sameClient && !row.cached)).toBe(true);
 			await info.attach("hydration-observations", {
 				body: JSON.stringify(result, null, 2),
 				contentType: "application/json",

--- a/apps/web/e2e/auth/hydration.pw.ts
+++ b/apps/web/e2e/auth/hydration.pw.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+import type {} from "./hydration.browser";
+
+for (const sdk of ["ready", "loading"] as const) {
+	test(`SSR hydration with live SDK ${sdk}`, async ({ page }, info) => {
+		const entry = Promise.withResolvers<void>();
+		await page.route("**/e2e/auth/hydration.browser.tsx", async (route) => {
+			await entry.promise;
+			await route.continue();
+		});
+		try {
+			await page.goto(`/__auth-hydration?sdk=${sdk}`, { waitUntil: "commit" });
+			await expect(page.getByRole("heading")).toHaveText("Server-admitted document");
+			await page.frameLocator("iframe").getByRole("textbox").fill("before hydration");
+			const frame = await page.locator("iframe").elementHandle();
+			if (!frame) throw new Error("Missing SSR iframe");
+			entry.resolve();
+			await expect
+				.poll(() => page.evaluate(() => window.hydrationTest?.observations.length ?? 0))
+				.toBeGreaterThan(0);
+			if (sdk === "loading") {
+				await expect(page.locator("iframe")).toHaveCount(0);
+				await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+				await page.evaluate(() => window.hydrationTest.emitSdk({ status: "ready" }));
+				await expect(page.locator("iframe")).toBeVisible();
+				await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(2);
+				await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue("");
+				expect(await frame.evaluate((node) => node.isConnected)).toBe(false);
+			} else {
+				await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(1);
+				await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue(
+					"before hydration",
+				);
+				expect(await frame.evaluate((node) => node === document.querySelector("iframe"))).toBe(
+					true,
+				);
+			}
+			const result = await page.evaluate(() => ({ ...window.hydrationTest, emitSdk: undefined }));
+			expect(result.errors).toEqual([]);
+			expect(result.unmounts).toBe(sdk === "ready" ? 0 : 1);
+			if (sdk === "ready")
+				expect(
+					result.observations.every(
+						(row) => row.sameClient && row.cached && row.status === "signed-in",
+					),
+				).toBe(true);
+			else expect(result.observations.some((row) => !row.sameClient && !row.cached)).toBe(true);
+			await info.attach("hydration-observations", {
+				body: JSON.stringify(result, null, 2),
+				contentType: "application/json",
+			});
+		} finally {
+			entry.resolve();
+			await info.attach("hydration-diagnostics", {
+				body: JSON.stringify(
+					await page.evaluate(() =>
+						window.hydrationTest ? { ...window.hydrationTest, emitSdk: undefined } : null,
+					),
+					null,
+					2,
+				),
+				contentType: "application/json",
+			});
+		}
+	});
+}

--- a/apps/web/e2e/auth/index.html
+++ b/apps/web/e2e/auth/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Auth boundary contract</title></head><body><div id="app"></div><script type="module" src="/e2e/auth/lifecycle.browser.tsx"></script></body></html>

--- a/apps/web/e2e/auth/lifecycle.browser.tsx
+++ b/apps/web/e2e/auth/lifecycle.browser.tsx
@@ -1,0 +1,187 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	createRootRouteWithContext,
+	createRoute,
+	createRouter,
+	Link,
+	Outlet,
+	RouterProvider,
+} from "@tanstack/react-router";
+import { useLayoutEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
+import { AuthRouterBridge } from "@/components/auth-router-bridge";
+import { AuthStatus } from "@/components/auth-status";
+import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
+import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
+import { ApiError, normalizeApiError } from "@/lib/api-errors";
+import { useAuthToken, useRouteAuth } from "@/lib/auth-client";
+import {
+	type AppRouterContext,
+	RouteAuthUnavailable,
+	requireRouteIdentity,
+} from "@/lib/route-auth";
+import { emitSdk, signOutCalls } from "./clerk-fixture";
+import "@/styles/globals.css";
+
+const commits: { identity: string | null; data: string | undefined }[] = [];
+let currentClient: ReturnType<typeof useQueryClient> | undefined;
+let held: ReturnType<typeof Promise.withResolvers<string>> | undefined;
+let abortedPreload = false;
+
+const root = createRootRouteWithContext<AppRouterContext>()({
+	component: () => (
+		<AuthRouterBridge>
+			<Outlet />
+		</AuthRouterBridge>
+	),
+});
+const protectedRoute = createRoute({
+	getParentRoute: () => root,
+	id: "_protected",
+	beforeLoad: ({ context, location }) => ({
+		authIdentity: requireRouteIdentity(context.auth, location.href),
+	}),
+	errorComponent: ({ error }) =>
+		error instanceof RouteAuthUnavailable ? (
+			<AuthStatus status={error.status} />
+		) : (
+			<p role="alert">Route failed</p>
+		),
+	component: () => {
+		const { authIdentity } = protectedRoute.useRouteContext();
+		return (
+			<ProtectedAuthBoundary identity={authIdentity}>
+				<AccountSuspensionBoundary>
+					<PrivatePane />
+				</AccountSuspensionBoundary>
+			</ProtectedAuthBoundary>
+		);
+	},
+});
+const a = createRoute({
+	getParentRoute: () => protectedRoute,
+	path: "/private/a",
+	component: () => <h1>Destination A</h1>,
+});
+const b = createRoute({
+	getParentRoute: () => protectedRoute,
+	path: "/private/b",
+	loader: async ({ abortController }) => {
+		const pending = held;
+		if (!pending) return "ready";
+		const onAbort = () => {
+			abortedPreload = true;
+			pending.reject(abortController.signal.reason);
+		};
+		abortController.signal.addEventListener("abort", onAbort, { once: true });
+		try {
+			return await pending.promise;
+		} finally {
+			abortController.signal.removeEventListener("abort", onAbort);
+		}
+	},
+	component: () => <h1>Destination B</h1>,
+});
+const signIn = createRoute({
+	getParentRoute: () => root,
+	path: "/sign-in",
+	component: () => <h1>Sign in</h1>,
+});
+const publicRoute = createRoute({
+	getParentRoute: () => root,
+	path: "/public",
+	component: () => <h1>Public content</h1>,
+});
+const router = createRouter({
+	routeTree: root.addChildren([protectedRoute.addChildren([a, b]), signIn, publicRoute]),
+	context: { auth: undefined },
+	defaultPreload: "intent",
+});
+
+function PrivatePane() {
+	const auth = useRouteAuth();
+	const { getToken } = useAuthToken();
+	const client = useQueryClient();
+	const [draft, setDraft] = useState("");
+	const data = useQuery({
+		queryKey: ["private-destination"],
+		retry: false,
+		queryFn: async ({ signal }) => {
+			const token = await getToken();
+			const response = await fetch("http://127.0.0.1:8000/private-data", {
+				headers: { authorization: `Bearer ${token}` },
+				signal,
+			});
+			if (!response.ok) throw new ApiError(response.status, "Denied");
+			return response.text();
+		},
+	});
+	useLayoutEffect(() => {
+		currentClient = client;
+		commits.push({
+			identity: auth.status === "signed-in" ? `${auth.userId}:${auth.sessionId}` : null,
+			data: data.data,
+		});
+	});
+	return (
+		<main>
+			<nav>
+				<Link<typeof router> to="/private/a">A</Link>
+				<Link<typeof router> to="/private/b">B</Link>
+				<Link<typeof router> to="/public">Public</Link>
+			</nav>
+			<Outlet />
+			{data.error ? (
+				<p role="alert">{normalizeApiError(data.error)}</p>
+			) : (
+				<p data-private>{data.data}</p>
+			)}
+			<textarea aria-label="Draft" value={draft} onChange={(e) => setDraft(e.target.value)} />
+			<iframe
+				title="Private runtime"
+				srcDoc="<!doctype html><textarea aria-label='Runtime draft'></textarea>"
+			/>
+			<UnsavedNavigationGuard dirty={Boolean(draft)} busy={false} />
+		</main>
+	);
+}
+
+window.authTest = {
+	emitSdk,
+	commits,
+	navigate: (to) => router.navigate({ to }),
+	holdPreload: () => {
+		router.clearCache({ filter: (match) => match.routeId === b.id });
+		held = Promise.withResolvers<string>();
+		void router.preloadRoute({ to: "/private/b" }).catch(() => undefined);
+	},
+	releasePreload: () => {
+		held?.resolve("old-generation");
+		held = undefined;
+	},
+	get abortedPreload() {
+		return abortedPreload;
+	},
+	get signOutCalls() {
+		return signOutCalls;
+	},
+	refetch: () => currentClient?.refetchQueries(),
+};
+declare global {
+	interface Window {
+		authTest: {
+			emitSdk: typeof emitSdk;
+			commits: typeof commits;
+			navigate: (to: string) => Promise<void>;
+			holdPreload: () => void;
+			releasePreload: () => void;
+			abortedPreload: boolean;
+			signOutCalls: number;
+			refetch: () => Promise<void> | undefined;
+		};
+	}
+}
+const element = document.getElementById("app");
+if (!element) throw new Error("Missing test root");
+createRoot(element).render(<RouterProvider router={router} />);

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -1,0 +1,171 @@
+import { expect, type Page, test } from "@playwright/test";
+import type {} from "./lifecycle.browser";
+
+async function start(page: Page) {
+	await page.route("http://127.0.0.1:8000/**", (route) =>
+		route.fulfill({
+			contentType: "application/json",
+			body: route.request().url().endsWith("private-data")
+				? route.request().headers().authorization?.replace("Bearer ", "")
+				: "{}",
+		}),
+	);
+	await page.goto("/e2e/auth/");
+	await page.evaluate(() => window.authTest.navigate("/private/a"));
+	await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
+}
+
+test("same identity keeps cache, draft and iframe document across navigation and history", async ({
+	page,
+}) => {
+	await start(page);
+	const frame = page.frameLocator("iframe");
+	await frame.getByRole("textbox").fill("retained-runtime-draft");
+	await page.getByRole("link", { name: "B", exact: true }).click();
+	await expect(page.getByRole("heading")).toHaveText("Destination B");
+	await page.goBack();
+	await expect(page.getByRole("heading")).toHaveText("Destination A");
+	await page.goForward();
+	await expect(page.getByRole("heading")).toHaveText("Destination B");
+	await expect(frame.getByRole("textbox")).toHaveValue("retained-runtime-draft");
+	await page.getByRole("textbox", { name: "Draft", exact: true }).fill("unsaved");
+	await page.getByRole("link", { name: "A", exact: true }).click();
+	await expect(page.getByRole("alertdialog")).toBeVisible();
+	await page.getByRole("button", { name: "Keep editing" }).click();
+	await expect(page.getByRole("textbox", { name: "Draft", exact: true })).toHaveValue("unsaved");
+});
+
+test("public routes stay available while loading and signed-out client navigation stays protected", async ({
+	page,
+}) => {
+	await page.goto("/e2e/auth/");
+	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: false }));
+	await page.evaluate(() => window.authTest.navigate("/private/a"));
+	await expect(page.locator("main")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+	await page.evaluate(() => window.authTest.navigate("/public"));
+	await expect(page.getByRole("heading")).toHaveText("Public content");
+	await page.evaluate(() =>
+		window.authTest.emitSdk({ isLoaded: true, userId: null, sessionId: null }),
+	);
+	await page.evaluate(() => window.authTest.navigate("/private/a"));
+	await expect(page.getByRole("heading")).toHaveText("Sign in");
+	await expect(page.locator("[data-private]")).toHaveCount(0);
+});
+
+for (const update of [{ userId: "user-b", sessionId: "session-b" }, { sessionId: "session-b" }]) {
+	test(`identity switch isolates cached destinations and retires preloads: ${JSON.stringify(update)}`, async ({
+		page,
+	}) => {
+		await start(page);
+		await page.evaluate(() => window.authTest.navigate("/private/b"));
+		await page.evaluate(() => window.authTest.navigate("/private/a"));
+		await page.evaluate(() => window.authTest.holdPreload());
+		await page.frameLocator("iframe").getByRole("textbox").fill("old-session");
+		await page.evaluate((update) => window.authTest.emitSdk(update), update);
+		await expect(page.locator("[data-private]")).toHaveText(
+			`${update.userId ?? "user-a"}:session-b`,
+		);
+		await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue("");
+		expect(await page.evaluate(() => window.authTest.abortedPreload)).toBe(true);
+		await page.evaluate(() => window.authTest.releasePreload());
+		const commits = await page.evaluate(() => window.authTest.commits);
+		expect(commits.filter((commit) => commit.data && commit.data !== commit.identity)).toEqual([]);
+		await page.goBack();
+		await expect(page.locator("[data-private]")).toHaveText(
+			`${update.userId ?? "user-a"}:session-b`,
+		);
+	});
+}
+
+for (const update of [{ userId: null, sessionId: null }, { pending: true }]) {
+	test(`logout/session-task emissions remove protected UI and cached history: ${JSON.stringify(update)}`, async ({
+		page,
+	}) => {
+		await start(page);
+		await page.evaluate(() => window.authTest.navigate("/private/b"));
+		await page.evaluate((update) => window.authTest.emitSdk(update), update);
+		await expect(page.locator("iframe")).toHaveCount(0);
+		await expect(page.getByRole("heading")).toHaveText("Sign in");
+		await page.goBack();
+		await expect(page.locator("[data-private]")).toHaveCount(0);
+		await page.evaluate(() => window.authTest.navigate("/public"));
+		await expect(page.getByRole("heading")).toHaveText("Public content");
+	});
+}
+
+for (const status of ["loading", "degraded", "error"] as const) {
+	test(`SDK ${status} blocks stale snapshots without signing out and recovers by event`, async ({
+		page,
+	}) => {
+		await start(page);
+		await page.evaluate((status) => window.authTest.emitSdk({ status }), status);
+		await expect(page.locator("iframe")).toHaveCount(0);
+		await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+		expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+		await page.evaluate(() => window.authTest.emitSdk({ status: "ready" }));
+		await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
+	});
+}
+
+test("late old-identity queries cannot publish in the new identity", async ({ page }) => {
+	await start(page);
+	const late = Promise.withResolvers<void>();
+	let seen = false;
+	await page.route("**/private-data", async (route) => {
+		if (route.request().headers().authorization?.includes("user-a")) {
+			seen = true;
+			await late.promise;
+		}
+		await route.fallback();
+	});
+	await page.evaluate(() => {
+		void window.authTest.refetch();
+	});
+	await expect.poll(() => seen).toBe(true);
+	await page.evaluate(() => window.authTest.emitSdk({ userId: "user-b", sessionId: "session-b" }));
+	late.resolve();
+	await expect(page.locator("[data-private]")).toHaveText("user-b:session-b");
+	expect(
+		await page.evaluate(() =>
+			window.authTest.commits.filter((c) => c.data && c.data !== c.identity),
+		),
+	).toEqual([]);
+});
+
+test("401 account admission is denied; resource 403 and refresh/network failures do not hard-logout", async ({
+	page,
+}) => {
+	await start(page);
+	await page.route("**/private-data", (route) => route.fulfill({ status: 403, body: "Forbidden" }));
+	await page.evaluate(() => window.authTest.refetch());
+	await expect(page.getByRole("alert")).toBeVisible();
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+	await expect(page.locator("iframe")).toBeVisible();
+	await page.route("**/v1/auth/me", (route) => route.fulfill({ status: 403, body: "Forbidden" }));
+	await page.evaluate(() => window.authTest.refetch());
+	await expect(page.getByText("Session unavailable.", { exact: true })).toBeVisible();
+	await expect(page.locator("iframe")).toHaveCount(0);
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+	await page.unroute("**/v1/auth/me");
+	await page.evaluate(() => window.authTest.emitSdk({ tokenFailure: true }));
+	await page.evaluate(() => window.authTest.refetch());
+	await expect(page.getByText("Session unavailable.", { exact: true })).toBeVisible();
+	await expect(page.locator("iframe")).toHaveCount(0);
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+	await page.evaluate(() => window.authTest.emitSdk({ tokenFailure: false }));
+	await page.route("**/v1/auth/me", (route) =>
+		route.fulfill({
+			status: 401,
+			contentType: "application/json",
+			body: '{"detail":"Invalid session"}',
+		}),
+	);
+	await page.evaluate(() => window.authTest.refetch());
+	await expect(page.locator("iframe")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Sign in again", exact: true })).toBeVisible();
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+	await page.getByRole("button", { name: "Sign in again", exact: true }).click();
+	await expect(page.getByRole("heading")).toHaveText("Sign in");
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(1);
+});

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -94,7 +94,7 @@ for (const update of [{ userId: null, sessionId: null }, { pending: true }]) {
 	});
 }
 
-for (const status of ["loading", "degraded", "error"] as const) {
+for (const status of ["degraded", "error"] as const) {
 	test(`SDK ${status} blocks stale snapshots without signing out and recovers by event`, async ({
 		page,
 	}) => {
@@ -107,6 +107,18 @@ for (const status of ["loading", "degraded", "error"] as const) {
 		await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
 	});
 }
+
+test("native unknown auth removes an admitted session independently of script status", async ({
+	page,
+}) => {
+	await start(page);
+	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: false }));
+	await expect(page.locator("iframe")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
+	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: true }));
+	await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
+});
 
 test("late old-identity queries cannot publish in the new identity", async ({ page }) => {
 	await start(page);

--- a/apps/web/e2e/auth/vite.config.ts
+++ b/apps/web/e2e/auth/vite.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [react(), tailwindcss()],
+	resolve: {
+		alias: [
+			{ find: "@", replacement: fileURLToPath(new URL("../../src", import.meta.url)) },
+			{
+				find: /^@clerk\/tanstack-react-start$/,
+				replacement: fileURLToPath(new URL("./clerk-fixture.ts", import.meta.url)),
+			},
+		],
+	},
+});

--- a/apps/web/e2e/auth/vite.config.ts
+++ b/apps/web/e2e/auth/vite.config.ts
@@ -4,7 +4,41 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [react(), tailwindcss()],
+	optimizeDeps: { entries: ["e2e/auth/index.html", "e2e/auth/hydration.browser.tsx"] },
+	plugins: [
+		react(),
+		tailwindcss(),
+		{
+			name: "auth-hydration-fixture",
+			configureServer(server) {
+				server.middlewares.use(async (request, response, next) => {
+					if (request.url?.split("?")[0] !== "/__auth-hydration") return next();
+					try {
+						const module = await server.ssrLoadModule("/e2e/auth/hydration.browser.tsx");
+						const output: unknown = await module.renderHydrationProbe();
+						if (
+							!output ||
+							typeof output !== "object" ||
+							!("markup" in output) ||
+							!("bootstrap" in output) ||
+							typeof output.markup !== "string" ||
+							typeof output.bootstrap !== "string"
+						)
+							throw new Error("Invalid SSR fixture output");
+						response.setHeader("Content-Type", "text/html");
+						response.end(
+							await server.transformIndexHtml(
+								request.url,
+								`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Auth hydration contract</title></head><body><div id="app">${output.markup}</div>${output.bootstrap}<script type="module" src="/e2e/auth/hydration.browser.tsx"></script></body></html>`,
+							),
+						);
+					} catch (error) {
+						next(error);
+					}
+				});
+			},
+		},
+	],
 	resolve: {
 		alias: [
 			{ find: "@", replacement: fileURLToPath(new URL("../../src", import.meta.url)) },

--- a/apps/web/e2e/auth/vite.config.ts
+++ b/apps/web/e2e/auth/vite.config.ts
@@ -26,10 +26,14 @@ export default defineConfig({
 						)
 							throw new Error("Invalid SSR fixture output");
 						response.setHeader("Content-Type", "text/html");
+						const template = await server.transformIndexHtml(
+							request.url,
+							'<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Auth hydration contract</title></head><body><!--ssr-outlet--><script type="module" src="/e2e/auth/hydration.browser.tsx"></script></body></html>',
+						);
 						response.end(
-							await server.transformIndexHtml(
-								request.url,
-								`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Auth hydration contract</title></head><body><div id="app">${output.markup}</div>${output.bootstrap}<script type="module" src="/e2e/auth/hydration.browser.tsx"></script></body></html>`,
+							template.replace(
+								"<!--ssr-outlet-->",
+								() => `<div id="app">${output.markup}</div>${output.bootstrap}`,
 							),
 						);
 					} catch (error) {

--- a/apps/web/playwright.auth.config.ts
+++ b/apps/web/playwright.auth.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./e2e/auth",
+	testMatch: "*.pw.ts",
+	workers: 1,
+	timeout: 30000,
+	expect: { timeout: 10000 },
+	use: { baseURL: "http://127.0.0.1:3111", trace: "retain-on-failure" },
+	webServer: {
+		command:
+			"bun x --no-install vite --config e2e/auth/vite.config.ts --host 127.0.0.1 --port 3111 --strictPort",
+		url: "http://127.0.0.1:3111/e2e/auth/",
+		env: {
+			VITE_DEV_AUTH_BYPASS: "false",
+			VITE_CLERK_PUBLISHABLE_KEY: "pk_test_contract_fixture",
+			VITE_CLAWDI_API_URL: "http://127.0.0.1:8000",
+		},
+	},
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
 	testMatch: "**/*.pw.ts",
 	globalSetup: "./e2e/global-setup.ts",
 	testIgnore: [
+		// SDK lifecycle contracts use their own isolated Clerk fixture server.
+		"**/auth/**",
 		// Hosted suites run under playwright.hosted.config.ts
 		// (VITE_CLAWDI_HOSTED=true); in the OSS build those surfaces cannot
 		// render.

--- a/apps/web/src/components/account-suspension-boundary.tsx
+++ b/apps/web/src/components/account-suspension-boundary.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useSyncExternalStore } from "react";
 import { AccountSuspendedPage } from "@/components/account-suspended-page";
+import { AuthStatus } from "@/components/auth-status";
 import {
 	getAccountSuspendedServerSnapshot,
 	getAccountSuspendedSnapshot,
 	subscribeToAccountSuspension,
 } from "@/lib/account-suspension";
 import { useOpenApi } from "@/lib/api";
-import { isAccountSuspendedError } from "@/lib/api-errors";
+import { isAccountSuspendedError, isApiAuthError } from "@/lib/api-errors";
 import { useAuthActions, useCurrentUser } from "@/lib/auth-client";
 import { useHydrated } from "@/lib/use-hydrated";
 
@@ -35,12 +36,14 @@ export function AccountSuspensionBoundary({ children }: { children: React.ReactN
 	);
 
 	if (suspended || isAccountSuspendedError(access.error)) {
-		return <SuspendedAccountState />;
+		return <AccountAccessDeniedState suspended />;
 	}
+	if (isApiAuthError(access.error)) return <AccountAccessDeniedState suspended={false} />;
+	if (access.isError) return <AuthStatus status="unavailable" />;
 	return children;
 }
 
-function SuspendedAccountState() {
+function AccountAccessDeniedState({ suspended }: { suspended: boolean }) {
 	const { signOut } = useAuthActions();
 	const [signingOut, setSigningOut] = useState(false);
 	const [signOutError, setSignOutError] = useState<string | null>(null);
@@ -56,6 +59,16 @@ function SuspendedAccountState() {
 		}
 	};
 
+	if (!suspended) {
+		return (
+			<AuthStatus
+				status="signed-out"
+				onSignIn={() => void handleSignOut()}
+				signingIn={signingOut}
+				error={signOutError}
+			/>
+		);
+	}
 	return (
 		<AccountSuspendedPage
 			onSignOut={() => void handleSignOut()}

--- a/apps/web/src/components/auth-router-bridge.tsx
+++ b/apps/web/src/components/auth-router-bridge.tsx
@@ -1,0 +1,46 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { RouterContextProvider, useRouter } from "@tanstack/react-router";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { clearAccountSuspension } from "@/lib/account-suspension";
+import { useRouteAuth } from "@/lib/auth-client";
+import { createAppQueryClient } from "@/lib/query-client";
+import { routeAuthIdentity } from "@/lib/route-auth";
+
+const isProtectedMatch = (match: { routeId: string }) => match.routeId.startsWith("/_protected");
+
+export function AuthRouterBridge({ children }: { children: React.ReactNode }) {
+	const router = useRouter();
+	const auth = useRouteAuth();
+	const identity = routeAuthIdentity(auth);
+	const authKey = identity ?? auth.status;
+	const previousAuthKey = useRef<string | undefined>(undefined);
+	const [scope, setScope] = useState(() => ({ identity, queryClient: createAppQueryClient() }));
+	if (scope.identity !== identity) {
+		// React retries this render before children commit. Old requests and
+		// mutation callbacks retain their old client, never the next session's.
+		setScope({ identity, queryClient: createAppQueryClient() });
+	}
+	useEffect(() => () => scope.queryClient.clear(), [scope.queryClient]);
+	useLayoutEffect(() => {
+		if (previousAuthKey.current === authKey) return;
+		previousAuthKey.current = authKey;
+		clearAccountSuspension();
+		router.clearCache({ filter: isProtectedMatch });
+		if (
+			![...router.state.matches, ...router.matchRoutes(router.state.location)].some(
+				isProtectedMatch,
+			)
+		) {
+			return;
+		}
+		void router
+			.invalidate({ filter: isProtectedMatch })
+			.catch(() => console.error("Failed to refresh authenticated routes"));
+	}, [authKey, router]);
+
+	return (
+		<RouterContextProvider router={router} context={{ auth }}>
+			<QueryClientProvider client={scope.queryClient}>{children}</QueryClientProvider>
+		</RouterContextProvider>
+	);
+}

--- a/apps/web/src/components/auth-status.tsx
+++ b/apps/web/src/components/auth-status.tsx
@@ -1,0 +1,48 @@
+import { Link } from "@tanstack/react-router";
+import { LoaderCircle, LogIn, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function AuthStatus({
+	status,
+	onSignIn,
+	signingIn = false,
+	error,
+}: {
+	status: "loading" | "unavailable" | "signed-out";
+	onSignIn?: () => void;
+	signingIn?: boolean;
+	error?: string | null;
+}) {
+	return (
+		<section className="flex min-h-64 flex-col items-center justify-center gap-4 p-6">
+			{status === "loading" ? (
+				<LoaderCircle className="size-5 animate-spin" role="status" aria-label="Loading session" />
+			) : (
+				<p className="text-sm text-muted-foreground">
+					{status === "signed-out" ? "Please sign in to continue." : "Session unavailable."}
+				</p>
+			)}
+			{onSignIn ? (
+				<Button onClick={onSignIn} disabled={signingIn}>
+					<LogIn className="size-4" />
+					Sign in again
+				</Button>
+			) : status === "signed-out" ? (
+				<Button nativeButton={false} render={<Link to="/sign-in" />}>
+					<LogIn className="size-4" />
+					Sign in
+				</Button>
+			) : (
+				<Button variant="outline" onClick={() => window.location.reload()}>
+					<RotateCcw className="size-4" />
+					Reload
+				</Button>
+			)}
+			{error && (
+				<p role="alert" className="text-sm text-destructive">
+					{error}
+				</p>
+			)}
+		</section>
+	);
+}

--- a/apps/web/src/components/protected-auth-boundary.tsx
+++ b/apps/web/src/components/protected-auth-boundary.tsx
@@ -1,0 +1,29 @@
+import type { ErrorComponentProps } from "@tanstack/react-router";
+import { Fragment } from "react";
+import { AuthStatus } from "@/components/auth-status";
+import RootError from "@/components/root-error";
+import { useRouteAuth } from "@/lib/auth-client";
+import { RouteAuthUnavailable, routeAuthIdentity } from "@/lib/route-auth";
+
+export function ProtectedRouteError({ error, reset }: ErrorComponentProps) {
+	return error instanceof RouteAuthUnavailable ? (
+		<AuthStatus status={error.status} />
+	) : (
+		<RootError error={error} reset={reset} />
+	);
+}
+
+export function ProtectedAuthBoundary({
+	identity: admittedIdentity,
+	children,
+}: {
+	identity: string;
+	children: React.ReactNode;
+}) {
+	const auth = useRouteAuth();
+	const identity = routeAuthIdentity(auth);
+	if (auth.status !== "signed-in") return <AuthStatus status={auth.status} />;
+	// Cached/in-flight matches cannot render under a different live session.
+	if (identity !== admittedIdentity) return <AuthStatus status="loading" />;
+	return <Fragment key={identity}>{children}</Fragment>;
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,59 +1,21 @@
 "use client";
 
-import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
-import { useEffect, useRef, useState } from "react";
+import { AuthRouterBridge } from "@/components/auth-router-bridge";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { clearAccountSuspension } from "@/lib/account-suspension";
-import { useCurrentUser } from "@/lib/auth-client";
-import { createAppQueryClient, resetQueryClientForAuthChange } from "@/lib/query-client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-	const [queryClient] = useState(createAppQueryClient);
 	return (
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<NuqsAdapter>
-				<QueryClientProvider client={queryClient}>
-					<QueryCacheAuthBoundary queryClient={queryClient}>
-						<AnalyticsProvider>
-							<TooltipProvider delay={200}>{children}</TooltipProvider>
-						</AnalyticsProvider>
-					</QueryCacheAuthBoundary>
-				</QueryClientProvider>
+				<AuthRouterBridge>
+					<AnalyticsProvider>
+						<TooltipProvider delay={200}>{children}</TooltipProvider>
+					</AnalyticsProvider>
+				</AuthRouterBridge>
 			</NuqsAdapter>
 		</ThemeProvider>
 	);
-}
-
-function QueryCacheAuthBoundary({
-	children,
-	queryClient,
-}: {
-	children: React.ReactNode;
-	queryClient: QueryClient;
-}) {
-	const { isLoaded, isSignedIn, user } = useCurrentUser();
-	const lastAuthKey = useRef<string | null>(null);
-
-	useEffect(() => {
-		if (!isLoaded) return;
-		if (!isSignedIn) clearAccountSuspension();
-
-		const authKey = isSignedIn ? (user?.id ?? "signed-in") : "signed-out";
-		if (lastAuthKey.current === null) {
-			lastAuthKey.current = authKey;
-			return;
-		}
-		if (lastAuthKey.current !== authKey) {
-			void resetQueryClientForAuthChange(queryClient).catch((error: unknown) => {
-				console.error("Failed to reset dashboard data after authentication changed", error);
-			});
-			clearAccountSuspension();
-			lastAuthKey.current = authKey;
-		}
-	}, [isLoaded, isSignedIn, queryClient, user?.id]);
-
-	return children;
 }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAuth, useClerk, useUser } from "@clerk/tanstack-react-start";
-import { useCallback, useSyncExternalStore } from "react";
 import { env } from "@/lib/env";
 import { resolveRouteAuth } from "@/lib/route-auth";
 
@@ -49,19 +48,9 @@ export function useRouteAuth() {
 	const auth = useDashboardAuth();
 	if (env.VITE_DEV_AUTH_BYPASS) return resolveRouteAuth(auth, "ready");
 	const clerk = useClerk();
-	const status = useSyncExternalStore(
-		useCallback(
-			(listener) => {
-				clerk.on("status", listener);
-				return () => clerk.off("status", listener);
-			},
-			[clerk],
-		),
-		() => clerk.status,
-		// Only SSR/hydration uses the server-authenticated Clerk snapshot.
-		() => "ready" as const,
-	);
-	return resolveRouteAuth(auth, status);
+	// ClerkProvider propagates status changes. useAuth owns the native SSR
+	// snapshot during SDK bootstrap; script loading is not identity loss.
+	return resolveRouteAuth(auth, clerk.status);
 }
 
 export function useCurrentUser() {

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import { useAuth, useClerk, useUser } from "@clerk/tanstack-react-start";
+import { useCallback, useSyncExternalStore } from "react";
 import { env } from "@/lib/env";
+import { resolveRouteAuth } from "@/lib/route-auth";
 
 const DEV_AUTH_BEARER = env.VITE_DEV_AUTH_TOKEN;
 
@@ -33,12 +35,33 @@ export function useAuthToken() {
 export function useDashboardAuth() {
 	if (env.VITE_DEV_AUTH_BYPASS) {
 		return {
+			isLoaded: true,
 			isSignedIn: true,
 			userId: DEV_USER.id,
+			sessionId: "dev_browser_session",
 			getToken: async () => DEV_AUTH_BEARER,
 		};
 	}
 	return useAuth();
+}
+
+export function useRouteAuth() {
+	const auth = useDashboardAuth();
+	if (env.VITE_DEV_AUTH_BYPASS) return resolveRouteAuth(auth, "ready");
+	const clerk = useClerk();
+	const status = useSyncExternalStore(
+		useCallback(
+			(listener) => {
+				clerk.on("status", listener);
+				return () => clerk.off("status", listener);
+			},
+			[clerk],
+		),
+		() => clerk.status,
+		// Only SSR/hydration uses the server-authenticated Clerk snapshot.
+		() => "ready" as const,
+	);
+	return resolveRouteAuth(auth, status);
 }
 
 export function useCurrentUser() {

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,45 +1,31 @@
-import { describe, expect, test } from "bun:test";
-import { QueryClient, QueryObserver } from "@tanstack/react-query";
-import { resetQueryClientForAuthChange } from "@/lib/query-client";
+import { expect, test } from "bun:test";
+import { createAppQueryClient } from "@/lib/query-client";
 
-describe("query cache authentication boundary", () => {
-	test("refetches active observers while removing prior-user cached state", async () => {
-		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false } },
-		});
-		let attempt = 0;
-		const observer = new QueryObserver(queryClient, {
-			queryKey: ["auth-change", "active"],
-			queryFn: () => {
-				attempt += 1;
-				if (attempt === 1) return new Promise<string>(() => undefined);
-				return Promise.resolve("fresh-user-data");
+test("retired session requests and callbacks cannot populate the replacement cache", async () => {
+	const oldClient = createAppQueryClient();
+	const newClient = createAppQueryClient();
+	const deferred = Promise.withResolvers<string>();
+	let signal: AbortSignal | undefined;
+	const request = oldClient
+		.fetchQuery({
+			queryKey: ["private"],
+			queryFn: (context) => {
+				signal = context.signal;
+				return deferred.promise;
 			},
-		});
-		const unsubscribe = observer.subscribe(() => undefined);
-		queryClient.setQueryData(["auth-change", "inactive"], "prior-user-data");
-		queryClient.getMutationCache().build(queryClient, {
-			mutationKey: ["auth-change", "mutation"],
-			mutationFn: async () => "prior-user-result",
-		});
-
-		try {
-			expect(observer.getCurrentResult().fetchStatus).toBe("fetching");
-			expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
-
-			await resetQueryClientForAuthChange(queryClient);
-
-			expect(queryClient.getQueryData(["auth-change", "inactive"])).toBeUndefined();
-			expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
-			expect(attempt).toBe(2);
-			expect(observer.getCurrentResult()).toMatchObject({
-				data: "fresh-user-data",
-				fetchStatus: "idle",
-				status: "success",
-			});
-		} finally {
-			unsubscribe();
-			queryClient.clear();
-		}
-	});
+		})
+		.catch(() => undefined);
+	oldClient.setQueryData(["cached-destination"], "old-user");
+	try {
+		oldClient.clear();
+		expect(signal?.aborted).toBe(true);
+		deferred.resolve("late-old-user");
+		await request;
+		oldClient.setQueryData(["mutation-callback"], "old-user");
+		expect(newClient.getQueryCache().getAll()).toHaveLength(0);
+		expect(oldClient.getQueryData(["private"])).toBeUndefined();
+	} finally {
+		oldClient.clear();
+		newClient.clear();
+	}
 });

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -29,10 +29,3 @@ export function createAppQueryClient(): QueryClient {
 		},
 	});
 }
-
-/** Clear prior-user state without detaching observers mounted during sign-in. */
-export async function resetQueryClientForAuthChange(queryClient: QueryClient): Promise<void> {
-	queryClient.getMutationCache().clear();
-	queryClient.removeQueries({ type: "inactive" });
-	await queryClient.resetQueries({ type: "active" });
-}

--- a/apps/web/src/lib/route-auth.test.ts
+++ b/apps/web/src/lib/route-auth.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { isRedirect } from "@tanstack/react-router";
+import {
+	RouteAuthUnavailable,
+	requireRouteIdentity,
+	resolveRouteAuth,
+	routeAuthIdentity,
+} from "./route-auth";
+
+const signedIn = { isLoaded: true, isSignedIn: true, userId: "user-a", sessionId: "session-a" };
+
+test("admission uses a loaded live session, including same-user session changes", () => {
+	const auth = resolveRouteAuth(signedIn, "ready");
+	expect(requireRouteIdentity(auth, "/agents")).toBe(JSON.stringify(["user-a", "session-a"]));
+	expect(
+		routeAuthIdentity(resolveRouteAuth({ ...signedIn, sessionId: "session-b" }, "ready")),
+	).not.toBe(routeAuthIdentity(auth));
+	expect(routeAuthIdentity(resolveRouteAuth({ ...signedIn, userId: "user-b" }, "ready"))).not.toBe(
+		routeAuthIdentity(auth),
+	);
+});
+
+test("SDK loading and unavailable states never admit, even with a signed-in SSR snapshot", () => {
+	for (const status of ["loading", "degraded", "error"] as const) {
+		expect(() => requireRouteIdentity(resolveRouteAuth(signedIn, status), "/agents")).toThrow(
+			RouteAuthUnavailable,
+		);
+	}
+	expect(() => requireRouteIdentity(undefined, "/agents")).toThrow(RouteAuthUnavailable);
+	expect(() =>
+		requireRouteIdentity(resolveRouteAuth({ ...signedIn, isLoaded: false }, "ready"), "/agents"),
+	).toThrow(RouteAuthUnavailable);
+});
+
+test("signed-out and Clerk's default pending-as-signed-out result redirect with the destination", () => {
+	const auth = resolveRouteAuth(
+		{ isLoaded: true, isSignedIn: false, userId: null, sessionId: null },
+		"ready",
+	);
+	try {
+		requireRouteIdentity(auth, "/agents?view=all");
+		throw new Error("Expected a redirect");
+	} catch (error) {
+		expect(isRedirect(error)).toBe(true);
+		if (isRedirect(error))
+			expect(error.options).toMatchObject({
+				to: "/sign-in",
+				search: { redirect_url: "/agents?view=all" },
+			});
+	}
+});

--- a/apps/web/src/lib/route-auth.test.ts
+++ b/apps/web/src/lib/route-auth.test.ts
@@ -20,16 +20,22 @@ test("admission uses a loaded live session, including same-user session changes"
 	);
 });
 
-test("SDK loading and unavailable states never admit, even with a signed-in SSR snapshot", () => {
-	for (const status of ["loading", "degraded", "error"] as const) {
+test("native authenticated SSR state admits during SDK bootstrap", () => {
+	expect(resolveRouteAuth(signedIn, "loading")).toEqual(resolveRouteAuth(signedIn, "ready"));
+});
+
+test("unknown auth and explicit SDK failures never admit, even with a signed-in SSR snapshot", () => {
+	for (const status of ["degraded", "error"] as const) {
 		expect(() => requireRouteIdentity(resolveRouteAuth(signedIn, status), "/agents")).toThrow(
 			RouteAuthUnavailable,
 		);
 	}
 	expect(() => requireRouteIdentity(undefined, "/agents")).toThrow(RouteAuthUnavailable);
-	expect(() =>
-		requireRouteIdentity(resolveRouteAuth({ ...signedIn, isLoaded: false }, "ready"), "/agents"),
-	).toThrow(RouteAuthUnavailable);
+	for (const status of ["loading", "ready"] as const) {
+		expect(() =>
+			requireRouteIdentity(resolveRouteAuth({ ...signedIn, isLoaded: false }, status), "/agents"),
+		).toThrow(RouteAuthUnavailable);
+	}
 });
 
 test("signed-out and Clerk's default pending-as-signed-out result redirect with the destination", () => {

--- a/apps/web/src/lib/route-auth.ts
+++ b/apps/web/src/lib/route-auth.ts
@@ -1,0 +1,41 @@
+import type { useAuth, useClerk } from "@clerk/tanstack-react-start";
+import { redirect } from "@tanstack/react-router";
+
+export type RouteAuth =
+	| { status: "loading" | "unavailable" | "signed-out" }
+	| { status: "signed-in"; userId: string; sessionId: string };
+
+export interface AppRouterContext {
+	auth: RouteAuth | undefined;
+}
+
+export function routeAuthIdentity(auth: RouteAuth | undefined): string | null {
+	return auth?.status === "signed-in" ? JSON.stringify([auth.userId, auth.sessionId]) : null;
+}
+
+export function resolveRouteAuth(
+	auth: Pick<ReturnType<typeof useAuth>, "isLoaded" | "isSignedIn" | "userId" | "sessionId">,
+	status: ReturnType<typeof useClerk>["status"],
+): RouteAuth {
+	if (status === "degraded" || status === "error") return { status: "unavailable" };
+	if (status === "loading" || !auth.isLoaded) return { status: "loading" };
+	if (!auth.isSignedIn || !auth.userId || !auth.sessionId) return { status: "signed-out" };
+	return { status: "signed-in", userId: auth.userId, sessionId: auth.sessionId };
+}
+
+export class RouteAuthUnavailable extends Error {
+	constructor(readonly status: "loading" | "unavailable") {
+		super("Authentication is not ready");
+	}
+}
+
+export function requireRouteIdentity(auth: RouteAuth | undefined, href: string): string {
+	if (!auth || auth.status === "loading" || auth.status === "unavailable") {
+		throw new RouteAuthUnavailable(auth?.status === "unavailable" ? "unavailable" : "loading");
+	}
+	const identity = routeAuthIdentity(auth);
+	if (identity === null) {
+		throw redirect({ to: "/sign-in", search: { redirect_url: href } });
+	}
+	return identity;
+}

--- a/apps/web/src/lib/route-auth.ts
+++ b/apps/web/src/lib/route-auth.ts
@@ -18,7 +18,7 @@ export function resolveRouteAuth(
 	status: ReturnType<typeof useClerk>["status"],
 ): RouteAuth {
 	if (status === "degraded" || status === "error") return { status: "unavailable" };
-	if (status === "loading" || !auth.isLoaded) return { status: "loading" };
+	if (!auth.isLoaded) return { status: "loading" };
 	if (!auth.isSignedIn || !auth.userId || !auth.sessionId) return { status: "signed-out" };
 	return { status: "signed-in", userId: auth.userId, sessionId: auth.sessionId };
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -5,6 +5,7 @@ import { routeTree } from "./routeTree.gen";
 export function getRouter() {
 	const router = createRouter({
 		routeTree,
+		context: { auth: undefined },
 		defaultPreload: "intent",
 		scrollRestoration: true,
 		scrollToTopSelectors: ["#dashboard-scroll-container"],

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,18 +1,19 @@
 /// <reference types="vite/client" />
 
-import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { AppNotFound } from "@/components/app-not-found";
 import { AuthProvider } from "@/components/auth-provider";
 import { Providers } from "@/components/providers";
 import RootError from "@/components/root-error";
 import { APP_TITLE } from "@/lib/document-title";
+import type { AppRouterContext } from "@/lib/route-auth";
 import "@/styles/globals.css";
 
 const DESCRIPTION =
 	"Cloud control plane for AI agents - manage sessions, skills, memories, and secrets across the machines you connect.";
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<AppRouterContext>()({
 	head: () => ({
 		meta: [
 			{ charSet: "utf-8" },

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,34 +1,45 @@
 import { auth } from "@clerk/tanstack-react-start/server";
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createIsomorphicFn, createServerFn } from "@tanstack/react-start";
 import { setResponseHeader } from "@tanstack/react-start/server";
 import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
+import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
 import { env } from "@/lib/env";
+import { type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
 
 const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
 	setResponseHeader("cache-control", "no-store");
-	if (env.VITE_DEV_AUTH_BYPASS) return { userId: "dev_browser" };
-	const { userId } = await auth();
-	return { userId };
+	if (env.VITE_DEV_AUTH_BYPASS) {
+		return { userId: "dev_browser", sessionId: "dev_browser_session" };
+	}
+	const { userId, sessionId } = await auth();
+	return { userId, sessionId };
 });
 
+const admitRoute = createIsomorphicFn()
+	.server(async ({ href }: { auth: RouteAuth | undefined; href: string }) => {
+		const { userId, sessionId } = await getAuthState();
+		const serverAuth: RouteAuth =
+			userId && sessionId ? { status: "signed-in", userId, sessionId } : { status: "signed-out" };
+		return { authIdentity: requireRouteIdentity(serverAuth, href) };
+	})
+	.client(({ auth, href }: { auth: RouteAuth | undefined; href: string }) => ({
+		authIdentity: requireRouteIdentity(auth, href),
+	}));
+
 export const Route = createFileRoute("/_protected")({
-	beforeLoad: async ({ location }) => {
-		const { userId } = await getAuthState();
-		if (!userId) {
-			throw redirect({
-				to: "/sign-in",
-				search: { redirect_url: location.href },
-			});
-		}
-	},
+	beforeLoad: ({ context, location }) => admitRoute({ auth: context.auth, href: location.href }),
+	errorComponent: ProtectedRouteError,
 	component: ProtectedLayout,
 });
 
 function ProtectedLayout() {
+	const { authIdentity } = Route.useRouteContext();
 	return (
-		<AccountSuspensionBoundary>
-			<Outlet />
-		</AccountSuspensionBoundary>
+		<ProtectedAuthBoundary identity={authIdentity}>
+			<AccountSuspensionBoundary>
+				<Outlet />
+			</AccountSuspensionBoundary>
+		</ProtectedAuthBoundary>
 	);
 }

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -59,6 +59,34 @@ bun run --cwd apps/web test
 validated env module. If you bypass that Bun config, seed
 `VITE_CLERK_PUBLISHABLE_KEY` yourself.
 
+## Route admission
+
+Initial SSR still uses Clerk request middleware and server `auth()` with
+`cache-control: no-store`. SPA navigation uses live Clerk `useAuth()` and SDK
+status through typed native Router context; it does not reverify the session
+on the Start server for each navigation. API, Files grants, runtime and stream
+authorization remain independent server boundaries.
+
+`AuthRouterBridge` replaces the QueryClient on user/session identity changes,
+retires protected route preloads, and invalidates protected matches.
+`ProtectedAuthBoundary` prevents a cached match from rendering under another
+live identity. Same-identity navigation keeps its cache and mounted state.
+Loading/pending/unavailable SDK states do not admit protected UI. SDK readiness
+is not proof of immediate remote revocation or current JWT validity; denied
+API requests remain errors. Account-admission failures block protected content;
+401 offers explicit reauthentication, while other failures remain recoverable
+without signing the user out.
+
+Inside an isolated Docker browser-test environment with dependencies and
+Chromium installed, run the SDK-event contract suite:
+
+```bash
+bun run --cwd apps/web e2e --config=playwright.auth.config.ts
+```
+
+Done: the lifecycle suite passes without Clerk credentials. Its event mocks
+test the integration contract, not a live Clerk tenant.
+
 ## OSS build boundary
 
 `bun run --cwd apps/web build:oss` is defined as:

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -71,9 +71,13 @@ authorization remain independent server boundaries.
 retires protected route preloads, and invalidates protected matches.
 `ProtectedAuthBoundary` prevents a cached match from rendering under another
 live identity. Same-identity navigation keeps its cache and mounted state.
-Loading/pending/unavailable SDK states do not admit protected UI. SDK readiness
-is not proof of immediate remote revocation or current JWT validity; denied
-API requests remain errors. Account-admission failures block protected content;
+Clerk's native authenticated SSR snapshot remains admitted while its browser
+SDK initializes; script loading alone does not replace the cache or unmount
+content. Unknown auth, pending/signed-out sessions and explicit SDK
+degraded/error states do not admit protected UI. No application auth snapshot
+is retained: Clerk owns the handover from SSR to emitted client resources.
+Native auth is not proof of immediate remote revocation or current JWT validity;
+denied API requests remain errors. Account-admission failures block protected content;
 401 offers explicit reauthentication, while other failures remain recoverable
 without signing the user out.
 


### PR DESCRIPTION
## Behavior
Client-side protected navigation uses native Clerk useAuth through typed TanStack Router context instead of a Start auth RPC on every navigation. Initial SSR retains Clerk middleware and no-store server admission; all API, Files, runtime and stream authorization remains server-side.

Native Clerk SSR state bridges SDK bootstrap without clearing caches or remounting the SSR iframe. The redundant SDK-status subscription and loading veto were removed. Confirmed signed-out/pending/unknown auth, identity changes and explicit SDK degraded/error states isolate the protected subtree. QueryClient ownership is scoped to user/session; no application auth cache, timer or grace period is introduced.

## Verification
- Root reviewed actual authentication/context/cache and hydration diffs against documented native behavior.
- Docker final: workspace typecheck, 1174 web unit tests, Biome, OSS/hosted builds, 17 CI auth contracts and 6 additional installed-Clerk hydration cases passed.
- Original SSR iframe, draft and QueryClient retained during bootstrap; confirmed sign-out/pending/user/session changes retire old content and cache.
- Production middleware with bypass off and ephemeral RSA fixtures: unsigned/expired redirects, signed-in SSR and no-store/native initial-state transport passed. Auth contracts run in Client CI.
- Controlled optimized-build warm navigation: median 75.6ms, zero auth RPC/new application scripts (3 samples, artificial300ms API/400ms script delay). Prior paired baseline was388.1ms with1 auth RPC; not a production latency guarantee.

## Limits
No real Clerk tenant lifecycle or immediate remote revocation was tested. Native SSR state can remain available until the SDK emits or reports failure; client route UX is not fresh server verification. Private endpoints remain independent authorization boundaries.

No production/tenant/billing operations performed. PR not merged or deployed.