### PR TITLE
fix: compact Compute configuration and separate actions

### DIFF
--- a/apps/web/e2e/agent-overview-geometry.ts
+++ b/apps/web/e2e/agent-overview-geometry.ts
@@ -18,7 +18,9 @@ export async function expectAgentOverviewGeometry(
 			"[data-overview-subscription-status]",
 		);
 		const subscriptionDetails = subscriptionRow?.querySelector("dd > span");
-		const subscriptionAction = subscriptionRow?.querySelector("[data-slot=button]");
+		const subscriptionAction = main.querySelector(
+			'[data-testid="overview-compute-summary"] [data-slot=button]',
+		);
 		const subscriptionDate = subscriptionRow?.nextElementSibling;
 		const entries = Array.from(
 			main.querySelectorAll('[data-overview-section="tools"] [data-slot="card"]'),
@@ -54,8 +56,13 @@ export async function expectAgentOverviewGeometry(
 		paint(getComputedStyle(resourceCard).backgroundColor);
 		const resourceBackground = pixel();
 		return {
+			computeSpecs: Array.from(main.querySelectorAll('[aria-label="Compute resources"] > div')).map(
+				(spec) => spec.getBoundingClientRect().toJSON(),
+			),
 			computeRows: Array.from(
-				main.querySelectorAll('[data-testid="overview-compute-summary"] dl > div'),
+				main.querySelectorAll(
+					'[data-testid="overview-compute-summary"] dl:not([aria-label]) > div',
+				),
 			).map((row) => {
 				const label = row.querySelector("dt:not(.sr-only)");
 				const value = row.querySelector("dd > span");
@@ -115,11 +122,16 @@ export async function expectAgentOverviewGeometry(
 		};
 	});
 	const aligned = (a: number, b: number) => expect(Math.abs(a - b)).toBeLessThanOrEqual(1);
+	for (const spec of geometry.computeSpecs) {
+		aligned(spec.height, 16);
+		if ((page.viewportSize()?.width ?? 0) >= 390) aligned(spec.top, geometry.computeSpecs[0].top);
+	}
 	for (const { row, label, value, hasAction, overflows } of geometry.computeRows) {
 		expect(overflows).toBe(false);
+		expect(hasAction).toBe(false);
 		if (label) {
 			expect(value.left - label.right).toBeGreaterThanOrEqual(16);
-			if (!hasAction) aligned(value.right, row.right);
+			aligned(value.right, row.right);
 		}
 	}
 	for (const heading of geometry.headings) {
@@ -179,18 +191,13 @@ export async function expectAgentOverviewGeometry(
 			expect(color.contrast).toBeGreaterThanOrEqual(4.5);
 		}
 		if (geometry.subscription) {
-			const { row, status, details, action, date } = geometry.subscription;
+			const { row, details, action, date } = geometry.subscription;
 			if (action) {
 				expect(action.left).toBeGreaterThanOrEqual(row.left - 1);
-				expect(action.right).toBeLessThanOrEqual(row.right + 1);
-				if (details && action.top >= details.bottom) {
-					expect(action.top - details.bottom).toBeGreaterThanOrEqual(8);
-				} else {
-					aligned(status.y + status.height / 2, action.y + action.height / 2);
-					aligned(action.right, row.right);
-					expect(action.left - status.right).toBeGreaterThanOrEqual(12);
-				}
-			} else if (details) aligned(row.height, details.height);
+				aligned(action.right, row.right);
+				expect(action.top - (date ?? row).bottom).toBeGreaterThanOrEqual(8);
+			}
+			if (details) aligned(row.height, details.height);
 			if (date) expect(date.top).toBeGreaterThan(row.bottom);
 		}
 		const tools = geometry.tools;

--- a/apps/web/e2e/agent-overview-geometry.ts
+++ b/apps/web/e2e/agent-overview-geometry.ts
@@ -54,6 +54,21 @@ export async function expectAgentOverviewGeometry(
 		paint(getComputedStyle(resourceCard).backgroundColor);
 		const resourceBackground = pixel();
 		return {
+			computeRows: Array.from(
+				main.querySelectorAll('[data-testid="overview-compute-summary"] dl > div'),
+			).map((row) => {
+				const label = row.querySelector("dt:not(.sr-only)");
+				const value = row.querySelector("dd > span");
+				const details = row.querySelector("dd");
+				if (!value || !details) throw new Error("Missing Compute value");
+				return {
+					row: row.getBoundingClientRect().toJSON(),
+					label: label?.getBoundingClientRect().toJSON() ?? null,
+					value: value.getBoundingClientRect().toJSON(),
+					hasAction: Boolean(row.querySelector("[data-slot=button]")),
+					overflows: details.scrollWidth > details.clientWidth + 1,
+				};
+			}),
 			headings: Array.from(main.querySelectorAll("[data-overview-heading]")).map((row) => ({
 				row: row.getBoundingClientRect().toJSON(),
 				title: row.querySelector("h2")?.getBoundingClientRect().toJSON(),
@@ -100,6 +115,13 @@ export async function expectAgentOverviewGeometry(
 		};
 	});
 	const aligned = (a: number, b: number) => expect(Math.abs(a - b)).toBeLessThanOrEqual(1);
+	for (const { row, label, value, hasAction, overflows } of geometry.computeRows) {
+		expect(overflows).toBe(false);
+		if (label) {
+			expect(value.left - label.right).toBeGreaterThanOrEqual(16);
+			if (!hasAction) aligned(value.right, row.right);
+		}
+	}
 	for (const heading of geometry.headings) {
 		if (!heading.title || !heading.content) throw new Error("Missing overview heading or content");
 		aligned(heading.row.height, 32);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1145,6 +1145,13 @@ test("overview loading geometry retains card structure and section rhythm", asyn
 		try {
 			await page.goto(`/agents/${railHostedEnvironmentId}`);
 			await expect(page.getByTestId("overview-status-card-skeleton")).toBeVisible();
+			const compute = page.locator('[data-overview-status="compute"]');
+			// Compare geometry after the shared theme stylesheet has applied.
+			await expect(compute).toHaveCSS("border-radius", "14px");
+			await compute.evaluate((element) => element.scrollIntoView({ block: "center" }));
+			await compute.screenshot({
+				path: testInfo.outputPath(`paid-${viewport.width}-cold-compute.png`),
+			});
 			await page.locator("#dashboard-scroll-container").evaluate((element) => {
 				element.scrollTop = 0;
 			});
@@ -1199,14 +1206,24 @@ test("overview loading geometry retains card structure and section rhythm", asyn
 				hosted: true,
 				desktop: viewport.width === 1440,
 			});
+			expect(geometry.computeRows.map(({ row }) => row)).toEqual(
+				loadingGeometry.computeRows.map(({ row }) => row),
+			);
 			await testInfo.attach(`paid-${viewport.width}-loading-geometry`, {
 				body: JSON.stringify({ loading, ready, geometry }, null, 2),
 				contentType: "application/json",
 			});
-			await captureAgentOverview(page, testInfo, `paid-performance-${viewport.width}-dark`);
-			await page.locator('[data-overview-status="compute"]').screenshot({
-				path: testInfo.outputPath(`paid-performance-${viewport.width}-compute.png`),
-			});
+			for (const theme of ["dark", "light"]) {
+				await page.locator("html").evaluate((element, dark) => {
+					element.classList.toggle("dark", dark);
+				}, theme === "dark");
+				const name = `paid-performance-${viewport.width}-${theme}`;
+				await captureAgentOverview(page, testInfo, name);
+				await compute.evaluate((element) => element.scrollIntoView({ block: "center" }));
+				await compute.screenshot({
+					path: testInfo.outputPath(`${name}-compute.png`),
+				});
+			}
 			for (const count of [0, 1]) {
 				Object.assign(sessionsPage, hostedOverviewSessionsPage(count));
 				await page.reload();
@@ -4312,8 +4329,8 @@ test("overview billing facts and shortcuts follow subscription authority", async
 				? null
 				: { ...runtimeStatus, summary_state: scenario.name === "stopped" ? "stopped" : "running" };
 		deployment.upgrade_available = scenario.name === "included" || scenario.name === "stopped";
-		for (const width of scenario.name === "payment-retry"
-			? [1440, 320]
+		for (const width of scenario.name === "payment-retry" || scenario.name === "included"
+			? [1440, 390, 320]
 			: scenario.name === "paid"
 				? [1440, 390]
 				: [1440]) {
@@ -4349,6 +4366,17 @@ test("overview billing facts and shortcuts follow subscription authority", async
 			await expect(compute.locator("a a, a button, button a, [data-slot=badge]")).toHaveCount(0);
 			await expectAgentOverviewGeometry(page, { hosted: true, desktop: width === 1440 });
 			await captureAgentOverview(page, testInfo, `hermes-final-clean-${scenario.name}-${width}`);
+			if (scenario.name === "included" || scenario.name === "payment-retry") {
+				for (const theme of ["dark", "light"]) {
+					await page.locator("html").evaluate((element, dark) => {
+						element.classList.toggle("dark", dark);
+					}, theme === "dark");
+					await compute.evaluate((element) => element.scrollIntoView({ block: "center" }));
+					await compute.screenshot({
+						path: testInfo.outputPath(`${scenario.name}-${width}-${theme}-compute.png`),
+					});
+				}
+			}
 			if (scenario.name === "paid" && width === 1440) {
 				await page.locator("html").evaluate((element) => element.classList.add("dark"));
 				await expectAgentOverviewGeometry(page, { hosted: true, desktop: true });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3803,12 +3803,10 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	);
 	expect(aiProviderRequests).toEqual([]);
 	await expect.poll(() => managedModelRequests.length).toBe(1);
-	for (const configuration of ["2 vCPU", "4 GiB", "20 GiB"])
+	for (const configuration of ["2 vCPU", "4 GiB RAM", "20 GiB storage"])
 		await expect(compute.getByText(configuration, { exact: true })).toBeVisible();
 	await expect(compute.getByText("Plan", { exact: true })).toHaveCount(0);
-	await expect(compute.getByText("CPU", { exact: true })).toBeVisible();
-	await expect(compute.getByText("Memory", { exact: true })).toBeVisible();
-	await expect(compute.getByText("Storage", { exact: true })).toBeVisible();
+	await expect(compute.getByLabel("Compute resources").locator("dt:not(.sr-only)")).toHaveCount(0);
 	await expect(overview.locator('[data-overview-module="skills"]')).toContainText(
 		"No skills installed",
 	);
@@ -3852,6 +3850,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	await expect(vaultsLink).toHaveAttribute("data-active", "");
 	await expect(skillsLink).not.toHaveAttribute("data-active", "");
 	await page.goto(`/agents/${railHostedEnvironmentId}`);
+	await expect(page.locator('main [data-slot="skeleton"]')).toHaveCount(0);
 	await expect(overview.locator("[data-overview-module]")).toHaveCount(9);
 	await expect(overview.getByText("Scope", { exact: true })).toHaveCount(0);
 	await expect(overview.getByText("Access", { exact: true })).toHaveCount(0);
@@ -4355,6 +4354,7 @@ test("overview billing facts and shortcuts follow subscription authority", async
 			if (scenario.date) for (const text of scenario.date) await expect(date).toContainText(text);
 			const actions = body.getByRole("button");
 			await expect(actions).toHaveCount(scenario.action ? 1 : 0);
+			await expect(body.locator("dl [data-slot=button]")).toHaveCount(0);
 			if (scenario.action) {
 				await expect(actions).toHaveText(scenario.action);
 				await expect(
@@ -4366,12 +4366,14 @@ test("overview billing facts and shortcuts follow subscription authority", async
 			await expect(compute.locator("a a, a button, button a, [data-slot=badge]")).toHaveCount(0);
 			await expectAgentOverviewGeometry(page, { hosted: true, desktop: width === 1440 });
 			await captureAgentOverview(page, testInfo, `hermes-final-clean-${scenario.name}-${width}`);
-			if (scenario.name === "included" || scenario.name === "payment-retry") {
+			if (["included", "payment-retry", "paid"].includes(scenario.name)) {
 				for (const theme of ["dark", "light"]) {
 					await page.locator("html").evaluate((element, dark) => {
 						element.classList.toggle("dark", dark);
 					}, theme === "dark");
 					await compute.evaluate((element) => element.scrollIntoView({ block: "center" }));
+					await expect(compute).toBeInViewport({ ratio: 1 });
+					await expectAgentOverviewGeometry(page, { hosted: true, desktop: width === 1440 });
 					await compute.screenshot({
 						path: testInfo.outputPath(`${scenario.name}-${width}-${theme}-compute.png`),
 					});

--- a/apps/web/src/components/dashboard/overview-compute-body.tsx
+++ b/apps/web/src/components/dashboard/overview-compute-body.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 type ComputeFact = { label: string | null; value: ReactNode };
 
-/** Specs and commercial facts share one label/value track, including while loading. */
+/** Specs and billing facts share a right edge, including while loading. */
 export function OverviewComputeBody({
 	planLabel,
 	resources,
@@ -34,24 +34,21 @@ export function OverviewComputeBody({
 		: [subscription, date].filter((fact): fact is ComputeFact => Boolean(fact));
 	return (
 		<div
-			className="space-y-1.5"
+			className="space-y-2"
 			data-testid="overview-compute-summary"
 			aria-busy={loading || undefined}
 		>
 			<div data-overview-compute-plan className="text-sm text-muted-foreground">
 				{loading ? <Skeleton className="h-lh w-32 max-w-full" /> : planLabel}
 			</div>
-			<dl
-				aria-label="Compute resources"
-				className="grid grid-cols-[fit-content(40%)_minmax(0,1fr)] gap-x-4 gap-y-0.5 text-xs text-muted-foreground"
-			>
+			<dl aria-label="Compute resources" className="space-y-1 text-xs text-muted-foreground">
 				{[...rows, ...commercial].map((item, index) => (
 					<div
 						key={item.label ?? "access"}
 						className={cn(
-							"col-span-full grid grid-cols-subgrid items-baseline",
+							"grid grid-cols-[fit-content(40%)_minmax(0,1fr)] items-baseline gap-x-4",
 							loading && "items-center",
-							index === rows.length && "mt-2",
+							index === rows.length && "mt-3",
 						)}
 						data-overview-subscription-row={index === rows.length || undefined}
 					>
@@ -69,7 +66,7 @@ export function OverviewComputeBody({
 						<dd
 							className={
 								item.label
-									? "flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-2 break-words"
+									? "flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-2 text-right break-words"
 									: "col-span-full flex min-w-0 flex-wrap items-center justify-between gap-3 break-words"
 							}
 						>

--- a/apps/web/src/components/dashboard/overview-compute-body.tsx
+++ b/apps/web/src/components/dashboard/overview-compute-body.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 type ComputeFact = { label: string | null; value: ReactNode };
 
-/** Specs and billing facts share a right edge, including while loading. */
+/** Inline specs and billing facts keep their own space above optional actions. */
 export function OverviewComputeBody({
 	planLabel,
 	resources,
@@ -21,10 +21,18 @@ export function OverviewComputeBody({
 	action?: ReactNode;
 	loading?: boolean;
 }) {
-	const rows: ComputeFact[] = [
-		{ label: "CPU", value: resources ? `${resources.vcpu} vCPU` : null },
-		{ label: "Memory", value: resources ? formatMemoryMib(resources.memory_mib) : null },
-		{ label: "Storage", value: resources ? `${resources.disk_gib} GiB` : null },
+	const specs = [
+		{ label: "CPU", value: resources ? `${resources.vcpu} vCPU` : null, width: "w-10" },
+		{
+			label: "Memory",
+			value: resources ? `${formatMemoryMib(resources.memory_mib)} RAM` : null,
+			width: "w-16",
+		},
+		{
+			label: "Storage",
+			value: resources ? `${resources.disk_gib} GiB storage` : null,
+			width: "w-20",
+		},
 	];
 	const commercial = loading
 		? [
@@ -41,46 +49,65 @@ export function OverviewComputeBody({
 			<div data-overview-compute-plan className="text-sm text-muted-foreground">
 				{loading ? <Skeleton className="h-lh w-32 max-w-full" /> : planLabel}
 			</div>
-			<dl aria-label="Compute resources" className="space-y-1 text-xs text-muted-foreground">
-				{[...rows, ...commercial].map((item, index) => (
-					<div
-						key={item.label ?? "access"}
-						className={cn(
-							"grid grid-cols-[fit-content(40%)_minmax(0,1fr)] items-baseline gap-x-4",
-							loading && "items-center",
-							index === rows.length && "mt-3",
-						)}
-						data-overview-subscription-row={index === rows.length || undefined}
-					>
-						<dt className={item.label ? "min-w-0 break-words" : "sr-only"}>
-							{loading && index >= rows.length ? (
-								<Skeleton className="relative h-lh max-w-full">
-									<span className="invisible" aria-hidden="true">
-										{item.label}
-									</span>
-								</Skeleton>
+			<dl
+				aria-label="Compute resources"
+				className="flex flex-wrap gap-x-1.5 gap-y-1 text-xs text-muted-foreground"
+			>
+				{specs.map((item, index) => (
+					<div key={item.label}>
+						<dt className="sr-only">{item.label}</dt>
+						<dd className="flex items-center gap-1.5">
+							{index > 0 && <span aria-hidden="true">·</span>}
+							{loading ? (
+								<Skeleton className={cn("h-lh max-w-full", item.width)} />
 							) : (
-								(item.label ?? "Plan access")
+								<span>{item.value}</span>
 							)}
-						</dt>
-						<dd
-							className={
-								item.label
-									? "flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-2 text-right break-words"
-									: "col-span-full flex min-w-0 flex-wrap items-center justify-between gap-3 break-words"
-							}
-						>
-							<span
-								data-overview-subscription-status={index === rows.length || undefined}
-								className="min-w-0"
-							>
-								{loading ? <Skeleton className="h-lh w-16 max-w-full" /> : item.value}
-							</span>
-							{index === rows.length ? action : null}
 						</dd>
 					</div>
 				))}
 			</dl>
+			{commercial.length > 0 && (
+				<dl className="space-y-1 text-xs text-muted-foreground">
+					{commercial.map((item, index) => (
+						<div
+							key={item.label ?? "access"}
+							className={cn(
+								"grid grid-cols-[fit-content(40%)_minmax(0,1fr)] items-baseline gap-x-4",
+								loading && "items-center",
+							)}
+							data-overview-subscription-row={index === 0 || undefined}
+						>
+							<dt className={item.label ? "min-w-0 break-words" : "sr-only"}>
+								{loading ? (
+									<Skeleton className="relative h-lh max-w-full">
+										<span className="invisible" aria-hidden="true">
+											{item.label}
+										</span>
+									</Skeleton>
+								) : (
+									(item.label ?? "Plan access")
+								)}
+							</dt>
+							<dd
+								className={
+									item.label
+										? "min-w-0 text-right break-words"
+										: "col-span-full min-w-0 break-words"
+								}
+							>
+								<span
+									data-overview-subscription-status={index === 0 || undefined}
+									className="inline-block max-w-full align-top"
+								>
+									{loading ? <Skeleton className="h-lh w-16 max-w-full" /> : item.value}
+								</span>
+							</dd>
+						</div>
+					))}
+				</dl>
+			)}
+			{action && <div className="flex flex-wrap justify-end gap-2 pt-1">{action}</div>}
 		</div>
 	);
 }


### PR DESCRIPTION
Show hardware in one compact summary line, wrapping naturally at segment boundaries when necessary. Keep subscription and date values right-aligned, with optional actions in a separate footer so buttons cannot squeeze the facts. Loading uses the matching structure. Billing semantics and other page layouts are unchanged.

Docker verification of final revision: TypeScript, 69 related unit tests, Biome, OSS build and three existing browser scenarios passed. Root reviewed the actual diff and paid desktop/narrow payment recovery screenshots. Not merged or deployed.