### PR TITLE
fix(deploy): use raw inspection output and fail on command errors

### DIFF
--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -16,17 +16,23 @@ readonly backend_image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION:
 	exit 1
 }
 
-remote_value() {
+inspection_value() {
 	local output value
-	output="$(kamal server exec "$1")"
-	value="$(printf '%s\n' "${output}" | sed -n 's/^.*CLAWDI_VALUE=//p' | tail -n 1)"
-	[[ -n "${value}" ]] || { echo "Remote inspection returned no value" >&2; exit 1; }
+	if ! output="$("$@")"; then
+		echo "Remote inspection command failed" >&2
+		return 1
+	fi
+	value="${output#CLAWDI_VALUE=}"
+	if [[ "${output}" != CLAWDI_VALUE=* || -z "${value}" || "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+		echo "Remote inspection must return exactly one value" >&2
+		return 1
+	fi
 	printf '%s\n' "${value}"
 }
 
 role_state() {
 	local role="$1"
-	remote_value "
+	inspection_value kamal server exec --raw "
 		set -eu
 		set -- \$(docker ps -q --no-trunc --filter 'label=service=${service}' --filter 'label=role=${role}')
 		if [ \"\$#\" -eq 0 ]; then printf 'CLAWDI_VALUE=missing\\n'; exit 0; fi
@@ -80,10 +86,9 @@ validate_embedding_state() {
 }
 
 require_database_headroom() {
-	local available output
-	output="$(kamal accessory exec postgres --reuse \
-		"psql -U clawdi -d clawdi -Atqc \"SELECT 'CLAWDI_VALUE=' || (current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int - current_setting('reserved_connections')::int - count(*) FILTER (WHERE backend_type = 'client backend')) FROM pg_stat_activity\"")"
-	available="$(printf '%s\n' "${output}" | sed -n 's/^.*CLAWDI_VALUE=//p' | tail -n 1)"
+	local available
+	available="$(inspection_value kamal accessory exec postgres --reuse --raw \
+		"psql -U clawdi -d clawdi -Atqc \"SELECT 'CLAWDI_VALUE=' || (current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int - current_setting('reserved_connections')::int - count(*) FILTER (WHERE backend_type = 'client backend')) FROM pg_stat_activity\"")" || return 1
 	[[ "${available}" =~ ^[0-9]+$ ]] || { echo "Invalid PostgreSQL capacity result" >&2; exit 1; }
 	(( available >= minimum_available_connections )) || {
 		echo "PostgreSQL has ${available} available connections; ${minimum_available_connections} required" >&2

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -10,6 +10,22 @@ cat > "${tmp}/bin/kamal" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "$*" >> "${FAKE_LOG}"
+if [[ "$*" == 'server exec '* || "$*" == 'accessory exec postgres '* ]]; then
+	[[ " $* " == *' --raw '* ]] || { echo 'Expected raw inspection' >&2; exit 1; }
+fi
+
+emit_value() {
+	local target="$1" value="$2"
+	if [[ "${INSPECTION_TARGET:-}" == "${target}" ]]; then
+		case "${INSPECTION_FAILURE:-}" in
+			failed) printf 'CLAWDI_VALUE=%s\n' "${value}"; return 1 ;;
+			duplicate) printf 'CLAWDI_VALUE=%s\nCLAWDI_VALUE=%s\n' "${value}" "${value}"; return ;;
+			log-only) printf 'INFO running command CLAWDI_VALUE=%s\n' "${value}"; return ;;
+		esac
+	fi
+	printf 'CLAWDI_VALUE=%s\n' "${value}"
+}
+
 case "$*" in
 	"deploy -P --roles web "*) touch "${FAKE_LOG}.web.deployed"; exit 0 ;;
 	"deploy -P --roles channels-worker "*) touch "${FAKE_LOG}.channels-worker.deployed"; exit 0 ;;
@@ -23,7 +39,7 @@ case "$*" in
 		exit
 		;;
 	"app exec "*|"app stop "*) exit 0 ;;
