### PR TITLE
fix(web): preserve production SSR module initialization order

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -180,6 +180,9 @@ jobs:
             exit 2
           fi
           bunx turbo typecheck build "${filters[@]}" --output-logs=errors-only
+      - name: Production SSR public routes
+        if: needs.changes.outputs.web == 'true'
+        run: bun run --cwd apps/web test:ssr:internal
       - name: Set up native Agent test dependencies
         if: needs.changes.outputs.cli == 'true'
         uses: astral-sh/setup-uv@v10.0.1

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
 		"lint": "biome ci --linter-enabled=true --formatter-enabled=false src",
 		"test": "../../scripts/test.sh web",
 		"test:internal": "bun test",
+		"test:ssr:internal": "node --test --test-timeout=180000 scripts/production-ssr.mjs",
 		"e2e": "playwright test",
 		"e2e:hosted": "playwright test --config=playwright.hosted.config.ts",
 		"generate-api": "../../scripts/openapi-typescript.sh http://localhost:8000/openapi.json -o ../../packages/shared/src/api/api.generated.ts",

--- a/apps/web/scripts/production-ssr.mjs
+++ b/apps/web/scripts/production-ssr.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { after, mock, test } from "node:test";
+
+// Exercise the deployed bundle graph with real Clerk middleware and providers.
+// These syntactically valid fixture keys do not belong to a Clerk tenant.
+for (const key of Object.keys(process.env)) {
+	if (/^(VITE_|CLERK_|SENTRY_|VERCEL(?:_|$))/.test(key)) delete process.env[key];
+}
+Object.assign(process.env, {
+	NODE_ENV: "production",
+	CI: "1",
+	VERCEL: "1",
+	VERCEL_ENV: "production",
+	NITRO_PRESET: "vercel",
+	VITE_CLAWDI_HOSTED: "true",
+	VITE_DEV_AUTH_BYPASS: "false",
+	VITE_CLERK_PUBLISHABLE_KEY: "pk_test_c3NyLmNsZXJrLmFjY291bnRzLmRldiQ=",
+});
+
+execFileSync("bun", ["run", "build"], {
+	cwd: new URL("../", import.meta.url),
+	stdio: "pipe",
+	timeout: 120_000,
+	maxBuffer: 10 * 1024 * 1024,
+});
+
+process.env.CLERK_SECRET_KEY = "sk_test_ssr_fixture";
+process.env.CLERK_TELEMETRY_DISABLED = "1";
+const network = mock.method(globalThis, "fetch", () => {
+	throw new Error("Public signed-out SSR must not need an external service");
+});
+const { default: server } = await import("../.vercel/output/functions/__server.func/index.mjs");
+
+after(() => {
+	assert.equal(network.mock.calls.length, 0, "SSR attempted an external request");
+});
+
+function request(path) {
+	return new Request(`http://localhost:3100${path}`, {
+		headers: { "user-agent": "Mozilla/5.0" },
+	});
+}
+
+for (const [path, title] of [
+	["/sign-in", "Sign in"],
+	["/sign-in/factor-one", "Sign in"],
+	["/sign-up", "Sign up"],
+	["/sign-up/verify-email-address", "Sign up"],
+]) {
+	test(`production SSR renders ${path} with Clerk`, async () => {
+		const response = await server.fetch(request(path));
+		const html = await response.text();
+		assert.equal(response.status, 200, html);
+		assert.match(response.headers.get("content-type"), /text\/html/);
+		assert.ok(html.includes(`<title>${title} · Clawdi</title>`));
+		assert.match(html, /window\.__clerk_init_state = /);
+		assert.match(html, /"isAuthenticated":false/);
+		assert.match(html, /<\/body><\/html>$/);
+	});
+}
+
+for (const path of ["/", "/agents"]) {
+	test(`production SSR protects ${path} without auth bypass`, async () => {
+		const response = await server.fetch(request(path));
+		assert.equal(response.status, 307);
+		assert.equal(
+			response.headers.get("location"),
+			`/sign-in?redirect_url=${encodeURIComponent(path)}`,
+		);
+		assert.equal(await response.text(), "");
+	});
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -47,7 +47,13 @@ export default defineConfig(({ mode }) => {
 					client: { specifiers: ["@clerk/tanstack-react-start/server"] },
 				},
 			}),
-			nitro(),
+			nitro({
+				rolldownConfig: {
+					// Server chunks must initialize dependencies before Clerk captures
+					// its provider exports, even when chunking introduces a cycle.
+					output: { strictExecutionOrder: true },
+				},
+			}),
 			tailwindcss(),
 			viteReact(),
 			...sentryPlugins,

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -48,6 +48,12 @@ generated route tree stays current. The public package `test` command routes
 through the Docker-backed clean runner; `test:internal` is reserved for that
 runner and CI.
 
+The clean runner also builds the hosted Vercel production bundle and executes
+its server entry with auth bypass off and synthetic Clerk keys. It checks
+sign-in/sign-up HTML and protected-route redirects without external requests.
+Client CI runs the same `test:ssr:internal` check. This catches server chunk
+initialization failures that the Vite dev-server E2E suite cannot detect.
+
 For broader changes, run the full web test suite:
 
 ```bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -123,6 +123,7 @@ web_tests() {
 
 web_build() {
 	bun run --cwd apps/web build:oss
+	bun run --cwd apps/web test:ssr:internal
 }
 
 cli_typecheck() {


### PR DESCRIPTION
Production sign-in returned HTTP 500 after Nitro split the server bundle into circular chunks. Clerk's InternalClerkProvider captured an uninitialized provider export, causing root-provider SSR to fail even though the build succeeded. Enable Rolldown's strictExecutionOrder for Nitro's server output so source-module initialization order is preserved across chunks.

Add a production Vercel-bundle regression check with auth bypass disabled, real Clerk middleware/providers, synthetic keys, and no external fetches. It verifies sign-in/sign-up HTML (including nested auth routes) and signed-out redirects for protected pages. Run it in Client CI and the Docker-backed web clean runner. Auth behavior and resource UI remain unchanged.

Validation: under the same Bun 1.3.14/Vercel production conditions, known-good 889c7e766 returned 200, acbcdd9e reproduced 500, and strict execution order restored 200. The new check fails four public-route cases before the fix and passes all six cases after it. Clean Bun 1.4.0 Docker checks passed: typecheck, 29 related tests, OSS build, production SSR, Biome, and five clean-runner contracts. Client output is byte-identical; server JavaScript grows approximately 5%. The patch was rebased onto current main 4f83735ea without conflicts; CI and actual protected Vercel preview verification gate publication.

Production was rolled back while this forward fix was verified. No database or backend changes, no auth bypass enabled in the product, and no CLI release.

Release verification: production at https://cloud.clawdi.ai now serves `39a57019cc2371649712efefefdd3e44ec3c28c1`, including resource UI #1410 and SSR fix #1415. The production deployment completed successfully; sign-in and sign-up return 200 with real Clerk SSR, signed-out Agents requests redirect to sign-in, and Cloud API health returns 200. No error logs were found in the bounded check of the new deployment.
