### PR TITLE
Fix native Skill test setup in CLI release

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -69,6 +69,12 @@ jobs:
         working-directory: packages/cli
         run: bun run typecheck
 
+      - name: Set up native Agent test dependencies
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.5"
+          python-version: "3.12"
+
       - name: Test (ephemeral internal suite)
         timeout-minutes: 20
         run: bun run --cwd packages/cli test:internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ database migration, CI, and implementation details.
 
 ### Changed
 
-- CLI 0.14.55 installs sourced Skills through Hermes and OpenClaw native
+- CLI 0.14.56 installs sourced Skills through Hermes and OpenClaw native
   capabilities, preserving supporting files and recovering interrupted changes.
 - CLI 0.14.54 delivers native BYOK credentials through OpenClaw configuration
   commands and Hermes authentication APIs while preserving agent model choices.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.55",
+      "version": "0.14.56",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.55",
+	"version": "0.14.56",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
The CLI 0.14.55 publish run stopped before artifact creation because the real Hermes tests require uv, which was configured in client CI but absent from the publishing job. Add the same pinned uv 0.12.5 and Python 3.12 setup before the release test suite. Publish the corrected source as CLI 0.14.56; no npm version is overwritten. Validation: canonical Docker CLI typecheck and 21 publish-workflow/native-Hermes tests passed (200 assertions); diff check passed. Production runtime logic is unchanged. Full PR CI is running.