-	"accessory exec postgres "*) echo "CLAWDI_VALUE=${AVAILABLE_CONNECTIONS:-80}"; exit 0 ;;
+	"accessory exec postgres "*) emit_value database "${AVAILABLE_CONNECTIONS:-80}"; exit ;;
 	*"docker ps -q"*"role=web"*) role=web ;;
 	*"docker ps -q"*"role=channels-worker"*) role=channels-worker ;;
 	*"docker ps -q"*"role=embedding-worker"*) role=embedding-worker ;;
@@ -55,7 +71,7 @@ if [[ -f "${FAKE_LOG}.${role}.deployed" ]]; then
 		embedding-worker) pool=:: ;;
 	esac
 fi
-echo "CLAWDI_VALUE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|${image}|${pool}|${workers}"
+emit_value "${role}" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|${image}|${pool}|${workers}"
 FAKE
 chmod +x "${tmp}/bin/kamal"
 
@@ -66,6 +82,7 @@ run() {
 	local scenario="$1" web_pool="$2" channels_pool="$3" available="${4:-80}"
 	local embedding_state="${5:-missing}" fail_embedding_health="${6:-0}"
 	local fail_web_ready="${7:-0}" web_workers="${8:-}"
+	local inspection_target="${9:-}" inspection_failure="${10:-}"
 	local log="${tmp}/${scenario}.log"
 	if ! FAKE_LOG="${log}" PATH="${tmp}/bin:${PATH}" \
 		DEPLOY_IMAGE_VERSION="${target_image}" CURRENT_IMAGE="${current_image}" \
@@ -73,6 +90,7 @@ run() {
 		AVAILABLE_CONNECTIONS="${available}" EMBEDDING_STATE="${embedding_state}" \
 		FAIL_EMBEDDING_HEALTH="${fail_embedding_health}" FAIL_WEB_READY="${fail_web_ready}" \
 		WEB_WORKERS="${web_workers}" \
+		INSPECTION_TARGET="${inspection_target}" INSPECTION_FAILURE="${inspection_failure}" \
 		"${root}/scripts/deploy-backend.sh" >/dev/null; then
 		return 1
 	fi
@@ -111,6 +129,16 @@ if run invalid 12:12:5 10:10:5 >/dev/null 2>&1; then
 	echo "Expected an unknown pool configuration to fail" >&2
 	exit 1
 fi
+
+for inspection_case in 'web failed' 'web duplicate' 'database failed' 'database log-only'; do
+	read -r inspection_target inspection_failure <<<"${inspection_case}"
+	scenario="inspection-${inspection_target}-${inspection_failure}"
+	if run "${scenario}" 8:0:5 10:10:5 80 present 0 0 2 "${inspection_target}" "${inspection_failure}" >/dev/null 2>&1; then
+		echo "Expected ${scenario} to fail before deployment" >&2
+		exit 1
+	fi
+	! grep -Eq '^deploy |^app exec ' "${tmp}/${scenario}.log"
+done
 
 if run saturated 10:10:5 10:10:5 21 >/dev/null 2>&1; then
 	echo "Expected insufficient PostgreSQL headroom to fail" >&2


### PR DESCRIPTION
## Problem and behavior
Deployment preflight scraped human-readable Kamal output using a greedy marker match and tail -n 1. Inside Bash command substitution, a failed inspection could still return a plausible value because errexit is not inherited reliably. Multiple output records were silently reduced to the last one.

Use the official Kamal 2.12 --raw option for server and reused accessory inspection, share one exact-record decoder, and explicitly propagate command failure. Reject missing, multiline and log-prefixed values before migration or deployment. Pool, role and headroom checks remain mandatory; no retry or bypass is added.

## Validation
- Existing deployment contract suite passes in an isolated Bash 5.2 container.
- Added cases verify failed server/accessory commands, duplicate records and log-only values stop before app exec or deployment.
- Bash syntax and git diff checks pass.
- A bounded isolated reproducer confirms the former helper accepts an exit-1 command as value=80 with exit=0.
- Verified --raw contract against the official Kamal v2.12.0 server/accessory CLI source. No global tooling or production configuration changed.

This is a reproducible inspection defect, not a proven reconstruction of the earlier intermittent Invalid embedding-worker container state incident. Local lefthook unavailable; checks executed independently.