### PR TITLE
Fix production auth SSR initialization across server chunks

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -180,6 +180,9 @@ jobs:
             exit 2
           fi
           bunx turbo typecheck build "${filters[@]}" --output-logs=errors-only
+      - name: Smoke production authentication SSR
+        if: needs.changes.outputs.web == 'true'
+        run: bun run --cwd apps/web test:auth-ssr
       - name: Set up native Agent test dependencies
         if: needs.changes.outputs.cli == 'true'
         uses: astral-sh/setup-uv@v10.0.1

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
 		"lint": "biome ci --linter-enabled=true --formatter-enabled=false src",
 		"test": "../../scripts/test.sh web",
 		"test:internal": "bun test",
+		"test:auth-ssr": "node scripts/test-auth-ssr.mjs",
 		"e2e": "playwright test",
 		"e2e:hosted": "playwright test --config=playwright.hosted.config.ts",
 		"generate-api": "../../scripts/openapi-typescript.sh http://localhost:8000/openapi.json -o ../../packages/shared/src/api/api.generated.ts",

--- a/apps/web/scripts/test-auth-ssr.mjs
+++ b/apps/web/scripts/test-auth-ssr.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const cwd = fileURLToPath(new URL("..", import.meta.url));
+const environment = {
+	...process.env,
+	NODE_ENV: "production",
+	NITRO_PRESET: "node-server",
+	VITE_CLAWDI_HOSTED: "true",
+	VITE_DEV_AUTH_BYPASS: "false",
+	VITE_CLERK_PUBLISHABLE_KEY: "pk_test_Y2xlcmsuZXhhbXBsZS50ZXN0JA==",
+	CLERK_SECRET_KEY: "sk_test_fixture",
+	CLERK_TELEMETRY_DISABLED: "1",
+	VITE_CLAWDI_API_URL: "http://127.0.0.1:9",
+	VITE_CLAWDI_DEPLOY_API_URL: "http://127.0.0.1:9",
+	SENTRY_AUTH_TOKEN: "",
+};
+const build = spawnSync("bun", ["run", "build"], {
+	cwd,
+	env: environment,
+	encoding: "utf8",
+	maxBuffer: 16 * 1024 * 1024,
+	timeout: 180_000,
+});
+assert.equal(build.status, 0, build.error?.message ?? build.stderr);
+
+const reservation = createServer().listen(0, "127.0.0.1");
+await once(reservation, "listening");
+const address = reservation.address();
+assert(address && typeof address === "object");
+await new Promise((resolve) => reservation.close(resolve));
+const server = spawn(process.execPath, [".output/server/index.mjs"], {
+	cwd,
+	env: { ...environment, NITRO_HOST: "127.0.0.1", NITRO_PORT: String(address.port) },
+	stdio: ["ignore", "pipe", "pipe"],
+});
+const exited = once(server, "exit");
+let logs = "";
+for (const stream of [server.stdout, server.stderr]) {
+	stream.on("data", (chunk) => {
+		logs = (logs + chunk).slice(-64_000);
+	});
+}
+try {
+	for (const path of ["/sign-in", "/sign-up"]) {
+		let response;
+		for (let attempt = 0; attempt < 50; attempt++) {
+			try {
+				response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+					redirect: "manual",
+					signal: AbortSignal.timeout(5_000),
+				});
+				break;
+			} catch (error) {
+				if (server.exitCode !== null || attempt === 49) throw error;
+				await delay(100);
+			}
+		}
+		assert.equal(response?.status, 200, `${path} SSR failed:\n${logs}`);
+		assert.match(
+			await response.text(),
+			/window\.__clerk_init_state/,
+			"Clerk SSR must render without an auth bypass",
+		);
+		console.log(`${path}: production Clerk SSR passed`);
+	}
+} finally {
+	server.kill("SIGTERM");
+	const deadline = setTimeout(() => server.kill("SIGKILL"), 5_000);
+	await exited;
+	clearTimeout(deadline);
+}

