### PR TITLE
fix(database): return connections after cancelled pre-ping

### DIFF
--- a/backend/app/core/asyncpg_dialect.py
+++ b/backend/app/core/asyncpg_dialect.py
@@ -1,0 +1,27 @@
+"""Keep SQLAlchemy pool invalidation atomic under AnyIO level cancellation."""
+
+import asyncio
+from typing import cast
+
+import anyio
+from sqlalchemy.dialects.postgresql.asyncpg import PGDialect_asyncpg
+from sqlalchemy.engine.interfaces import DBAPIConnection, Dialect
+
+
+class CancellationSafeAsyncpgDialect(PGDialect_asyncpg):
+    supports_statement_cache = True
+
+    def do_terminate(self, dbapi_connection: DBAPIConnection) -> None:
+        parent = cast(Dialect, super())
+        # Pre-ping can fail before a session/connection takes ownership. A
+        # second cancellation during termination would skip the pool checkin.
+        try:
+            task = asyncio.current_task()
+        except RuntimeError:
+            task = None
+        if task is None:
+            # GC can also terminate connections outside a running task/loop.
+            parent.do_terminate(dbapi_connection)
+            return
+        with anyio.CancelScope(shield=True):
+            parent.do_terminate(dbapi_connection)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 
 import anyio
 from sqlalchemy import event
-from sqlalchemy.engine import Connection, ExceptionContext
+from sqlalchemy.dialects import registry
+from sqlalchemy.engine import Connection, ExceptionContext, make_url
 from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
@@ -37,6 +38,11 @@ _CONNECTION_CHECKED_OUT_AT = "clawdi_connection_checked_out_at"
 CONTROL_POOL_SIZE = 1
 
 
+registry.register(
+    "postgresql.clawdi_asyncpg", "app.core.asyncpg_dialect", "CancellationSafeAsyncpgDialect"
+)
+
+
 def _create_engine(
     *, pool_size: int, max_overflow: int, lock_timeout: str | None = None
 ) -> AsyncEngine:
@@ -46,8 +52,11 @@ def _create_engine(
     }
     if lock_timeout is not None:
         server_settings["lock_timeout"] = lock_timeout
