### PR TITLE
fix(connectors): remove per-app metadata requests from connected lists

### DIFF
--- a/apps/web/e2e/connector-loading.pw.ts
+++ b/apps/web/e2e/connector-loading.pw.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function app(name: string) {
+	return {
+		name,
+		display_name: name.toUpperCase(),
+		logo: name === "alpha" ? "https://logos.example.test/alpha.png" : "",
+		description: `${name} connection`,
+		auth_type: "oauth2",
+		connect_disabled: false,
+		connect_disabled_reason: null,
+	};
+}
+
+for (const width of [1440, 375]) {
+	test(`connector loading keeps stable slots at ${width}px`, async ({ page }, testInfo) => {
+		await page.setViewportSize({ width, height: 1000 });
+		const catalog = deferred();
+		const metadata = deferred();
+		const metadataStarted = deferred();
+		const batches: string[][] = [];
+		const logo = deferred();
+		const details: string[] = [];
+		const errors: string[] = [];
+		page.on("pageerror", (error) => errors.push(error.message));
+		await page.route("https://logos.example.test/**", async (route) => {
+			await logo.promise;
+			await route.fulfill({
+				contentType: "image/png",
+				body: readFileSync(new URL("../public/favicon-32x32.png", import.meta.url)),
+			});
+		});
+		await page.route("**/v1/**", async (route) => {
+			const path = new URL(route.request().url()).pathname;
+			let body: unknown = {};
+			if (path === "/v1/connectors") {
+				body = ["alpha", "beta", "gamma", "retired", "alpha"].map((name, index) => ({
+					id: `connection-${index}`,
+					app_name: name,
+					status: "ACTIVE",
+					created_at: "2026-09-07T00:00:00Z",
+				}));
+			} else if (path === "/v1/connectors/available") {
+				await catalog.promise;
+				body = { items: [app("alpha")], total: 1, page: 1, page_size: 24 };
+			} else if (path === "/v1/connectors/metadata:batchRead") {
+				batches.push(route.request().postDataJSON().names);
+				metadataStarted.resolve();
+				await metadata.promise;
+				body = {
+					items: ["alpha", "beta", "gamma"].map((name) => {
+						const value = app(name);
+						return {
+							name,
+							display_name: value.display_name,
+							logo: value.logo,
+							description: value.description,
+						};
+					}),
+					missing: ["retired"],
+				};
+			} else if (path.startsWith("/v1/connectors/available/")) {
+				const name = path.split("/").at(-1) ?? "";
+				details.push(name);
+				body = app(name);
+			} else if (["/v1/agents", "/v1/projects", "/v1/vault", "/v1/auth/keys"].includes(path)) {
+				body = [];
+			} else if (path.endsWith("/tools")) {
+				body = [];
+			} else if (["/v1/sessions", "/v1/skills", "/v1/memories"].includes(path)) {
+				body = { items: [], total: 0, page: 1, page_size: 24 };
+			}
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify(body),
+			});
+		});
+		try {
+			await page.goto("/connectors");
+			await expect(page.getByText("5 active", { exact: true })).toBeVisible();
+			await metadataStarted.promise;
+			metadata.resolve();
+			const rail = page
+				.locator("section")
+				.filter({ has: page.getByText("Ready to use", { exact: true }) });
+			const gamma = rail.getByRole("link", { name: "GAMMA", exact: true });
+			await expect(gamma).toBeVisible();
+			await expect(rail.getByText("4 apps", { exact: true })).toBeVisible();
+			await expect(rail.getByRole("link", { name: "retired", exact: true })).toBeVisible();
+			expect(batches).toEqual([["alpha", "beta", "gamma", "retired"]]);
+			const before = await gamma.boundingBox();
+			expect(before).not.toBeNull();
+			const alpha = rail.getByRole("link", { name: "ALPHA", exact: true }).locator("..");
+			await expect(alpha.getByText("A", { exact: true })).toBeVisible();
+			catalog.resolve();
+			await expect(page.getByText("1 available").first()).toBeVisible();
+			await page.screenshot({
+				path: testInfo.outputPath("connectors-loading.png"),
+				fullPage: true,
+			});
+			await expect(rail.getByRole("link", { name: "BETA", exact: true })).toBeVisible();
+			expect(await gamma.boundingBox()).toEqual(before);
+			expect(details).toEqual([]);
+			logo.resolve();
+			await expect(alpha.locator("img")).toHaveCSS("opacity", "1");
+			await expect(alpha.getByText("A", { exact: true })).toHaveCSS("visibility", "hidden");
+			expect(
+				await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+			).toBe(true);
+			expect(errors).toEqual([]);
+			await page.screenshot({ path: testInfo.outputPath("connectors-loaded.png"), fullPage: true });
+			await rail.getByRole("link", { name: "ALPHA", exact: true }).click();
+			await expect.poll(() => details).toEqual(["alpha"]);
+			expect(errors).toEqual([]);
+		} finally {
+			catalog.resolve();
+			metadata.resolve();
+			logo.resolve();
+		}
+	});
+}

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -2,8 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
-import { useCallback } from "react";
-import { ConnectorConnectAction } from "@/components/connectors/connector-connect-action";
+import { type ReactNode, useCallback } from "react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { connectorSearchSupportingText } from "@/components/connectors/connector-search";
 import { ENTITY_GRID_CLASS, EntityCardSkeleton, EntityRow } from "@/components/entity-card";
