### PR TITLE
fix(sync): own SSE child cleanup through request cancellation

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -138,31 +138,31 @@ for observed_engine in (engine, control_engine, control_snapshot_engine):
     event.listen(observed_engine.sync_engine.pool, "checkin", _connection_checkin)
 
 
-async def _close_resource(close: Callable[[], Coroutine[object, object, None]]) -> None:
-    """Return the connection before propagating request cancellation."""
-    close_task = asyncio.create_task(close())
+async def finish_cleanup(cleanup: Callable[[], Coroutine[object, object, None]]) -> None:
+    """Finish owned cleanup before propagating request cancellation."""
+    cleanup_task = asyncio.create_task(cleanup())
     cancellation: asyncio.CancelledError | None = None
 
     with anyio.CancelScope(shield=True):
-        while not close_task.done():
+        while not cleanup_task.done():
             try:
-                await asyncio.shield(close_task)
+                await asyncio.shield(cleanup_task)
             except asyncio.CancelledError as exc:
                 cancellation = exc
             except Exception as exc:
                 if cancellation is None:
                     raise
 
-                log.exception("Database resource cleanup failed during request cancellation")
+                log.exception("Cleanup failed during request cancellation")
                 raise cancellation from exc
 
     try:
-        close_task.result()
+        cleanup_task.result()
     except Exception as exc:
         if cancellation is None:
             raise
 
-        log.exception("Database resource cleanup failed during request cancellation")
+        log.exception("Cleanup failed during request cancellation")
         raise cancellation from exc
 
     if cancellation is not None:
@@ -171,7 +171,7 @@ async def _close_resource(close: Callable[[], Coroutine[object, object, None]]) 
 
 class _CancellationSafeAsyncSession(AsyncSession):
     async def close(self) -> None:
-        await _close_resource(super().close)
+        await finish_cleanup(super().close)
 
     async def __aexit__(self, type_: object, value: object, traceback: object) -> None:
         await self.close()
@@ -238,7 +238,7 @@ async def _reserved_connection() -> AsyncGenerator[AsyncConnection, None]:
     try:
         yield connection
     finally:
-        await _close_resource(connection.close)
+        await finish_cleanup(connection.close)
 
 
 async def get_runtime_manifest_sessions() -> AsyncGenerator[RuntimeManifestSessions, None]:
