### PR TITLE
feat(connectors): batch display metadata without per-app upstream calls

### DIFF
--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -14,6 +14,8 @@ from app.schemas.connector import (
     ConnectorCredentialsConnectResponse,
     ConnectorDisconnectResponse,
     ConnectorMcpConfigResponse,
+    ConnectorMetadataBatchRequest,
+    ConnectorMetadataBatchResponse,
     ConnectorToolResponse,
     ConnectRequest,
 )
@@ -29,6 +31,7 @@ from app.services.composio import (
     get_auth_fields,
     get_available_apps,
     get_connected_accounts,
+    get_connector_metadata,
     invalidate_tool_router_mcp_session,
     normalize_composio_failure,
 )
@@ -128,6 +131,20 @@ async def list_connections(
     # MCP bridge call to create a fresh session.
     await invalidate_tool_router_mcp_session(clerk_id)
     return [ConnectorConnectionResponse.model_validate(account) for account in accounts]
+
+
+@router.post("/metadata:batchRead", response_model=ConnectorMetadataBatchResponse)
+async def read_connector_metadata(
+    body: ConnectorMetadataBatchRequest,
+    auth: AuthContext = Depends(require_user_auth_short_session),
+) -> ConnectorMetadataBatchResponse:
+    """Batch display metadata; connection/auth configuration remains a separate read."""
+    if not settings.composio_api_key:
+        return ConnectorMetadataBatchResponse(items=[], missing=body.names)
+    try:
+        return await get_connector_metadata(body.names)
+    except ComposioRouteError as exc:
+        raise _map_composio_error(exc) from exc
 
 
 @router.get("/available")

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -1,7 +1,7 @@
-from typing import Literal
+from typing import Annotated, Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, JsonValue, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 
 from app.core.config import settings
 
@@ -80,11 +80,27 @@ class ConnectorConnectionResponse(BaseModel):
     account_display: str | None = None
 
 
-class ConnectorAvailableAppResponse(BaseModel):
+class ConnectorMetadataResponse(BaseModel):
     name: str
     display_name: str
     logo: str
     description: str
+
+
+class ConnectorMetadataBatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    names: list[Annotated[str, Field(min_length=1, max_length=256)]] = Field(
+        min_length=1, max_length=100
+    )
+
+
+class ConnectorMetadataBatchResponse(BaseModel):
+    items: list[ConnectorMetadataResponse]
+    missing: list[str]
+
+
+class ConnectorAvailableAppResponse(ConnectorMetadataResponse):
     # Surfaces Composio's auth scheme so the UI can pick OAuth vs an
     # API-key form on click. Lowercase strings: `oauth2`, `api_key`,
     # `bearer_token`, `basic`, `none`.

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -45,6 +45,8 @@ from app.schemas.connector import (
     ConnectorConnectionResponse,
     ConnectorConnectResponse,
     ConnectorCredentialsConnectResponse,
+    ConnectorMetadataBatchResponse,
+    ConnectorMetadataResponse,
     ConnectorToolResponse,
 )
 
@@ -1565,6 +1567,24 @@ async def get_app_by_name(name: str) -> ConnectorAvailableAppResponse | None:
             detail = await _get_toolkit_detail(name)
             return await _annotate_connect_status(client, detail, _serialize_app(detail))
     return None
+
+
+async def get_connector_metadata(names: list[str]) -> ConnectorMetadataBatchResponse:
+    """Read display metadata in one catalog pass; never resolve per-app auth details."""
+    by_name = {toolkit.slug: toolkit for toolkit in await _get_all_toolkits()}
+    return ConnectorMetadataBatchResponse(
+        items=[
+            ConnectorMetadataResponse(
+                name=name,
+                display_name=by_name[name].name,
+                logo=by_name[name].meta.logo,
+                description=by_name[name].meta.description[:200],
+            )
+            for name in names
+            if name in by_name
+        ],
+        missing=[name for name in names if name not in by_name],
+    )
 
 
 async def _get_toolkit_detail(name: str) -> _Toolkit:

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -451,6 +451,55 @@ def _reset_composio_app_cache(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
+async def test_connector_metadata_batch_reads_catalog_once_without_auth_details(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    fake = FakeClient(list_toolkits=[_posthog_list_toolkit(), _gmail_detail_toolkit()])
+    calls = 0
+    list_toolkits = fake.toolkits.list
+
+    async def counted_list(**kwargs):
+        nonlocal calls
+        calls += 1
+        return await list_toolkits(**kwargs)
+
+    async def unexpected_detail(_slug):
+        raise AssertionError("Display metadata must not fetch per-toolkit auth details")
+
+    monkeypatch.setattr(settings, "composio_api_key", "test-key")
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+    monkeypatch.setattr(fake.toolkits, "list", counted_list)
+    monkeypatch.setattr(fake.toolkits, "retrieve", unexpected_detail)
+    response = await client.post(
+        "/v1/connectors/metadata:batchRead", json={"names": ["gmail", "missing", "posthog"]}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [item["name"] for item in body["items"]] == ["gmail", "posthog"]
+    assert body["missing"] == ["missing"]
+    assert set(body["items"][0]) == {"name", "display_name", "logo", "description"}
+    repeated = await client.post("/v1/connectors/metadata:batchRead", json={"names": ["posthog"]})
+    assert repeated.status_code == 200
+    assert calls == 1
+    assert not fake.auth_configs.listed
+    oversized = await client.post(
+        "/v1/connectors/metadata:batchRead", json={"names": ["gmail"] * 101}
+    )
+    assert oversized.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_connector_metadata_batch_requires_authentication():
+    from app.main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/v1/connectors/metadata:batchRead", json={"names": ["gmail"]})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_connector_detail_uses_toolkit_auth_config_details(monkeypatch: pytest.MonkeyPatch):
     fake = FakeClient()
     serialized: list[str] = []

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2815,6 +2815,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/connectors/metadata:batchRead": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Read Connector Metadata
+         * @description Batch display metadata; connection/auth configuration remains a separate read.
+         */
+        post: operations["read_connector_metadata_v1_connectors_metadata_batchRead_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/connectors/available": {
         parameters: {
             query?: never;
@@ -5475,6 +5495,29 @@ export interface components {
             mcp_url: string;
             /** Mcp Token */
             mcp_token: string;
+        };
+        /** ConnectorMetadataBatchRequest */
+        ConnectorMetadataBatchRequest: {
+            /** Names */
+            names: string[];
+        };
+        /** ConnectorMetadataBatchResponse */
+        ConnectorMetadataBatchResponse: {
+            /** Items */
+            items: components["schemas"]["ConnectorMetadataResponse"][];
+            /** Missing */
+            missing: string[];
+        };
+        /** ConnectorMetadataResponse */
+        ConnectorMetadataResponse: {
+            /** Name */
+            name: string;
+            /** Display Name */
+            display_name: string;
+            /** Logo */
+            logo: string;
+            /** Description */
+            description: string;
         };
         /** ConnectorToolParametersResponse */
         ConnectorToolParametersResponse: {
@@ -15242,6 +15285,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ConnectorConnectionResponse"][];
+                };
+            };
+        };
+    };
+    read_connector_metadata_v1_connectors_metadata_batchRead_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConnectorMetadataBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectorMetadataBatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Problem and contract
Connected-app lists currently need one upstream-backed detail request per app just to display names and logos. Add an authenticated, read-only `POST /v1/connectors/metadata:batchRead` for up to 100 names.

The service reads the existing shared toolkit catalog once, preserves request order, and returns only display metadata plus explicit missing names. It never fetches per-toolkit auth details or auth configs, and does not return connection eligibility or credentials. Existing detail/connect APIs remain authoritative.

## Verification
- Isolated Docker/PostgreSQL: 72 connector, MCP and cleanup tests passed; Ruff and basedpyright passed.
- Tests verify authentication, batch bound, order, missing names, exact output fields, one catalog read across repeated calls and no per-toolkit detail/config calls.
- Generated TypeScript regenerated through the repository tool and verified byte-for-byte.
- API-only branch also passed existing frontend typecheck, metadata tests and OSS build in isolation.
- No migration, production operation or new cache framework. Local lefthook unavailable; checks ran independently.

## Release order
Merge and deploy this API before the frontend update in #1403. The frontend will use the batch contract rather than fall back to per-item requests. Metadata can still wait for an upstream cold catalog refresh; this removes N+1 lookups, not all network latency.
