### PR TITLE
fix(composio): prevent stale session publication after invalidation

### DIFF
--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -248,6 +248,7 @@ class ConnectorAppPage(TypedDict):
 _client: AsyncComposio | None = None
 _sdk_client: Composio[OpenAITool, OpenAIToolCollection] | None = None
 _tool_router_session_cache: dict[str, ComposioMcpSession] = {}
+_tool_router_session_creations: dict[str, set[object]] = {}
 _tool_router_tools_cache: dict[str, tuple[ComposioMcpSession, ListToolsResult]] = {}
 _tool_router_tools_inflight: dict[str, asyncio.Task[ListToolsResult]] = {}
 
@@ -521,6 +522,7 @@ def get_composio_sdk() -> Composio[OpenAITool, OpenAIToolCollection]:
 async def close_composio_client() -> None:
     """Close the shared Composio HTTP clients on ASGI shutdown."""
     global _client, _sdk_client
+    _tool_router_session_creations.clear()
     pending_tools = tuple(_tool_router_tools_inflight.values())
     _tool_router_tools_inflight.clear()
     for task in pending_tools:
@@ -584,16 +586,34 @@ async def get_tool_router_mcp_session(user_id: str) -> ComposioMcpSession:
     cached = _tool_router_session_cache.get(user_id)
     if cached and cached.expires_at > now:
         return cached
-    if cached is not None:
-        await cached.retire()
 
-    session = await _create_tool_router_mcp_session(user_id, now=now)
-    _tool_router_session_cache[user_id] = session
-    return session
+    # Invalidation detaches this group; its in-flight requests cannot republish.
+    pending = _tool_router_session_creations.setdefault(user_id, set())
+    creation = object()
+    pending.add(creation)
+    try:
+        if cached is not None:
+            await cached.retire()
+        session = await _create_tool_router_mcp_session(user_id, now=now)
+        if _tool_router_session_creations.get(user_id) is not pending:
+            await session.retire()
+            raise ComposioMcpUpstreamError("Composio session invalidated during creation")
+        current = _tool_router_session_cache.get(user_id)
+        if current is not None and current.expires_at > datetime.now(UTC):
+            if current is not session:
+                await session.retire()
+            return current
+        _tool_router_session_cache[user_id] = session
+        return session
+    finally:
+        pending.discard(creation)
+        if not pending and _tool_router_session_creations.get(user_id) is pending:
+            _tool_router_session_creations.pop(user_id)
 
 
 async def invalidate_tool_router_mcp_session(user_id: str) -> None:
     """Drop a user's cached Tool Router session and schemas after connection changes."""
+    _tool_router_session_creations.pop(user_id, None)
     session = _tool_router_session_cache.pop(user_id, None)
     _tool_router_tools_cache.pop(user_id, None)
     if session is not None:

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -73,6 +73,7 @@ def tool_router_cache(monkeypatch):
         return sessions[user_id].pop(0)
 
     monkeypatch.setattr(composio, "_tool_router_session_cache", {})
+    monkeypatch.setattr(composio, "_tool_router_session_creations", {})
     monkeypatch.setattr(composio, "_tool_router_tools_cache", {})
     monkeypatch.setattr(composio, "_tool_router_tools_inflight", {})
     monkeypatch.setattr(composio, "_create_tool_router_mcp_session", fake_create)
@@ -881,6 +882,94 @@ async def test_composio_mcp_client_runs_lifecycle_and_parses_json_and_sse(monkey
     }
     await session.retire()
     assert clients[0].is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalidation", ["none", "account-change", "shutdown"])
+async def test_session_creation_cannot_replace_a_newer_session(
+    monkeypatch, tool_router_cache, invalidation
+):
+    composio, _sessions = tool_router_cache
+    stale = _mcp_session("publication", 1)
+    fresh = _mcp_session("publication", 2)
+    candidates = [stale, fresh]
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def create(_user_id, *, now):
+        candidate = candidates.pop(0)
+        if candidate is stale:
+            started.set()
+            await release.wait()
+        return candidate
+
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", create)
+    monkeypatch.setattr(composio, "_client", None)
+    monkeypatch.setattr(composio, "_sdk_client", None)
+    request = asyncio.create_task(composio.get_tool_router_mcp_session("publication"))
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            if invalidation == "account-change":
+                await composio.invalidate_tool_router_mcp_session("publication")
+            elif invalidation == "shutdown":
+                await composio.close_composio_client()
+            assert await composio.get_tool_router_mcp_session("publication") is fresh
+            release.set()
+            if invalidation != "none":
+                with pytest.raises(composio.ComposioMcpUpstreamError):
+                    await request
+            else:
+                assert await request is fresh
+        assert composio._tool_router_session_cache["publication"] is fresh
+        assert stale._retired
+        assert not fresh._retired
+        assert await composio.get_tool_router_mcp_session("publication") is fresh
+        assert not composio._tool_router_session_creations
+    finally:
+        release.set()
+        if not request.done():
+            request.cancel()
+        await asyncio.gather(request, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_session_creation_does_not_invalidate_another_creator(
+    monkeypatch, tool_router_cache
+):
+    composio, _sessions = tool_router_cache
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def create(_user_id, *, now):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            started.set()
+        await release.wait()
+        return _mcp_session("survivor")
+
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", create)
+    first = asyncio.create_task(composio.get_tool_router_mcp_session("survivor"))
+    second = asyncio.create_task(composio.get_tool_router_mcp_session("survivor"))
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+            release.set()
+            surviving = await second
+        assert composio._tool_router_session_cache["survivor"] is surviving
+        assert not surviving._retired
+        assert not composio._tool_router_session_creations
+    finally:
+        release.set()
+        for task in (first, second):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(first, second, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem and fix
A Composio session creation that started before account-cache invalidation could finish later and repopulate stale state. Independently, a late concurrent creator could overwrite an already-published fresh session.

Track only active creation groups per user. Invalidation and shutdown detach the group so old candidates cannot publish. Late candidates retire their local session and reuse an already-published valid winner. Finally blocks remove tracking after completion, failure or cancellation; no permanent epoch table, new background task, global lock or retry framework.

An invalidated creation returns the existing sanitized ComposioMcpUpstreamError; the next request obtains a fresh session. Tool calls are not automatically replayed. Cross-worker invalidation behavior is unchanged.

## Verification
- Before implementation, both deterministic publication/invalidation cases failed against the existing code.
- Isolated Docker/PostgreSQL: 78 MCP, connector, cleanup and capability regression tests passed. Added shutdown coverage and reran all 30 MCP tests successfully.
- Coverage includes late completion, account invalidation, shutdown, candidate retirement and cancelling one creator without invalidating another. Existing tools single-flight/invalidation/cancellation tests remain passing.
- Ruff lint/format, basedpyright and diff checks passed. Local lefthook unavailable; gates ran independently.
- Temporary test script, containers and network removed. No production operations.

## Limits
This fixes process-local publication correctness. It does not promise fewer upstream session-creation requests during simultaneous cold misses, revoke provider-side sessions, or solve all distributed cache consistency concerns.