+    url = make_url(settings.database_url)
+    if url.drivername == "postgresql+asyncpg":
+        url = url.set(drivername="postgresql+clawdi_asyncpg")
     return create_async_engine(
-        settings.database_url,
+        url,
         echo=settings.debug,
         hide_parameters=True,
         pool_size=pool_size,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -121,6 +121,7 @@ strict = [
     "app/__init__.py",
     "app/core/__init__.py",
     "app/core/api_scopes.py",
+    "app/core/asyncpg_dialect.py",
     "app/core/auth.py",
     "app/core/config.py",
     "app/core/database.py",

--- a/backend/tests/test_database_session_cleanup.py
+++ b/backend/tests/test_database_session_cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import hashlib
 import secrets
 from datetime import UTC, datetime
@@ -9,6 +10,7 @@ import anyio
 import httpx
 import pytest
 from sqlalchemy import event, text
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from app.core import database
@@ -21,6 +23,105 @@ def _database_pool() -> QueuePool:
     pool = database.engine.sync_engine.pool
     assert isinstance(pool, QueuePool)
     return pool
+
+
+@pytest.mark.parametrize("owner", ["session", "connection"])
+async def test_cancelled_pre_ping_returns_unowned_connection(monkeypatch, caplog, owner):
+    engine = database._create_engine(pool_size=1, max_overflow=0)
+    sessions = async_sessionmaker(engine, class_=database.async_session_factory.class_)
+    pool = engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    ping_started = asyncio.Event()
+    cancellations: list[asyncio.CancelledError] = []
+    ping = engine.sync_engine.dialect.do_ping
+
+    def mark_ping(connection):
+        # Preserve real driver I/O; wake the canceller as pre-ping enters it.
+        ping_started.set()
+        return ping(connection)
+
+    async def request():
+        try:
+            async with sessions() if owner == "session" else engine.connect() as resource:
+                await resource.execute(text("SELECT 1"))
+        except asyncio.CancelledError as exc:
+            # Retain the traceback so GC cannot hide a missed pool checkin.
+            cancellations.append(exc)
+            raise
+
+    try:
+        async with engine.connect() as connection:
+            original_pid = await connection.scalar(text("SELECT pg_backend_pid()"))
+        monkeypatch.setattr(engine.sync_engine.dialect, "do_ping", mark_ping)
+        async with asyncio.timeout(5):
+            async with anyio.create_task_group() as tasks:
+                tasks.start_soon(request)
+                await ping_started.wait()
+                tasks.cancel_scope.cancel()
+        assert cancellations
+        assert pool.checkedout() == 0
+        async with engine.connect() as connection:
+            assert await connection.scalar(text("SELECT pg_backend_pid()")) != original_pid
+    finally:
+        cancellations.clear()
+        gc.collect()
+        await engine.dispose()
+
+    assert not [record for record in caplog.records if record.name.startswith("sqlalchemy.pool")]
+
+
+@pytest.mark.parametrize("owner", ["session", "connection"])
+async def test_level_cancelled_running_query_terminates_and_returns_connection(
+    engine, caplog, owner
+):
+    query_engine = database._create_engine(pool_size=1, max_overflow=0)
+    sessions = async_sessionmaker(query_engine, class_=database.async_session_factory.class_)
+    pool = query_engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    query_started = asyncio.Event()
+    query_pid: int | None = None
+    cancelled = False
+
+    async def request():
+        nonlocal query_pid, cancelled
+        try:
+            async with sessions() if owner == "session" else query_engine.connect() as resource:
+                query_pid = await resource.scalar(text("SELECT pg_backend_pid()"))
+                query_started.set()
+                await resource.execute(text("SELECT pg_sleep(30)"))
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+
+    try:
+        async with engine.connect() as observer, asyncio.timeout(5):
+            async with anyio.create_task_group() as tasks:
+                tasks.start_soon(request)
+                await query_started.wait()
+                # Cancel an executing server query, not just its initial checkout.
+                while (
+                    await observer.scalar(
+                        text("SELECT wait_event FROM pg_stat_activity WHERE pid = :pid"),
+                        {"pid": query_pid},
+                    )
+                    != "PgSleep"
+                ):
+                    await observer.rollback()
+                    await asyncio.sleep(0.01)
+                tasks.cancel_scope.cancel()
+            assert cancelled
+            assert pool.checkedout() == 0
+            await observer.rollback()
+            assert not await observer.scalar(
+                text("SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid = :pid)"),
+                {"pid": query_pid},
+            )
+            async with query_engine.connect() as connection:
+                assert await connection.scalar(text("SELECT 1")) == 1
+    finally:
+        await query_engine.dispose()
+
+    assert not [record for record in caplog.records if record.name.startswith("sqlalchemy.pool")]
 
 
 async def test_externally_cancelled_dependency_waits_for_session_close() -> None:

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -445,6 +445,16 @@ must retain its ordinary connection for the consumer lifetime; releasing it woul
 duplicate consumers. Delivery transactions that fence authority across sends
 also retain their locks deliberately.
 
+All three runtime engines use the asyncpg dialect in
+`backend/app/core/asyncpg_dialect.py`. It shields only driver termination from
+[AnyIO level cancellation](https://github.com/agronholm/anyio/blob/4.14.2/docs/cancellation.rst).
+In [SQLAlchemy 2.0.52](https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0_52/lib/sqlalchemy/pool/base.py),
+cancellation during pre-ping precedes session ownership; another cancellation
+during termination can interrupt `_checkin_failed()` before pool return.
+Session close cannot recover that unowned connection. The dialect preserves
+query cancellation and upstream graceful-close timeout/force-close behavior;
+the existing session and reserved-connection cleanup remains necessary.
+
 Pool timeout handling distinguishes HTTP from WebSocket: HTTP returns 503
 with `Retry-After: 1`; WebSocket sends `websocket.close` (1013 after acceptance,
 handshake rejection before acceptance). This follows the pinned
@@ -456,12 +466,15 @@ WebSocket close frame can be delivered before the upgrade.
 
 ```bash
 scripts/test.sh backend tests/test_runtime_manifest_pool.py tests/test_platform_workload_oauth.py tests/test_smoke.py
+scripts/test.sh backend tests/test_database_session_cleanup.py
 ```
 
 Done: slow admin provider I/O and real PostgreSQL pool contention leave
 deployment control and concurrent nested snapshots usable, both
 WebSocket timeout paths close without HTTP ASGI messages, synchronized manifests
 complete without nested pool starvation, and the command exits 0.
+Cancelled pre-ping and running-query tests return connections before GC,
+preserve cancellation, and allow the next checkout without pool warnings.
 
 Admin endpoints are disabled by default. The local setup and key-minting flow is
 in [`AGENTS.md`](../AGENTS.md#local-end-to-end). To exercise admin endpoints


### PR DESCRIPTION
Cancellation during asyncpg pre-ping can occur before a session owns the connection. Repeated AnyIO cancellation then interrupts SQLAlchemy termination before failed-checkout return, leaving a pool slot checked out until garbage collection. Shield driver termination through SQLAlchemy's dialect extension point for all three runtime engines. Preserve query cancellation, upstream graceful-close timeout, existing session cleanup, and connection budgets.

Validation: Python 3.14 and isolated PostgreSQL 18.4 reproduced the unreturned connection. Restoring the upstream hook fails all four new regression cases; the fix passes session/raw-connection pre-ping and running-query cases. Focused tests: 24 passed. Full backend: 2619 passed, 7 skipped. Strict/owned typing, Ruff, dependency audit, compilation, exception inventory and diff checks passed. Reviewer inspected the actual diff and pinned SQLAlchemy termination source.

Production traces show the same cancellation/GC mechanism, but cannot establish that every historical GC event used pre-ping. Post-deployment verification must check termination/GC warnings, pool counters and request cancellation behavior. No capacity change or query replay is introduced.