--- a/apps/web/scripts/test-auth-ssr.mjs
+++ b/apps/web/scripts/test-auth-ssr.mjs
@@ -18,6 +18,7 @@ const environment = {
 	VITE_CLAWDI_API_URL: "http://127.0.0.1:9",
 	VITE_CLAWDI_DEPLOY_API_URL: "http://127.0.0.1:9",
 	SENTRY_AUTH_TOKEN: "",
+	VITE_SENTRY_DSN: "",
 };
 const build = spawnSync("bun", ["run", "build"], {
 	cwd,
@@ -39,6 +40,17 @@ const server = spawn(process.execPath, [".output/server/index.mjs"], {
 	stdio: ["ignore", "pipe", "pipe"],
 });
 const exited = once(server, "exit");
+let shutdownDeadline;
+function stopServer() {
+	server.kill("SIGTERM");
+	shutdownDeadline ??= setTimeout(() => server.kill("SIGKILL"), 5_000);
+}
+function cancel() {
+	process.exitCode = 1;
+	stopServer();
+}
+process.once("SIGINT", cancel);
+process.once("SIGTERM", cancel);
 let logs = "";
 for (const stream of [server.stdout, server.stderr]) {
 	stream.on("data", (chunk) => {
@@ -69,8 +81,12 @@ try {
 		console.log(`${path}: production Clerk SSR passed`);
 	}
 } finally {
-	server.kill("SIGTERM");
-	const deadline = setTimeout(() => server.kill("SIGKILL"), 5_000);
-	await exited;
-	clearTimeout(deadline);
+	stopServer();
+	try {
+		await exited;
+	} finally {
+		clearTimeout(shutdownDeadline);
+		process.off("SIGINT", cancel);
+		process.off("SIGTERM", cancel);
+	}
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -47,7 +47,11 @@ export default defineConfig(({ mode }) => {
 					client: { specifiers: ["@clerk/tanstack-react-start/server"] },
 				},
 			}),
-			nitro(),
+			nitro({
+				// Keep SDK initialization ordered across generated server chunks.
+				// Clerk's internal Provider alias otherwise captures an uninitialized export.
+				rolldownConfig: { output: { strictExecutionOrder: true } },
+			}),
 			tailwindcss(),
 			viteReact(),
 			...sentryPlugins,


### PR DESCRIPTION
Superseded by #1415, which independently landed the same strict execution-order fix and a production SSR regression. Closing this duplicate rather than adding a second smoke test.

Production `cloud.clawdi.ai` was independently verified at `39a57019cc2371649712efefefdd3e44ec3c28c1`, including UI #1414. Sign-in/sign-up return 200 with Clerk SSR, and the served provider setup asset contains the new label-row layout and no removed boilerplate. The temporary preview-access credential created during diagnosis was revoked.

Production `/sign-in` returned 500 after otherwise green development/browser checks. The generated server chunks formed a cycle: Clerk's internal provider alias captured an imported `ClerkProvider` before its initialization, leaving React to render `undefined`. The previous production deployment was restored immediately.

Enable Rolldown's documented `strictExecutionOrder` option in Nitro's server build so module initialization follows source order across chunks. This adds server initialization wrappers but requires no new dependencies, SDK copies, auth bypass, or manual chunk layout. Add a CI smoke that builds the real production app with synthetic Clerk keys, starts its server, and verifies `/sign-in` and `/sign-up` render Clerk SSR without the development auth bypass.

Validation: reproduced the exact 500 in isolated Docker before the fix. Fresh Docker with frozen dependencies passed Web typecheck, both production SSR requests, and 9 focused auth/provider regressions (226 assertions). Locked Biome and diff checks passed. The synthetic server and temporary containers are bounded and cleaned up.

Reference: https://rolldown.rs/reference/OutputOptions.strictExecutionOrder (verified against locked Rolldown 1.2.5 and Nitro 3.0.260610-beta).
