### PR TITLE
Simplify provider setup and retain brand icons

### DIFF
--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -125,6 +125,17 @@ test("popular BYOK providers have branded icons and credential-only product setu
 		).toBeVisible();
 		await expect(dialog.getByText("Choose and manage models inside your agent.")).toHaveCount(0);
 		await expect(dialog.getByText("Encrypted at rest and never shown again.")).toHaveCount(0);
+		const credentialInput = dialog.getByLabel(choice.credential, { exact: true });
+		await expect(credentialInput).toHaveAttribute(
+			"placeholder",
+			choice.credential === "API key" ? "Enter API key" : "Enter access token",
+		);
+		await expect(
+			dialog.getByRole("button", {
+				name: choice.credential === "API key" ? "Show API key" : "Show access token",
+				exact: true,
+			}),
+		).toBeVisible();
 		await dialog.screenshot({ path: testInfo.outputPath(`provider-setup-${choice.id}.png`) });
 		if (choice.product) {
 			await dialog.getByRole("combobox", { name: "Product", exact: true }).click();

--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -120,6 +120,12 @@ test("popular BYOK providers have branded icons and credential-only product setu
 	]) {
 		await dialog.getByRole("textbox", { name: "Search providers" }).fill(choice.query);
 		await dialog.getByRole("button", { name: new RegExp(`^${choice.name}`) }).click();
+		await expect(
+			dialog.locator('[data-slot="dialog-title"] svg[data-icon-source="lobehub"]'),
+		).toBeVisible();
+		await expect(dialog.getByText("Choose and manage models inside your agent.")).toHaveCount(0);
+		await expect(dialog.getByText("Encrypted at rest and never shown again.")).toHaveCount(0);
+		await dialog.screenshot({ path: testInfo.outputPath(`provider-setup-${choice.id}.png`) });
 		if (choice.product) {
 			await dialog.getByRole("combobox", { name: "Product", exact: true }).click();
 			await page.getByRole("option", { name: choice.product, exact: true }).click();

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -5,11 +5,12 @@ import { nativeAiProvider } from "@clawdi/shared";
 import { ArrowLeft, CircleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { EntityIcon } from "@/components/entity-icon";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
-	DialogDescription,
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
@@ -458,7 +459,6 @@ export function AddProviderDialog({
 			.catch(() => null);
 		if (!result || dialogSession !== dialogSessionRef.current) return;
 		setDraftTestResult(result);
-		if (result.ok) toast.success("Connection verified");
 	}
 
 	function requestClose(next: boolean) {
@@ -494,24 +494,6 @@ export function AddProviderDialog({
 		oauthDeviceStart.isPending ||
 		oauthDevicePoll.isPending;
 
-	function setupDescription(): string {
-		if (renderedOAuth)
-			return "Open ChatGPT, enter the one-time code, and this page will finish automatically.";
-		if (step === "choose" && !isEdit) return "Choose a common provider or bring a custom endpoint.";
-		if (isOAuthEdit)
-			return "Subscription access is ready. Reconnect only to change or repair the account.";
-		if (form.authMethod === "oauth") return "Sign in with ChatGPT to connect your account.";
-		if (nativeConnection) {
-			if (isEdit && savedCredentialAvailable) return "Update the credential for this connection.";
-			return `Connect using your ${(selectedPreset?.credential_label ?? "API key").toLowerCase()}.`;
-		}
-		if (isEdit)
-			return editing?.auth.type === "none"
-				? "Enter an API key to finish setup. Optional provider details are in Advanced."
-				: "Update this provider. Enter a new API key only if you want to replace it.";
-		return "Enter the credential and connection details for this custom endpoint.";
-	}
-
 	return (
 		<Dialog open={open} onOpenChange={requestClose} onOpenChangeComplete={completeOpenChange}>
 			<DialogContent
@@ -520,19 +502,34 @@ export function AddProviderDialog({
 				className="flex max-h-[min(92vh,calc(100dvh-1rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
 			>
 				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
-					<DialogTitle>
-						{renderedOAuth
-							? "Sign in with ChatGPT"
-							: isEdit
-								? (editing?.readiness?.deployable ?? editing?.usable) &&
-									editing.auth.type !== "none"
-									? "Edit provider"
-									: "Finish provider setup"
-								: step === "choose"
-									? "Add a provider"
-									: `Set up ${providerLabel}`}
+					<DialogTitle className="flex min-w-0 items-center gap-3">
+						{step === "configure" || isEdit || renderedOAuth ? (
+							<span aria-hidden="true">
+								<EntityIcon
+									kind="provider"
+									id={
+										renderedOAuth || form.authMethod === "oauth"
+											? "openai"
+											: (selectedPreset?.id ?? form.type)
+									}
+									label={providerLabel}
+									size="md"
+								/>
+							</span>
+						) : null}
+						<span className="min-w-0 break-words">
+							{renderedOAuth
+								? "Sign in with ChatGPT"
+								: isEdit
+									? (editing?.readiness?.deployable ?? editing?.usable) &&
+										editing.auth.type !== "none"
+										? `Edit ${providerLabel}`
+										: `Finish ${providerLabel} setup`
+									: step === "choose"
+										? "Add a provider"
+										: `Set up ${providerLabel}`}
+						</span>
 					</DialogTitle>
-					<DialogDescription>{setupDescription()}</DialogDescription>
 				</DialogHeader>
 
 				<div
@@ -553,12 +550,21 @@ export function AddProviderDialog({
 					) : (
 						<div className="flex flex-col gap-3">
 							{!providerListReady ? (
-								<div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
-									<CircleAlert className="mt-0.5 size-3.5 shrink-0" />
-									{providers.isLoading
-										? "Providers are still loading."
-										: "Providers couldn't be loaded. Refresh and try again."}
-								</div>
+								providers.isLoading ? (
+									<div
+										className="flex items-center gap-2 text-sm text-muted-foreground"
+										role="status"
+									>
+										<Spinner className="size-4" /> Loading providers…
+									</div>
+								) : (
+									<Alert variant="destructive">
+										<CircleAlert />
+										<AlertDescription>
+											Providers couldn’t be loaded. Refresh and try again.
+										</AlertDescription>
+									</Alert>
+								)
 							) : null}
 							<ProviderFieldsForm
 								nativeConnection={nativeConnection}
@@ -599,18 +605,13 @@ export function AddProviderDialog({
 								startingOAuth={oauthDeviceStart.isPending}
 							/>
 							{draftTestResult ? (
-								<div
-									aria-live="polite"
-									className={
-										draftTestResult.ok
-											? "rounded-md border border-success/30 bg-success-muted p-3 text-xs text-success"
-											: "rounded-md border border-warning/30 bg-warning-muted p-3 text-xs text-warning-muted-foreground"
-									}
-								>
-									{draftTestResult.ok
-										? "Connection verified. The provider accepted the test request."
-										: providerConnectionIssueMessage(draftTestResult.error)}
-								</div>
+								<Alert role="status" variant={draftTestResult.ok ? "default" : "destructive"}>
+									<AlertDescription>
+										{draftTestResult.ok
+											? "Connection verified"
+											: providerConnectionIssueMessage(draftTestResult.error)}
+									</AlertDescription>
+								</Alert>
 							) : null}
 						</div>
 					)}

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -504,7 +504,7 @@ export function AddProviderDialog({
 				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
 					<DialogTitle className="flex min-w-0 items-center gap-3">
 						{step === "configure" || isEdit || renderedOAuth ? (
-							<span aria-hidden="true">
+							<span aria-hidden="true" className="shrink-0">
 								<EntityIcon
 									kind="provider"
 									id={

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -50,11 +50,7 @@ export function ModelBindingPicker({
 		(item) => item.provider_id === primaryProviderChoice || item.id === primaryProviderChoice,
 	);
 	if (primaryProviderChoice !== MANAGED_AI_CHOICE && !provider) return null;
-	if (provider?.configuration_mode === "native") {
-		return (
-			<p className="text-sm text-muted-foreground">Choose and manage models inside your agent.</p>
-		);
-	}
+	if (provider?.configuration_mode === "native") return null;
 	const catalogInputId = `${idPrefix}-catalog-model`;
 	const modelInputId = `${idPrefix}-primary-model`;
 	const modelListId = `${idPrefix}-model-options`;

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -91,6 +91,7 @@ export function ProviderFieldsForm({
 	const apiModes = meta.apiModes;
 	const regions = preset?.region_variants ?? [];
 	const credentialLabel = preset?.credential_label ?? "API key";
+	const credentialName = credentialLabel === "API key" ? "API key" : credentialLabel.toLowerCase();
 	const isCustomEndpoint = meta.custom === true && preset === null;
 	const showPrimaryName = isCustomEndpoint;
 	const showAdvancedName = preset !== null || (!showPrimaryName && isEdit);
@@ -195,7 +196,20 @@ export function ProviderFieldsForm({
 				</div>
 			) : form.authMethod === "api_key" ? (
 				<div className="flex flex-col gap-1.5">
-					<Label htmlFor="provider-key">{credentialLabel}</Label>
+					<div className="flex items-center justify-between gap-2">
+						<Label htmlFor="provider-key">{credentialLabel}</Label>
+						{apiKeyUrl ? (
+							<a
+								href={apiKeyUrl}
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-primary hover:underline"
+							>
+								{preset?.credential_link_label ?? `Get ${credentialName}`}{" "}
+								<ExternalLink className="size-3" aria-hidden="true" />
+							</a>
+						) : null}
+					</div>
 					<InputGroup>
 						<InputGroupInput
 							id="provider-key"
@@ -205,7 +219,7 @@ export function ProviderFieldsForm({
 							placeholder={
 								isEdit && savedCredentialAvailable
 									? "Leave blank to keep current credential"
-									: `Enter ${credentialLabel.toLowerCase()}`
+									: `Enter ${credentialName}`
 							}
 							autoComplete="off"
 							autoCapitalize="none"
@@ -216,7 +230,7 @@ export function ProviderFieldsForm({
 							<InputGroupButton
 								size="icon-xs"
 								onClick={() => setApiKeyVisible((visible) => !visible)}
-								aria-label={`${apiKeyVisible ? "Hide" : "Show"} ${credentialLabel.toLowerCase()}`}
+								aria-label={`${apiKeyVisible ? "Hide" : "Show"} ${credentialName}`}
 								aria-pressed={apiKeyVisible}
 							>
 								{apiKeyVisible ? <EyeOff /> : <Eye />}
@@ -227,17 +241,6 @@ export function ProviderFieldsForm({
 						<p className="text-xs text-muted-foreground">
 							Testing sends one minimal inference request and may incur a small provider charge.
 						</p>
-					) : null}
-					{apiKeyUrl ? (
-						<a
-							href={apiKeyUrl}
-							target="_blank"
-							rel="noreferrer"
-							className="inline-flex w-fit items-center gap-1 text-xs font-medium text-primary hover:underline"
-						>
-							{preset?.credential_link_label ?? `Get ${credentialLabel.toLowerCase()}`}{" "}
-							<ExternalLink className="size-3" />
-						</a>
 					) : null}
 				</div>
 			) : null}

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -186,9 +186,7 @@ export function ProviderFieldsForm({
 					<UserRound className="size-4 shrink-0 text-muted-foreground" />
 					<div className="min-w-0 flex-1">
 						<p className="text-sm font-medium">ChatGPT sign-in</p>
-						<p className="text-xs text-muted-foreground">
-							Subscription access. Reconnect only to change or repair the account.
-						</p>
+						<p className="text-xs text-muted-foreground">Subscription access</p>
 					</div>
 					<Button variant="outline" size="sm" onClick={onReconnectOAuth} disabled={startingOAuth}>
 						{startingOAuth ? <Spinner /> : <RefreshCw />}
@@ -213,7 +211,6 @@ export function ProviderFieldsForm({
 							autoCapitalize="none"
 							autoCorrect="off"
 							spellCheck={false}
-							aria-describedby="provider-key-help"
 						/>
 						<InputGroupAddon align="inline-end">
 							<InputGroupButton
@@ -226,18 +223,6 @@ export function ProviderFieldsForm({
 							</InputGroupButton>
 						</InputGroupAddon>
 					</InputGroup>
-					<p id="provider-key-help" className="text-xs text-muted-foreground">
-						{isEdit
-							? editing?.auth.type === "none"
-								? `Enter ${credentialLabel.toLowerCase()} to finish setup.`
-								: "Leave blank to keep the current credential."
-							: "Encrypted at rest and never shown again."}
-					</p>
-					{meta.oauth ? (
-						<p className="text-xs text-muted-foreground">
-							OpenAI bills API key usage through your Platform account at standard API rates.
-						</p>
-					) : null}
 					{!nativeConnection ? (
 						<p className="text-xs text-muted-foreground">
 							Testing sends one minimal inference request and may incur a small provider charge.
@@ -255,15 +240,8 @@ export function ProviderFieldsForm({
 						</a>
 					) : null}
 				</div>
-			) : (
-				<div className="rounded-lg border bg-muted/30 p-3 text-sm">
-					You’ll finish setup on ChatGPT. No API key is required here.
-				</div>
-			)}
-
-			{nativeConnection ? (
-				<p className="text-sm text-muted-foreground">Choose and manage models inside your agent.</p>
 			) : null}
+
 			{onUseNative ? (
 				<Button variant="outline" onClick={onUseNative}>
 					Manage models in the agent


### PR DESCRIPTION
Provider setup repeated explanatory text instead of focusing on the credential fields, and the selected provider lost its logo after the chooser. Remove the repeated setup, encryption, and model-management copy; show the shared EntityIcon in setup/edit/OAuth titles and identify the provider in edit titles. Native model bindings render no placeholder message. Credential links sit at the right of the label row, and API stays capitalized in link, placeholder, and visibility-button copy.

Use the existing Alert and Spinner components for connection/loading feedback, retain actionable credential links and edit placeholders, and avoid duplicate success toasts. No provider contract or runtime behavior changes.

Validation: isolated Docker Web typecheck and 75 provider tests passed; all three existing browser flows passed, including light/dark icons, mobile setup logos, and credential-only submission. Setup screenshots reviewed. Locked Biome and diff checks passed.