@@ -310,7 +310,7 @@ async def runtime_snapshot_session(
         await _configure_runtime_snapshot(session)
         yield session
     finally:
-        await _close_resource(session.close)
+        await finish_cleanup(session.close)
 
 
 async def _configure_runtime_snapshot(session: AsyncSession) -> None:

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -47,7 +47,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_scope_short_session
-from app.core.database import async_session_factory
+from app.core.database import async_session_factory, finish_cleanup
 from app.core.project import project_ids_visible_to
 from app.core.skill_sync_protocol import (
     SKILL_SYNC_PROTOCOL_HEADER,
@@ -126,13 +126,19 @@ async def _cancel_and_wait(*tasks: asyncio.Task[object]) -> None:
     for task in tasks:
         if not task.done():
             task.cancel()
-    await asyncio.gather(*tasks, return_exceptions=True)
-    for task in tasks:
-        if task.cancelled():
-            continue
-        failure = task.exception()
-        if failure is not None:
-            raise failure
+
+    async def collect() -> None:
+        await asyncio.gather(*tasks, return_exceptions=True)
+        for task in tasks:
+            if task.cancelled():
+                continue
+            failure = task.exception()
+            if failure is not None:
+                raise failure
+
+    # The stream owns these tasks. Repeated cancellation of the stream must
+    # not cancel their in-progress database termination a second time.
+    await finish_cleanup(collect)
 
 
 async def _refresh_subscription_lease(lease_id: UUID, close_stream: asyncio.Event) -> None:
@@ -165,17 +171,7 @@ async def _release_subscription_lease_safely(lease_id: UUID) -> None:
         except Exception as error:  # noqa: BLE001 - expiry is the crash-safe fallback
             log.warning("sync events: subscription lease release failed: %s", error)
 
-    release_task = asyncio.create_task(release())
-    cancellation: asyncio.CancelledError | None = None
-    while not release_task.done():
-        try:
-            await asyncio.shield(release_task)
-        except asyncio.CancelledError as error:
-            cancellation = error
-
-    release_task.result()
-    if cancellation is not None:
-        raise cancellation
+    await finish_cleanup(release)
 
 
 async def _stream(

--- a/backend/tests/test_asyncpg_close_timeout.py
+++ b/backend/tests/test_asyncpg_close_timeout.py
@@ -1,0 +1,114 @@
+"""Upstream reproducer: close(timeout) must cover cancellation acknowledgement."""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import asyncpg
+import pytest
+
+
+@asynccontextmanager
+async def _paused_tcp_proxy(host: str, port: int):
+    """Pause existing traffic and newly opened CancelRequest connections."""
+    gate = asyncio.Event()
+    gate.set()
+    tasks = set()
+
+    async def relay(reader, writer):
+        try:
+            while data := await reader.read(65536):
+                await gate.wait()
+                writer.write(data)
+                await writer.drain()
+            await gate.wait()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def forward(reader, writer):
+        remote_reader, remote_writer = await asyncio.open_connection(host, port)
+        await asyncio.gather(
+            relay(reader, remote_writer), relay(remote_reader, writer), return_exceptions=True
+        )
+
+    def accept(reader, writer):
+        task = asyncio.create_task(forward(reader, writer))
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+    server = await asyncio.start_server(accept, "127.0.0.1", 0)
+    try:
+        yield server.sockets[0].getsockname()[1], gate
+    finally:
+        gate.set()
+        server.close()
+        await server.wait_closed()
+        if tasks:
+            await asyncio.wait_for(asyncio.gather(*tuple(tasks)), timeout=5)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="asyncpg 0.31.0 applies close timeout only after unbounded cancellation waits",
+)
+async def test_asyncpg_close_timeout_covers_stalled_cancellation(engine):
+    # This is an unresolved upstream contract, not a guarantee of the SSE fix.
+    # See asyncpg v0.31.0 asyncpg/protocol/protocol.pyx: Protocol.close().
+    url = engine.url.set(drivername="postgresql")
+    if url.host is None:
+        pytest.skip("The TCP stall reproducer requires a TCP PostgreSQL URL")
+    observer = await asyncpg.connect(url.render_as_string(hide_password=False), ssl=False)
+    try:
+        async with _paused_tcp_proxy(url.host, url.port or 5432) as (port, gate):
+            proxied = url.set(host="127.0.0.1", port=port)
+            connection = await asyncpg.connect(
+                proxied.render_as_string(hide_password=False),
+                ssl=False,
+                server_settings={"statement_timeout": "1s"},
+            )
+            pid = connection.get_server_pid()
+            query = asyncio.create_task(connection.execute("SELECT pg_sleep(30)"))
+            close_task = None
+            try:
+                async with asyncio.timeout(5):
+                    while (
+                        await observer.fetchval(
+                            "SELECT wait_event FROM pg_stat_activity WHERE pid=$1", pid
+                        )
+                        != "PgSleep"
+                    ):
+                        await asyncio.sleep(0.01)
+                gate.clear()
+                query.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await query
+                close_task = asyncio.create_task(connection.close(timeout=0.05))
+                # Observe without cancelling close ourselves: a stalled close
+                # needs its network restored before the reproducer can clean up.
+                done, _pending = await asyncio.wait({close_task}, timeout=0.5)
+                if close_task in done:
+                    with pytest.raises(TimeoutError):
+                        await close_task
+            finally:
+                gate.set()
+                if not query.done():
+                    query.cancel()
+                await asyncio.gather(query, return_exceptions=True)
+                if close_task is not None:
+                    results = await asyncio.wait_for(
+                        asyncio.gather(close_task, return_exceptions=True), 5
+                    )
+                    outcome = results[0]
+                    if isinstance(outcome, BaseException) and not isinstance(outcome, TimeoutError):
+                        raise outcome
+                else:
+                    await connection.close(timeout=2)
+                async with asyncio.timeout(3):
+                    while await observer.fetchval(
+                        "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid=$1)", pid
+                    ):
+                        await asyncio.sleep(0.01)
+            assert close_task in done, "close(timeout=0.05) is still waiting after 0.5s"
+    finally:
+        await observer.close()

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -427,13 +427,14 @@ async def test_stream_cancellation_awaits_internal_wait_tasks(
     next_chunk = original_create_task(gen.__anext__())
     await asyncio.wait_for(internal_tasks_created.wait(), timeout=1)
     assert len(internal_tasks) == 2
+    wait_tasks = tuple(internal_tasks)
 
     next_chunk.cancel()
     with pytest.raises(asyncio.CancelledError):
         await next_chunk
 
     assert all(task.done() for task in internal_tasks)
-    assert all(task.cancelled() for task in internal_tasks)
+    assert all(task.cancelled() for task in wait_tasks)
 
 
 @pytest.mark.asyncio
@@ -532,6 +533,55 @@ async def test_cancel_and_wait_collects_pending_sibling_before_surfacing_failure
         assert sibling_task.done()
         assert sibling_task.cancelled()
         assert sibling_cleaned.is_set()
+
+
+async def test_cancel_and_wait_preserves_failure_when_parent_is_cancelled(caplog):
+    from app.routes import sync as sync_route
+
+    started = asyncio.Event()
+    cleaning = asyncio.Event()
+    release = asyncio.Event()
+    failure = RuntimeError("child cleanup failed")
+
+    async def child():
+        try:
+            started.set()
+            await asyncio.Event().wait()
+        finally:
+            cleaning.set()
+            await release.wait()
+            raise failure
+
+    child_task = asyncio.create_task(child())
+    await started.wait()
+    owner = asyncio.create_task(sync_route._cancel_and_wait(child_task))
+    try:
+        await cleaning.wait()
+        assert owner.cancel("disconnect")
+        await asyncio.sleep(0)
+        assert owner.cancel("disconnect-again")
+        await asyncio.sleep(0)
+        assert not owner.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError, match="disconnect-again") as cancelled:
+            await owner
+        assert cancelled.value.__cause__ is failure
+        assert owner.cancelling() == 2
+        assert child_task.done()
+        assert child_task.cancelling() == 1
+        assert child_task.exception() is failure
+        records = [
+            record
+            for record in caplog.records
+            if record.message == "Cleanup failed during request cancellation"
+        ]
+        assert len(records) == 1
+        info = records[0].exc_info
+        assert info is not None
+        assert info[1] is failure
+    finally:
+        release.set()
+        await asyncio.gather(owner, child_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -1227,3 +1277,158 @@ async def test_try_subscribe_caps_per_user_and_per_key(seed_user: User):
     for q, _sub in routine_handles:
         sync_events.unsubscribe(user_id, q)
     sync_events._subscribers.pop(user_id, None)
+
+
+@pytest.mark.parametrize("disconnect", ["peer", "cancel"])
+@pytest.mark.parametrize("phase", ["pre_ping", "query"])
+async def test_real_sse_disconnect_drains_database_refresh(
+    db_session: AsyncSession,
+    seed_user: User,
+    engine,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+    disconnect: str,
+    phase: str,
+):
+    """The real ASGI 2.3 stream must not forward repeated cancellation to DB cleanup."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from sqlalchemy.pool import QueuePool
+
+    from app.core import database
+    from app.main import app
+    from app.routes import sync as sync_route
+    from app.services.api_key import mint_api_key
+
+    minted = await mint_api_key(db_session, user_id=seed_user.id, label="sse-cancellation")
+    await db_session.commit()
+    refresh_engine = database._create_engine(pool_size=1, max_overflow=0)
+    pool = refresh_engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    monkeypatch.setattr(
+        sync_route,
+        "async_session_factory",
+        async_sessionmaker(refresh_engine, class_=database.async_session_factory.class_),
+    )
+    connected = asyncio.Event()
+    disconnected = asyncio.Event()
+    query_started = asyncio.Event()
+    refresh_tasks = []
+    refresh_pids = []
+    invalidation_errors = []
+    invalidation_started = asyncio.Event()
+    response_statuses = []
+    first_request = True
+
+    async def receive():
+        nonlocal first_request
+        if first_request:
+            first_request = False
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            response_statuses.append(message["status"])
+        if message.get("body") == b": connected\n\n":
+            connected.set()
+
+    def capture_query(connection, _cursor, statement, *_args):
+        if phase == "query" and connected.is_set() and "FROM api_keys" in statement:
+            task = asyncio.current_task()
+            assert task is not None
+            refresh_tasks.append(task)
+            refresh_pids.append(connection.connection.driver_connection.get_server_pid())
+            query_started.set()
+
+    def capture_invalidation(_connection, _record, _exception):
+        # Retain the traceback so GC cannot hide an unreturned pre-ping slot.
+        invalidation_errors.append(_exception)
+        invalidation_started.set()
+
+    original_ping = refresh_engine.sync_engine.dialect.do_ping
+
+    def capture_ping(connection):
+        if phase == "pre_ping" and connected.is_set():
+            task = asyncio.current_task()
+            assert task is not None
+            refresh_tasks.append(task)
+            refresh_pids.append(connection.driver_connection.get_server_pid())
+            query_started.set()
+        return original_ping(connection)
+
+    monkeypatch.setattr(refresh_engine.sync_engine.dialect, "do_ping", capture_ping)
+
+    event.listen(refresh_engine.sync_engine, "before_cursor_execute", capture_query)
+    event.listen(refresh_engine.sync_engine, "invalidate", capture_invalidation)
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/v1/sync/events",
+        "raw_path": b"/v1/sync/events",
+        "query_string": b"",
+        "headers": [(b"authorization", f"Bearer {minted.raw_key}".encode())],
+        "client": ("127.0.0.1", 1),
+        "server": ("test", 80),
+    }
+    tasks_before = asyncio.all_tasks()
+    request_task = asyncio.create_task(app(scope, receive, send))
+    try:
+        async with asyncio.timeout(8), engine.connect() as observer:
+            await connected.wait()
+            assert response_statuses == [200]
+            # Block the unmodified refresh SELECT, after auth and stream setup.
+            await db_session.execute(text("LOCK TABLE api_keys IN ACCESS EXCLUSIVE MODE"))
+            sync_events.sync_subscriptions_changed.signal(str(seed_user.id))
+            await query_started.wait()
+            pid = refresh_pids[0]
+            if phase == "query":
+                while not await observer.scalar(
+                    text("SELECT cardinality(pg_blocking_pids(:pid)) > 0"), {"pid": pid}
+                ):
+                    await observer.rollback()
+                    await asyncio.sleep(0.01)
+            if disconnect == "peer":
+                disconnected.set()
+                await request_task
+            else:
+                assert request_task.cancel("request-shutdown")
+                await invalidation_started.wait()
+                assert request_task.cancel("request-shutdown-again")
+                with pytest.raises(asyncio.CancelledError):
+                    await request_task
+            assert request_task.cancelling() == (0 if disconnect == "peer" else 2)
+            assert len(refresh_tasks) == 1
+            assert refresh_tasks[0].done()
+            assert refresh_tasks[0].cancelling() == 1
+            # Keep the table locked: successful cleanup must cancel the server
+            # query, rather than wait for it to finish after releasing the lock.
+            await observer.rollback()
+            assert not await observer.scalar(
+                text("SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid=:pid)"),
+                {"pid": pid},
+            )
+            assert not await observer.scalar(
+                text("SELECT EXISTS (SELECT 1 FROM pg_locks WHERE pid=:pid)"), {"pid": pid}
+            )
+            assert pool.checkedout() == 0
+            assert not await observer.scalar(
+                select(SyncSubscriptionLease.id).where(
+                    SyncSubscriptionLease.user_id == seed_user.id
+                )
+            )
+            async with refresh_engine.connect() as replacement:
+                assert await replacement.scalar(text("SELECT 1")) == 1
+            assert asyncio.all_tasks() <= tasks_before
+    finally:
+        await db_session.rollback()
+        disconnected.set()
+        if not request_task.done():
+            request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+        invalidation_errors.clear()
+        await refresh_engine.dispose()
+    assert not [record for record in caplog.records if record.name.startswith("sqlalchemy.pool")]

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -610,3 +610,83 @@ health/metrics listener, not an externally routed API endpoint. When running
 that process directly, or from inside its container/network namespace,
 `curl -fsS http://127.0.0.1:8000/metrics | rg 'msg_router_channel_(queue|retention)'`
 prints the queue and retention metric families.
+
+## SSE cancellation ownership
+
+The application middleware is plain ASGI. Uvicorn 0.52.4 advertises ASGI 2.3,
+so Starlette 1.6.0's `StreamingResponse` still owns an internal AnyIO task group.
+On `/v1/sync/events` disconnect, the stream cancels its visibility/lease tasks.
+Awaiting their `asyncio.gather()` directly lets repeated cancellation of the
+stream cancel those children again, including during SQLAlchemy termination.
+An AnyIO shield inside the child cannot stop cancellation forwarded by gather.
+The stream now cancels each child once and uses the existing owned-cleanup
+helper to collect it before propagating cancellation or a child failure. The
+same helper owns lease deletion, replacing its separate cancellation-drain loop.
+Failure inspection runs inside the owned collection operation. If parent
+cancellation arrives during collection, cancellation remains primary and the
+first real child failure is logged and chained as its cause. Without parent
+cancellation, that failure propagates after all siblings finish. Returning an
+exception object as a task result is not treated as raising it.
+
+```bash
+scripts/test.sh backend tests/test_sync_events.py -k 'real_sse_disconnect or stream_cancellation'
+```
+
+Done: real API-key authentication and the full application middleware run with
+ASGI 2.3, without a synthetic `BaseHTTPMiddleware`. Disconnect and repeated
+request cancellation at pre-ping/query time leave the database child with one
+cancellation request. The server query and its locks are gone before the test
+releases the blocking table lock; the lease is deleted, the local slot is
+returned, and no request-owned tasks survive. This reproduces a real route
+mechanism, not the proven causal ordering of a historical production incident.
+
+MCP's outbound transport also has AnyIO scopes, but its transport bodies do not
+execute Clawdi database queries. `tools/list` loads in a separate cached task;
+`tools/call` exits its transport context before request-dependency cleanup.
+The MCP dependency session is lazy and its close already has owned cleanup.
+No MCP-specific cancellation change is justified by the inspected lifecycle.
+
+### Remaining stalled-network requirement
+
+This route fix is **not** a finite-cleanup guarantee under a network partition.
+The pinned asyncpg 0.31.0 `Protocol.close()` waits for `cancel_sent_waiter` and
+`cancel_waiter` before applying the supplied timeout and before entering its
+transport-abort `finally`. A caller timeout cannot safely repair that lifecycle
+using the current public API alone. `Connection.terminate()` also considers a
+protocol already in closing state closed. SQLAlchemy 2.0.52's pool bookkeeping
+can separately be interrupted even by a first cancellation arriving during
+an already-running invalidation.
+No private driver/pool patch or runtime fork is installed here.
+
+```bash
+scripts/test.sh backend tests/test_asyncpg_close_timeout.py --runxfail
+```
+
+Done: the isolated TCP proxy stalls both the original stream and cancellation
+channel. On the pinned driver this intentionally fails because a 50 ms close
+is still pending at 500 ms. The test restores the network, drains both tasks,
+and checks server exit before releasing its resources. Normal test runs mark
+this exact upstream contract as a strict expected failure; setup and cleanup
+errors are not accepted as that failure.
+
+A complete finite-local-cleanup solution requires a reviewed upstream driver
+change that covers cancellation acknowledgement with the close deadline and
+aborts the transport on every exit from that phase. The shielded lease-release
+operation also needs an explicit operation budget with its existing TTL fallback
+once cancellation can actually finish locally. Pool `finally` bookkeeping alone
+does not close an orphaned driver task or transport. These changes must be reviewed
+and tested upstream before being relied on in the application.
+
+Source contracts:
+
+- [Starlette 1.6.0 StreamingResponse](https://github.com/Kludex/starlette/blob/1.6.0/starlette/responses.py)
+- [Uvicorn 0.52.4 ASGI scope](https://github.com/Kludex/uvicorn/blob/0.52.4/uvicorn/protocols/http/httptools_impl.py)
+- [asyncpg 0.31.0 protocol close](https://github.com/MagicStack/asyncpg/blob/v0.31.0/asyncpg/protocol/protocol.pyx)
+- [asyncpg 0.31.0 connection close/terminate](https://github.com/MagicStack/asyncpg/blob/v0.31.0/asyncpg/connection.py)
+- [SQLAlchemy 2.0.52 pool invalidation](https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0_52/lib/sqlalchemy/pool/base.py)
+
+Psycopg 3.3.5 is not an automatic substitute: its bounded cancel attempt is
+followed by another wait on the original operation in
+[`AsyncConnection.wait()`](https://github.com/psycopg/psycopg/blob/3.3.5/psycopg/psycopg/connection_async.py).
+No driver migration is included without an independently verified ownership and
+network-stall contract.


### PR DESCRIPTION
SSE disconnect/shutdown can repeatedly cancel the StreamingResponse generator. Its direct await of gather forwarded that cancellation into a database-refresh child already cleaning up, interrupting driver termination and pool return. Cancel stream-owned children once, then collect them through the existing owned-cleanup helper. Reuse that helper for lease release; preserve child failures as the cause when parent cancellation takes precedence.

This is a sync-route task-lifecycle fix. The shipped driver/dialect and transaction commit behavior remain unchanged. No hard-terminate replacement, cancellation re-request, global commit checkpoint, private driver patch, pool expansion or query replay.

Previous baseline 650b67b14: isolated real app/API-key/ASGI 2.3 regression reproduces four failures with the old route and verifies one child cancellation, server query and lock release, lease cleanup, pool return before GC and no surviving owned tasks with the fix. SSE/auth/cleanup checks: 112 passed, 1 strict upstream xfail; uvloop: 8 passed, 1 strict upstream xfail. The initial implementation passed the full backend suite (2693 passed, 7 skipped, 1 xfail); final targeted verification includes exception-priority coverage. Production typing, dependency/import inventories, Ruff, compilation and generated-client consistency passed. Root reviewed the actual final runtime diff.

Remaining limitation: native asyncpg 0.31.0 close(timeout) does not bound its preceding cancellation-acknowledgement wait under a stalled network. The explicit strict xfail records this unresolved upstream contract, not a passing bounded-cleanup guarantee. Historical production traces do not prove complete causal ordering. Do not claim the entire production cleanup incident is solved.

Release preparation (2026-09-09): rebased without conflicts onto a25f7f6ff18f31b6964bd7e20efb251528812f82. Head 4a8eee16ad69a8f5cfe9c635f7f0573500d83881; range-diff confirms the patch is unchanged. Fresh Backend CI: https://github.com/Clawdi-AI/clawdi/actions/runs/34324685670. Owner authorized merge and deployment after verification. No schema migration, API/client change, or CLI package publication.

Final verification: fresh CI passed on the merge of 4a8eee16 into a25f7f6f: 2725 passed, 12 skipped, 1 strict upstream xfail; lint/typecheck/dependency/client gates passed. Merged as ccf7be8d1ab59645d8964859d6cc9ef569b08ca9. Production promotion uses the repository automatic Backend CI → Clawdi Image Release path.
