### PR TITLE
perf(backend): bound search indexing and prewarm OpenAPI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,6 +113,10 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     load off the main thread so it doesn't block startup itself; if it
     finishes before the first embedding call, that call is fast.
     """
+    # Populate FastAPI's schema cache before accepting requests: its default
+    # OpenAPI endpoint otherwise generates the schema on the event loop.
+    await asyncio.to_thread(_app.openapi)
+
     background: set[asyncio.Task[None]] = set()
     whatsapp_sidecars = ConfiguredWhatsAppSidecarClientPool(
         settings.channel_whatsapp_baileys_sidecar_token.get_secret_value(),

--- a/backend/app/routes/session_events.py
+++ b/backend/app/routes/session_events.py
@@ -142,7 +142,7 @@ async def _read_upload(file: UploadFile) -> bytes:
     return data
 
 
-def _stage_missing_chunk_search_projection(
+async def _stage_missing_chunk_search_projection(
     db: AsyncSession,
     session: Session,
     chunk: SessionEventChunk,
@@ -150,7 +150,7 @@ def _stage_missing_chunk_search_projection(
 ) -> bool:
     if chunk.search_indexed_at is not None:
         return False
-    stage_event_search_messages(
+    await stage_event_search_messages(
         db,
         user_id=session.user_id,
         session_id=session.id,
@@ -344,19 +344,19 @@ async def upload_session_event_generation_chunk(
             or existing.result_head_hash != validated.result_head_hash
         ):
             raise HTTPException(status.HTTP_409_CONFLICT, "Event chunk identity conflict")
-        if _stage_missing_chunk_search_projection(
-            db,
-            session,
-            existing,
-            validated.events,
-        ):
-            try:
+        try:
+            if await _stage_missing_chunk_search_projection(
+                db,
+                session,
+                existing,
+                validated.events,
+            ):
                 await db.commit()
-            except IntegrityError as exc:
-                await db.rollback()
-                raise HTTPException(
-                    status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
-                ) from exc
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
+            ) from exc
         return SessionEventChunkResponse(
             generation=generation_id,
             start_seq=existing.start_seq,
@@ -386,14 +386,14 @@ async def upload_session_event_generation_chunk(
             search_indexed_at=datetime.now(UTC),
         )
     )
-    stage_event_search_messages(
-        db,
-        user_id=session.user_id,
-        session_id=session.id,
-        generation_id=generation_id,
-        events=validated.events,
-    )
     try:
+        await stage_event_search_messages(
+            db,
+            user_id=session.user_id,
+            session_id=session.id,
+            generation_id=generation_id,
+            events=validated.events,
+        )
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
@@ -602,13 +602,13 @@ async def append_session_events(
         ).scalar_one_or_none()
         if existing_chunk is None:
             raise HTTPException(status.HTTP_409_CONFLICT, "Event append chunk is missing")
-        if _stage_missing_chunk_search_projection(
-            db,
-            session,
-            existing_chunk,
-            validated.events,
-        ):
-            try:
+        try:
+            if await _stage_missing_chunk_search_projection(
+                db,
+                session,
+                existing_chunk,
+                validated.events,
+            ):
                 await db.flush()
                 await finalize_event_search_index(
                     db,
@@ -617,11 +617,11 @@ async def append_session_events(
                     projection_complete=await event_search_projection_complete(db, generation),
                 )
                 await db.commit()
-            except IntegrityError as exc:
-                await db.rollback()
-                raise HTTPException(
-                    status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
-                ) from exc
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
+            ) from exc
         return SessionEventAppendResponse(
             generation=generation,
             revision=receipt.result_revision,
@@ -688,7 +688,7 @@ async def append_session_events(
             result_head_hash=final_head_hash,
         )
     )
-    stage_event_search_messages(
+    await stage_event_search_messages(
         db,
         user_id=session.user_id,
         session_id=session.id,

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
+from itertools import batched
 from typing import Literal, Protocol
 from uuid import UUID
 
@@ -13,6 +14,7 @@ from sqlalchemy import (
     cast,
     delete,
     func,
+    insert,
     literal,
     literal_column,
     or_,
@@ -402,7 +404,7 @@ def searchable_snapshot_messages(
     return projected
 
 
-def _add_documents(
+async def _add_documents(
     db: AsyncSession,
     *,
     user_id: UUID,
@@ -411,25 +413,27 @@ def _add_documents(
     content_revision: str,
     messages: Sequence[SearchableSessionMessage],
 ) -> None:
-    db.add_all(
-        [
-            SessionMessageSearch(
-                user_id=user_id,
-                session_id=session_id,
-                generation_id=generation_id,
-                content_revision=content_revision,
-                position=message.position,
-                chunk_index=chunk_index,
-                role=message.role,
-                content=content,
-            )
-            for message in messages
-            for chunk_index, content in enumerate(session_search_chunks(message.content))
-        ]
+    documents = (
+        {
+            "user_id": user_id,
+            "session_id": session_id,
+            "generation_id": generation_id,
+            "content_revision": content_revision,
+            "position": message.position,
+            "chunk_index": chunk_index,
+            "role": message.role,
+            "content": content,
+        }
+        for message in messages
+        for chunk_index, content in enumerate(session_search_chunks(message.content))
     )
+    # Bound Python work between database awaits without creating an ORM unit
+    # of work for the entire transcript. All batches share the caller's transaction.
+    for batch in batched(documents, 500):
+        await db.execute(insert(SessionMessageSearch), list(batch))
 
 
-def stage_event_search_messages(
+async def stage_event_search_messages(
     db: AsyncSession,
     *,
     user_id: UUID,
@@ -437,7 +441,7 @@ def stage_event_search_messages(
     generation_id: UUID,
     events: Sequence[SessionEvent],
 ) -> None:
-    _add_documents(
+    await _add_documents(
         db,
         user_id=user_id,
         session_id=session_id,
@@ -480,7 +484,7 @@ async def replace_snapshot_search_index(
     await db.execute(
         delete(SessionMessageSearch).where(SessionMessageSearch.session_id == session.id)
     )
-    _add_documents(
+    await _add_documents(
         db,
         user_id=session.user_id,
         session_id=session.id,
@@ -531,7 +535,7 @@ async def rebuild_session_search_index(
     await db.execute(
         delete(SessionMessageSearch).where(SessionMessageSearch.session_id == current.id)
     )
-    _add_documents(
+    await _add_documents(
         db,
         user_id=current.user_id,
         session_id=current.id,

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -13,6 +13,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.session import Session, SessionMessageSearch
+from app.models.user import User
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     EVENT_ADAPTER,
@@ -970,6 +971,7 @@ async def test_event_search_rebuild_fences_same_head_generation_replacement(
 async def test_generation_commit_does_not_publish_an_incomplete_search_projection(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
+    seed_user: User,
 ) -> None:
     from app.models.session import SessionEventChunk
     from app.routes import session_events as event_routes
@@ -1017,6 +1019,20 @@ async def test_generation_commit_does_not_publish_an_incomplete_search_projectio
             select(SessionEventChunk).where(SessionEventChunk.generation_id == generation_id)
         )
     ).scalar_one()
+    # An inconsistent projection must retain the retry's sanitized conflict
+    # response even when inserts execute before commit.
+    chunk.search_indexed_at = None
+    await db_session.commit()
+    conflicting_retry = await client.put(
+        f"/v1/sessions/{local_id}/events/generations/{generation}/chunks/0",
+        data={"base_head_hash": EMPTY_EVENT_HEAD, "content_hash": content_hash},
+        files={"file": ("0.ndjson", data, "application/x-ndjson")},
+    )
+    assert conflicting_retry.status_code == 409, conflicting_retry.text
+    assert conflicting_retry.json() == {"detail": "Event chunk search projection conflict"}
+    await db_session.refresh(seed_user)
+    await db_session.refresh(chunk)
+    assert chunk.search_indexed_at is None
     await db_session.execute(
         delete(SessionMessageSearch).where(SessionMessageSearch.generation_id == generation_id)
     )

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import httpx
 import pytest
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.query_utils import search_excerpt, search_highlight_terms, search_terms
@@ -381,6 +382,59 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     await db_session.commit()
     rebuilt = (await client.get("/v1/sessions", params={"q": "authoritative"})).json()
     assert [item["local_session_id"] for item in rebuilt["items"]] == [local_id]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_search_batches_preserve_rows_and_rollback_together(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    env_id = await _register_env(client)
+    session_id = await _push_session(client, env_id, local_session_id="batched-search")
+    session = await db_session.get(Session, UUID(session_id))
+    assert session is not None
+    messages = [
+        SearchableSessionMessage(
+            position=position,
+            role="user" if position % 2 == 0 else "assistant",
+            content=f"searchable message {position}",
+        )
+        for position in range(1001)
+    ]
+    original_hash, replacement_hash = "a" * 64, "b" * 64
+    session.content_hash = original_hash
+    await replace_snapshot_search_index(db_session, session, original_hash, messages)
+    await db_session.commit()
+
+    # A duplicate in the last batch must roll back both the earlier inserts
+    # and deletion of the previously active revision.
+    with pytest.raises(IntegrityError):
+        async with db_session.begin_nested():
+            session.content_hash = replacement_hash
+            await replace_snapshot_search_index(
+                db_session, session, replacement_hash, [*messages, messages[0]]
+            )
+    await db_session.refresh(session)
+    assert session.content_hash == original_hash
+    assert session.search_index_revision == f"snapshot:{original_hash}"
+    rows = (
+        await db_session.execute(
+            select(
+                SessionMessageSearch.position,
+                SessionMessageSearch.role,
+                SessionMessageSearch.content,
+                SessionMessageSearch.chunk_index,
+                SessionMessageSearch.generation_id,
+                SessionMessageSearch.content_revision,
+            )
+            .where(SessionMessageSearch.session_id == session.id)
+            .order_by(SessionMessageSearch.position)
+        )
+    ).all()
+    assert rows == [
+        (message.position, message.role, message.content, 0, None, session.search_index_revision)
+        for message in messages
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -19,11 +19,21 @@ from app.routes.channel_routers import discord, whatsapp
 
 
 @pytest.mark.asyncio
-async def test_openapi_available(client: httpx.AsyncClient):
-    """App boots and the OpenAPI schema is reachable."""
-    r = await client.get("/openapi.json")
-    assert r.status_code == 200
-    assert "paths" in r.json()
+async def test_openapi_available(client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch):
+    """Startup populates the same schema cache served by the public endpoint."""
+    monkeypatch.setattr(app, "openapi_schema", None)
+    async with app.router.lifespan_context(app):
+        schema = app.openapi_schema
+        assert schema is not None
+
+        def unexpected_generation(**_kwargs: object) -> None:
+            pytest.fail("OpenAPI must already be generated before serving requests")
+
+        monkeypatch.setattr("fastapi.applications.get_openapi", unexpected_generation)
+        r = await client.get("/openapi.json")
+        assert r.status_code == 200
+        assert "paths" in r.json()
+        assert r.json() == schema
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Large session uploads constructed and flushed every search document as an ORM object on the event loop; first OpenAPI requests also generated the schema synchronously. Bulk-insert search mappings in batches of 500 within the caller's existing transaction, and populate FastAPI's native OpenAPI cache before startup completes. Keep AsyncSession on its owning thread and preserve rollback, event conflict responses and schema/root-path behavior.

In isolated Python 3.14.7/PostgreSQL 18.4 synthetic tests, 60000-message uploads fell from a 15.51s median to 13.00s, worst loop stalls from 2467ms to 296ms, and worst concurrent health responses from 2.50s to 342ms. First OpenAPI reads fell from 1.94s to 11ms with identical content; generation cost moves to startup. These measurements do not attribute historical production requests or cover remote object-storage latency.

Final baseline 889c7e766: 2688 backend tests passed, 7 skipped; 87 focused tests passed. Ruff, compilation, dependency governance, type gates and generated-client checks passed with Bun 1.4.0. Production typing has zero diagnostics. Root reviewed the actual patch and verified an unchanged range-diff after rebase. Six files only; no migration or capacity changes.