@@ -11,11 +10,10 @@ import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { useOpenApi } from "@/lib/api";
 import {
 	availableAppQueryOptions,
-	type ConnectorAvailableApp,
+	type ConnectorMetadata,
 	connectorToolsQueryOptions,
 } from "@/lib/connectors-data";
 import {
-	connectorDetailHrefForScope,
 	connectorDetailLink,
 	LIBRARY_RESOURCE_SCOPE,
 	type ResourceNavigationScope,
@@ -32,11 +30,13 @@ export function ConnectorCard({
 	isConnected = false,
 	scope = LIBRARY_RESOURCE_SCOPE,
 	searchQuery,
+	actions,
 }: {
-	app: ConnectorAvailableApp;
+	app: ConnectorMetadata;
 	isConnected?: boolean;
 	scope?: ResourceNavigationScope;
 	searchQuery?: string;
+	actions?: ReactNode;
 }) {
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
@@ -47,6 +47,7 @@ export function ConnectorCard({
 
 	return (
 		<EntityRow
+			className="min-h-19"
 			ariaLabel={app.display_name}
 			icon={<ConnectorIcon logo={app.logo} name={app.display_name} size="md" />}
 			title={
@@ -71,14 +72,7 @@ export function ConnectorCard({
 					app.description
 				)
 			}
-			actions={
-				!isConnected ? (
-					<ConnectorConnectAction
-						app={app}
-						redirectHref={connectorDetailHrefForScope(scope, app.name)}
-					/>
-				) : undefined
-			}
+			actions={actions}
 			link={{
 				...connectorDetailLink(scope, app.name),
 				onMouseEnter: prefetchDetail,
@@ -89,7 +83,7 @@ export function ConnectorCard({
 }
 
 export function ConnectorCardSkeleton() {
-	return <EntityCardSkeleton />;
+	return <EntityCardSkeleton className="min-h-19" />;
 }
 
 export const CONNECTOR_GRID_CLASS = ENTITY_GRID_CLASS;

--- a/apps/web/src/components/connectors/connector-icon.tsx
+++ b/apps/web/src/components/connectors/connector-icon.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { cn } from "@/lib/utils";
 
 const SIZES = {
@@ -18,7 +18,20 @@ export function ConnectorIcon({
 	name: string;
 	size?: keyof typeof SIZES;
 }) {
-	const [imgError, setImgError] = useState(false);
+	const [imageState, setImageState] = useState<{
+		src: string;
+		status: "loaded" | "error";
+	} | null>(null);
+	const loaded = imageState?.status === "loaded" && imageState.src === logo;
+	const failed = imageState?.status === "error" && imageState.src === logo;
+	const imageRef = useCallback(
+		(image: HTMLImageElement | null) => {
+			if (logo && image?.complete) {
+				setImageState({ src: logo, status: image.naturalWidth > 0 ? "loaded" : "error" });
+			}
+		},
+		[logo],
+	);
 	const s = SIZES[size];
 	const letter =
 		name
@@ -26,36 +39,35 @@ export function ConnectorIcon({
 			.charAt(0)
 			.toUpperCase() || "?";
 
-	// Logo: bordered white tile with logo filling via object-contain + small
-	// breathing padding. Lets brand colors stay themselves instead of fighting
-	// a gray muted backdrop.
-	if (logo && !imgError) {
-		return (
-			<div
-				className={cn(
-					"flex shrink-0 items-center justify-center overflow-hidden border bg-background",
-					s.box,
-					s.radius,
-				)}
-			>
+	return (
+		<div
+			className={cn(
+				"relative flex shrink-0 items-center justify-center overflow-hidden border",
+				loaded ? "bg-background" : "bg-muted",
+				s.box,
+				s.radius,
+			)}
+		>
+			<span className={cn("font-semibold text-muted-foreground", s.text, loaded && "invisible")}>
+				{letter}
+			</span>
+			{logo && !failed ? (
 				<img
+					key={logo}
+					ref={imageRef}
 					src={logo}
 					alt=""
 					loading="lazy"
 					decoding="async"
-					className={cn("h-full w-full object-contain", s.pad)}
-					onError={() => setImgError(true)}
+					className={cn(
+						"absolute inset-0 h-full w-full object-contain transition-opacity",
+						s.pad,
+						loaded ? "opacity-100" : "opacity-0",
+					)}
+					onLoad={() => setImageState({ src: logo, status: "loaded" })}
+					onError={() => setImageState({ src: logo, status: "error" })}
 				/>
-			</div>
-		);
-	}
-
-	// Fallback: muted initial tile.
-	return (
-		<div
-			className={cn("flex shrink-0 items-center justify-center border bg-muted", s.box, s.radius)}
-		>
-			<span className={cn("font-semibold text-muted-foreground", s.text)}>{letter}</span>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/components/connectors/connectors-surface.tsx
+++ b/apps/web/src/components/connectors/connectors-surface.tsx
@@ -9,6 +9,7 @@ import {
 	ConnectorCard,
 	ConnectorCardSkeleton,
 } from "@/components/connectors/connector-card";
+import { ConnectorConnectAction } from "@/components/connectors/connector-connect-action";
 import { EmptyState } from "@/components/empty-state";
 import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
@@ -22,12 +23,17 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
 	CONNECTOR_CATALOG_PAGE_SIZE,
 	type ConnectorAvailableApp,
+	type ConnectorMetadata,
 	useAvailableApps,
 	useConnectedAppCards,
 } from "@/lib/connectors-data";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
-import { LIBRARY_RESOURCE_SCOPE, type ResourceNavigationScope } from "@/lib/resource-navigation";
+import {
+	connectorDetailHrefForScope,
+	LIBRARY_RESOURCE_SCOPE,
+	type ResourceNavigationScope,
+} from "@/lib/resource-navigation";
 import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn } from "@/lib/utils";
@@ -124,12 +130,12 @@ function ConnectorsList({
 	// Connector access is decided inside `connectors-data.ts`. The
 	// "Connected" rail and the paginated "All" grid both flow through
 	// the unified cloud-api hooks so the page stays branch-free.
-	const connected = useConnectedAppCards();
 	const catalogQ = useAvailableApps({
 		page,
 		pageSize: PAGE_SIZE,
 		search: debouncedQuery || undefined,
 	});
+	const connected = useConnectedAppCards();
 	const pageData = catalogQ.data;
 	const isCatalogLoading = catalogQ.isLoading;
 	const catalogError = shouldBlockQueryError(catalogQ.error, pageData) ? catalogQ.error : null;
@@ -141,7 +147,7 @@ function ConnectorsList({
 		: null;
 
 	const connectedNames = useMemo(
-		() => new Set(connected.activeConnections.map((c) => c.app_name)),
+		() => new Set(connected.activeConnections.flatMap((c) => (c.app_name ? [c.app_name] : []))),
 		[connected.activeConnections],
 	);
 
@@ -210,7 +216,7 @@ function ConnectorsList({
 			{showConnectedRail ? (
 				<ConnectedRail
 					apps={connected.data}
-					activeCount={connected.activeConnections.length}
+					appNames={[...connectedNames]}
 					isLoading={connected.isLoading}
 					error={connectedError}
 					onRetry={connected.refetch}
@@ -245,19 +251,21 @@ function ConnectorsList({
  */
 function ConnectedRail({
 	apps,
-	activeCount,
+	appNames,
 	isLoading,
 	error,
 	onRetry,
 	scope,
 }: {
-	apps: ConnectorAvailableApp[];
-	activeCount: number;
+	apps: ConnectorMetadata[];
+	appNames: readonly string[];
 	isLoading: boolean;
 	error: Error | null;
 	onRetry: () => void;
 	scope: ResourceNavigationScope;
 }) {
+	const byName = new Map(apps.map((app) => [app.name, app]));
+	const activeCount = appNames.length;
 	return (
 		<section className="space-y-3">
 			<SectionLabel
@@ -272,15 +280,20 @@ function ConnectedRail({
 				<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load connections" />
 			) : isLoading && apps.length === 0 ? (
 				<div className={CONNECTOR_GRID_CLASS}>
-					{Array.from({ length: 4 }).map((_, i) => (
+					{Array.from({ length: activeCount || 4 }).map((_, i) => (
 						<ConnectorCardSkeleton key={i} />
 					))}
 				</div>
 			) : (
 				<div className={CONNECTOR_GRID_CLASS}>
-					{apps.map((app) => (
-						<ConnectorCard key={app.name} app={app} isConnected scope={scope} />
-					))}
+					{appNames.map((name) => {
+						const app = byName.get(name);
+						return app ? (
+							<ConnectorCard key={name} app={app} isConnected scope={scope} />
+						) : (
+							<ConnectorCardSkeleton key={name} />
+						);
+					})}
 				</div>
 			)}
 		</section>
@@ -349,6 +362,14 @@ function CatalogSection({
 							isConnected={connectedNames.has(app.name)}
 							scope={scope}
 							searchQuery={query.trim() || undefined}
+							actions={
+								!connectedNames.has(app.name) ? (
+									<ConnectorConnectAction
+										app={app}
+										redirectHref={connectorDetailHrefForScope(scope, app.name)}
+									/>
+								) : undefined
+							}
 						/>
 					))}
 				</div>

--- a/apps/web/src/lib/connectors-data.test.ts
+++ b/apps/web/src/lib/connectors-data.test.ts
@@ -1,83 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import {
-	type ConnectorAvailableApp,
-	limitConnectedAppMetadataNames,
-	resolveConnectedAppMetadataPlan,
-} from "./connectors-data";
+import { connectorMetadataBatches } from "./connectors-data";
 
-function catalogApp(name: string): ConnectorAvailableApp {
-	return {
-		name,
-		display_name: name,
-		logo: "",
-		description: `${name} connector`,
-		auth_type: "oauth",
-		connect_disabled: false,
-		connect_disabled_reason: null,
-	};
-}
-
-describe("connected app metadata planning", () => {
-	it("limits Overview metadata lookups without changing the full stable app order", () => {
-		const names = ["github", "slack", "gmail", "notion", "linear"];
-
-		expect(limitConnectedAppMetadataNames(names, 4)).toEqual([
-			"github",
-			"slack",
-			"gmail",
-			"notion",
+describe("connected metadata batches", () => {
+	it("deduplicates names without reordering them or requesting empty names", () => {
+		expect(connectorMetadataBatches(["slack", "", "github", "slack"])).toEqual([
+			["slack", "github"],
 		]);
-		expect(limitConnectedAppMetadataNames(names)).toBe(names);
-		expect(limitConnectedAppMetadataNames(names, 0)).toEqual([]);
+		expect(connectorMetadataBatches([])).toEqual([]);
 	});
-
-	it("uses catalog metadata and only requests active apps missing from the catalog", () => {
-		const github = catalogApp("github");
-		const plan = resolveConnectedAppMetadataPlan(["github", "slack"], {
-			apps: [github, catalogApp("gmail")],
-			isLoading: false,
-			error: null,
-		});
-
-		expect(plan.catalogApps).toEqual([github]);
-		expect(plan.missingNames).toEqual(["slack"]);
-	});
-
-	it("does not start metadata requests while the first catalog page is loading", () => {
-		expect(
-			resolveConnectedAppMetadataPlan(["github", "slack"], {
-				apps: undefined,
-				isLoading: true,
-				error: null,
-			}),
-		).toEqual({ catalogApps: [], missingNames: [] });
-	});
-
-	it("falls back to detail requests when catalog loading fails", () => {
-		expect(
-			resolveConnectedAppMetadataPlan(["github", "slack"], {
-				apps: undefined,
-				isLoading: false,
-				error: new Error("catalog failed"),
-			}),
-		).toEqual({ catalogApps: [], missingNames: ["github", "slack"] });
-	});
-
-	it("keeps using stale catalog data when a background refresh fails", () => {
-		const github = catalogApp("github");
-		expect(
-			resolveConnectedAppMetadataPlan(["github", "slack"], {
-				apps: [github],
-				isLoading: false,
-				error: new Error("catalog refresh failed"),
-			}),
-		).toEqual({ catalogApps: [github], missingNames: ["slack"] });
-	});
-
-	it("preserves existing no-catalog behavior for other callers", () => {
-		expect(resolveConnectedAppMetadataPlan(["slack", "github"])).toEqual({
-			catalogApps: [],
-			missingNames: ["slack", "github"],
-		});
+	it("keeps every name while respecting the API batch bound", () => {
+		const names = Array.from({ length: 207 }, (_, index) => `app-${index}`);
+		const batches = connectorMetadataBatches(names);
+		expect(batches.map((batch) => batch.length)).toEqual([100, 100, 7]);
+		expect(batches.flat()).toEqual(names);
 	});
 });

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -1,9 +1,15 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { keepPreviousData, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
-import { type OpenApiClient, useOpenApi } from "@/lib/api";
+import {
+	keepPreviousData,
+	queryOptions,
+	useQueries,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useMemo } from "react";
+import { type OpenApiClient, unwrap, useApi, useOpenApi } from "@/lib/api";
 
 /**
  * Connector data hooks. Always talk to cloud-api — there is no
@@ -26,39 +32,25 @@ export const CONNECTOR_CATALOG_STALE_TIME_MS = 10 * 60 * 1000;
 export const CONNECTOR_CATALOG_GC_TIME_MS = CONNECTOR_CATALOG_STALE_TIME_MS;
 
 export type ConnectorAvailableApp = components["schemas"]["ConnectorAvailableAppResponse"];
+export type ConnectorMetadata = components["schemas"]["ConnectorMetadataResponse"];
 
-export type ConnectedAppCatalogSnapshot = {
-	apps: readonly ConnectorAvailableApp[] | undefined;
-	isLoading: boolean;
-	error: unknown;
-};
-
-type ConnectedAppMetadataPlan = {
-	catalogApps: ConnectorAvailableApp[];
-	missingNames: string[];
-};
-
-export function limitConnectedAppMetadataNames(
-	names: readonly string[],
-	limit?: number,
-): readonly string[] {
-	return limit === undefined ? names : names.slice(0, Math.max(0, limit));
+export function connectorMetadataBatches(names: readonly string[]): string[][] {
+	const unique = [...new Set(names.filter(Boolean))];
+	const batches: string[][] = [];
+	for (let offset = 0; offset < unique.length; offset += 100) {
+		batches.push(unique.slice(offset, offset + 100));
+	}
+	return batches;
 }
 
-export function resolveConnectedAppMetadataPlan(
-	names: readonly string[],
-	catalog?: ConnectedAppCatalogSnapshot,
-): ConnectedAppMetadataPlan {
-	if (!catalog) return { catalogApps: [], missingNames: [...names] };
-	if (catalog.isLoading && !catalog.apps) return { catalogApps: [], missingNames: [] };
-	const byName = new Map((catalog.apps ?? []).map((app) => [app.name, app]));
-	return {
-		catalogApps: names.flatMap((name) => {
-			const app = byName.get(name);
-			return app ? [app] : [];
-		}),
-		missingNames: names.filter((name) => !byName.has(name)),
-	};
+function connectorMetadataQueryOptions(api: ReturnType<typeof useApi>, names: string[]) {
+	return queryOptions({
+		queryKey: ["connector-metadata", names],
+		queryFn: async ({ signal }) =>
+			unwrap(await api.POST("/v1/connectors/metadata:batchRead", { body: { names }, signal })),
+		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+	});
 }
 
 export type AvailableAppsQueryArgs = {
@@ -162,20 +154,11 @@ export function useAvailableApps({
 	enabled = true,
 }: AvailableAppsQueryArgs & { enabled?: boolean }) {
 	const api = useOpenApi();
-	const queryClient = useQueryClient();
-	const query = useQuery({
+	return useQuery({
 		...availableAppsQueryOptions(api, { page, pageSize, search }),
 		placeholderData: keepPreviousData,
 		enabled,
 	});
-	useEffect(() => {
-		const apps = query.data?.items;
-		if (!apps) return;
-		for (const app of apps) {
-			queryClient.setQueryData<ConnectorAvailableApp>(availableAppQueryKey(app.name), app);
-		}
-	}, [query.data?.items, queryClient]);
-	return query;
 }
 
 export function useConnectorTools(appName: string) {
@@ -215,17 +198,12 @@ export function useDisconnect() {
  * without this rail, they'd never find their connections without
  * searching.
  *
- * Fan-out: one `/available/{name}` query per unique active app not
- * covered by a supplied catalog snapshot. Callers can cap metadata
- * resolution for compact previews without changing the full connection
- * count; the default preserves the existing unbounded behavior.
+ * Display metadata is fetched in bounded batches, independently of the
+ * current catalog page. It never seeds the authoritative detail query.
  */
-export function useConnectedAppCards(
-	catalog?: ConnectedAppCatalogSnapshot,
-	{ enabled = true, limit }: { enabled?: boolean; limit?: number } = {},
-) {
+export function useConnectedAppCards({ enabled = true }: { enabled?: boolean } = {}) {
 	const connectionsQ = useConnections({ enabled });
-	const api = useOpenApi();
+	const api = useApi();
 
 	const activeConnections = useMemo(
 		() => connectionsQ.data?.filter(isActiveConnection) ?? [],
@@ -237,41 +215,36 @@ export function useConnectedAppCards(
 	// the user picks between accounts. Filter out connections with a
 	// missing/empty `app_name` defensively — Composio always returns
 	// it in practice, but a malformed row would otherwise become an
-	// `undefined` Set entry and fan out a useQueries with a broken
-	// path param.
+	// invalid metadata name in a batch request.
 	const names = useMemo(
 		() => Array.from(new Set(activeConnections.flatMap((c) => (c.app_name ? [c.app_name] : [])))),
 		[activeConnections],
 	);
-	const metadataNames = useMemo(() => limitConnectedAppMetadataNames(names, limit), [names, limit]);
-	const metadataPlan = useMemo(
-		() => resolveConnectedAppMetadataPlan(metadataNames, catalog),
-		[metadataNames, catalog?.apps, catalog?.error, catalog?.isLoading],
-	);
+	const batches = useMemo(() => connectorMetadataBatches(names), [names]);
 
 	const lookup = useQueries({
-		queries: metadataPlan.missingNames.map((name) => ({
-			...availableAppQueryOptions(api, name),
+		queries: batches.map((batch) => ({
+			...connectorMetadataQueryOptions(api, batch),
 			enabled,
 		})),
 	});
 
 	const data = useMemo(() => {
-		const byName = new Map(metadataPlan.catalogApps.map((app) => [app.name, app]));
+		const byName = new Map<string, ConnectorMetadata>();
 		for (const query of lookup) {
-			if (query.data) byName.set(query.data.name, query.data);
+			for (const app of query.data?.items ?? []) byName.set(app.name, app);
+			for (const name of query.data?.missing ?? []) {
+				byName.set(name, { name, display_name: name, logo: "", description: "" });
+			}
 		}
-		return metadataNames.flatMap((name) => {
+		return names.flatMap((name) => {
 			const app = byName.get(name);
 			return app ? [app] : [];
 		});
-	}, [lookup, metadataPlan.catalogApps, metadataNames]);
-	const waitingForCatalog = Boolean(
-		catalog?.isLoading && !catalog.apps && metadataNames.length > 0,
-	);
-	const isLoading = connectionsQ.isLoading || waitingForCatalog || lookup.some((q) => q.isLoading);
+	}, [lookup, names]);
+	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
 	const connectionsLoading = connectionsQ.isLoading;
-	const metadataLoading = waitingForCatalog || lookup.some((q) => q.isLoading);
+	const metadataLoading = lookup.some((q) => q.isLoading);
 	const connectionsError = connectionsQ.error;
 	const metadataError = lookup.find((q) => q.error)?.error ?? null;
 	const error = connectionsError ?? metadataError;


### PR DESCRIPTION
Connected apps previously fetched one upstream-backed detail per app and appeared as independent requests completed. Directory data also populated the detail cache despite lacking authoritative connection configuration.

Use the generated metadata batch API from #1404 independently of the directory page. Remove per-app detail requests and directory-to-detail cache seeding. Display-only cards retain stable slots and logo initials; catalog connection actions still receive full configuration. Missing display metadata preserves the connected app name without inventing auth fields.

Validation: isolated web typecheck, batching tests, OSS build and Biome passed. Chromium checks at 1440px and 375px verified four unique apps produce one batch, no initial detail requests, stable layout, missing metadata, and detail reads on navigation. Backend contract tests and generated types passed in #1404. Rebased onto main containing #1404 and Composio 0.21.1; range-diff confirms the six frontend files are unchanged. Final CI reruns on the rebased head. Local lefthook was unavailable; checks ran independently.

Release: backend #1404 must be deployed before this frontend. This PR targets main and changes the shared Cloud Connectors surface. Upstream cold-catalog latency can remain; the connected rail no longer issues per-app detail requests.
