### PR TITLE
Transfer existing BYOK model ownership to native runtimes

### DIFF
--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -4,6 +4,69 @@ import { collectBrowserErrors, stubCloudApi } from "./hosted-fixtures";
 test.beforeEach(async ({ page }) => {
 	await stubCloudApi(page);
 });
+
+test("editing and rotating an agent-owned connection sends one atomic patch without models or env changes", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const provider = {
+		id: "connection-row",
+		provider_id: "saved-connection",
+		label: "Saved connection",
+		type: "custom_openai_compatible",
+		configuration_mode: "connection",
+		base_url: "https://custom.example/v1",
+		api_mode: "openai_responses",
+		runtime_env_name: "SAVED_CONNECTION_KEY",
+		managed_by: "user",
+		scope: "account",
+		models: [{ id: "historic-model" }],
+		auth: { type: "api_key", source: "managed" },
+		usable: true,
+		readiness: {
+			deployable: true,
+			credential_material: "available",
+			runtime_compatibility: { openclaw: true, hermes: true, codex: false },
+		},
+	};
+	const patches: unknown[] = [];
+	const unexpected: string[] = [];
+	page.on("request", (request) => {
+		if (/\/v1\/ai-providers\/(?:accept|.*test)(?:\?|$)/.test(request.url()))
+			unexpected.push(request.url());
+	});
+	await page.route("**/v1/ai-providers", (route) =>
+		route.fulfill({ json: { providers: [provider] } }),
+	);
+	await page.route("**/v1/ai-providers/saved-connection", async (route) => {
+		const body = route.request().postDataJSON();
+		patches.push(body);
+		await route.fulfill({ json: { ...provider, label: body.label, base_url: body.base_url } });
+	});
+	await page.goto("/ai-providers");
+	await page.getByRole("button", { name: "Edit Saved connection", exact: true }).click();
+	const dialog = page.getByRole("dialog");
+	await expect(dialog).toHaveAccessibleName("Edit Saved connection");
+	await expect(dialog.getByLabel("Model catalog")).toHaveCount(0);
+	await expect(dialog.getByRole("button", { name: "Test connection", exact: true })).toHaveCount(0);
+	await expect(dialog.getByLabel("Agent environment variable")).toHaveAttribute("readonly", "");
+	await dialog.getByLabel("Name", { exact: true }).fill("Updated connection");
+	await dialog.getByLabel("Base URL").fill("https://updated.example/v1");
+	await dialog.getByLabel("API key", { exact: true }).fill("synthetic-rotated-key");
+	await dialog.getByRole("button", { name: "Save settings", exact: true }).click();
+	await expect(dialog).toBeHidden();
+	expect(patches).toEqual([
+		{
+			configuration_mode: "connection",
+			label: "Updated connection",
+			base_url: "https://updated.example/v1",
+			api_mode: "openai_responses",
+			credential: { type: "api_key", value: "synthetic-rotated-key" },
+		},
+	]);
+	expect(unexpected).toEqual([]);
+	expect(errors).toEqual([]);
+});
 test("native BYOK saves credentials without a model catalog or inference probe", async ({
 	page,
 }) => {

--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -44,6 +44,54 @@ test("native BYOK saves credentials without a model catalog or inference probe",
 	expect(errors, `providers flow: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("editing a catalog connection preserves its models and configuration mode", async ({
+	page,
+}) => {
+	const models = [{ id: "existing-model", capabilities: { tools: true } }];
+	await page.route("**/v1/ai-providers", (route) =>
+		route.fulfill({
+			json: {
+				providers: [
+					{
+						id: "legacy-row",
+						provider_id: "legacy-openai",
+						label: "Existing OpenAI",
+						type: "openai",
+						configuration_mode: "catalog",
+						base_url: "https://api.openai.com/v1",
+						api_mode: "openai_responses",
+						runtime_env_name: "OPENAI_API_KEY",
+						managed_by: "user",
+						scope: "account",
+						models,
+						auth: { type: "api_key", source: "managed" },
+						usable: true,
+						readiness: {
+							deployable: true,
+							credential_material: "available",
+							runtime_compatibility: { openclaw: true, hermes: true, codex: true },
+						},
+					},
+				],
+			},
+		}),
+	);
+	await page.goto("/ai-providers");
+	await page.getByRole("button", { name: "Edit Existing OpenAI", exact: true }).click();
+	const dialog = page.getByRole("dialog", { name: "Edit Existing OpenAI" });
+	await expect(dialog.getByRole("button", { name: "Manage models in the agent" })).toHaveCount(0);
+	await dialog.getByLabel("API key", { exact: true }).fill("replacement-fixture-key");
+	const request = page.waitForRequest(
+		(item) => item.url().endsWith("/ai-providers/accept") && item.method() === "POST",
+	);
+	await dialog.getByRole("button", { name: "Save settings", exact: true }).click();
+	expect((await request).postDataJSON()).toMatchObject({
+		replace: true,
+		provider: { configuration_mode: "catalog", native_provider: null, models },
+	});
+	await expect(dialog).toBeHidden();
+});
+
 test("channels connect dialog opens without browser errors", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	await page.goto("/channels");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1285,7 +1285,9 @@ function OverviewTab({
 	const providers = useUserAiProviders({ enabled: !managedProvider });
 	const managedModelCatalog = useManagedModelCatalog({ enabled: managedProvider });
 	const nativeConnection = providers.data?.some(
-		(provider) => provider.provider_id === providerId && provider.configuration_mode === "native",
+		(provider) =>
+			provider.provider_id === providerId &&
+			(provider.configuration_mode === "native" || provider.configuration_mode === "connection"),
 	);
 	const model = nativeConnection
 		? "Managed in agent"
@@ -2429,7 +2431,8 @@ function AiProviderTab({
 		deploymentStatusFromResource(deployment.resource.status).kind === "updating";
 	const runtimeConfiguration = deployment.resource.spec.runtime_configuration;
 	const list = providers.data ?? [];
-	const availabilityContext = { runtime, environmentId };
+	const currentProviderIds = runtimeConfiguration.providers.map((provider) => provider.provider_id);
+	const availabilityContext = { runtime, environmentId, currentProviderIds };
 	const managedModels = managedModelCatalog.data?.models ?? [];
 	// A provider reference is only unresolved after the catalog has settled. While
 	// it is loading, preserve the server id verbatim so the binding does not briefly
@@ -2461,8 +2464,13 @@ function AiProviderTab({
 				(isManagedProviderId(primaryProviderRef)
 					? MANAGED_AI_CHOICE
 					: unresolvedProviderChoice(primaryProviderRef)));
+	const agentOwnsModels = list.some(
+		(provider) =>
+			provider.provider_id === primaryProviderRef &&
+			(provider.configuration_mode === "connection" || provider.configuration_mode === "native"),
+	);
 	const bindingModelIdentity =
-		currentAuthKind === "unmanaged"
+		currentAuthKind === "unmanaged" || agentOwnsModels
 			? ""
 			: primaryModelValue(configuredPrimaryModel) ||
 				(initialPrimaryChoice === MANAGED_AI_CHOICE
@@ -2511,6 +2519,7 @@ function AiProviderTab({
 				managedModels,
 				mode: "update",
 				providers: list,
+				currentProviderIds,
 			});
 		} catch (error) {
 			const copy = aiBindingBuildErrorCopy(error, "update");

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -218,7 +218,7 @@ describe("structural secret boundaries without the denylist", () => {
 		).toHaveLength(5);
 		expect(
 			source("hosted/v2/ai-providers/ai-providers-hooks.ts").split("return useSensitiveAction"),
-		).toHaveLength(5);
+		).toHaveLength(6);
 		expect(
 			source("hosted/billing/sensitive-actions.ts").split("return useSensitiveAction"),
 		).toHaveLength(9);

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -8,11 +8,9 @@ import {
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import { providerPresetSummary } from "@/hosted/v2/ai-providers/model-binding";
 import {
-	PROVIDER_PRESETS,
 	providerPresetById,
 	providerPresetForSavedProvider,
 	providerPresetRegion,
-	providerTypeForPreset,
 } from "@/hosted/v2/ai-providers/provider-presets";
 
 function testPreset(id: string) {
@@ -228,7 +226,7 @@ describe("providerFormIdentity", () => {
 		const kimi = testPreset("kimi-coding");
 		expect(
 			providerFormIdentity({
-				type: providerTypeForPreset(kimi),
+				type: kimi.provider_type,
 				authMethod: "api_key",
 				labelInput: "Work Kimi",
 				existingProviderIds: [],
@@ -239,7 +237,7 @@ describe("providerFormIdentity", () => {
 		const openrouter = testPreset("openrouter");
 		expect(
 			providerFormIdentity({
-				type: providerTypeForPreset(openrouter),
+				type: openrouter.provider_type,
 				authMethod: "api_key",
 				labelInput: "Team Router",
 				existingProviderIds: ["openrouter"],
@@ -250,17 +248,6 @@ describe("providerFormIdentity", () => {
 });
 
 describe("native provider form defaults", () => {
-	test("leaves model selection to the agent for every native choice", () => {
-		for (const preset of PROVIDER_PRESETS) {
-			expect(
-				derivedProviderFields(providerTypeForPreset(preset), "api_key", preset).modelsText,
-			).toBe("");
-			expect(preset).not.toHaveProperty("catalog");
-		}
-		expect(derivedProviderFields("openai", "api_key").modelsText).toBe("");
-		expect(derivedProviderFields("openai", "oauth").modelsText).toBe("");
-	});
-
 	test("preserves region and plan choices without asking for endpoint details", () => {
 		const preset = testPreset("qwen-dashscope");
 		const region = providerPresetRegion(preset, "coding-global");
@@ -280,20 +267,6 @@ describe("native provider form defaults", () => {
 			"TokenPlan",
 		]);
 		expect(testPreset("huggingface").credential_label).toBe("Access token");
-		for (const id of [
-			"nvidia",
-			"fireworks",
-			"huggingface",
-			"deepinfra",
-			"opencode",
-			"xiaomi",
-			"tencent",
-		]) {
-			const preset = testPreset(id);
-			expect(
-				derivedProviderFields(providerTypeForPreset(preset), "api_key", preset).modelsText,
-			).toBe("");
-		}
 	});
 
 	test("keeps custom endpoint input empty", () => {
@@ -301,7 +274,6 @@ describe("native provider form defaults", () => {
 			baseUrl: "",
 			apiMode: "openai_chat",
 			runtimeEnv: "CUSTOM_API_KEY",
-			modelsText: "",
 		});
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -1,9 +1,6 @@
 import { nativeAiProvider } from "@clawdi/shared";
 import { CLAWDI_CODEX_OAUTH_PROVIDER_ID } from "@/hosted/v2/ai-providers/codex-oauth";
-import {
-	type ProviderPreset,
-	presetRuntimeEnvName,
-} from "@/hosted/v2/ai-providers/provider-presets";
+import type { ProviderPreset } from "@/hosted/v2/ai-providers/provider-presets";
 import {
 	type ApiMode,
 	type ProviderTypeId,
@@ -28,7 +25,6 @@ export interface DerivedProviderFields {
 	baseUrl: string;
 	apiMode: ApiMode;
 	runtimeEnv: string;
-	modelsText: string;
 }
 
 export function authFor(method: AuthMethod): AiProviderUpsertAuth {
@@ -105,9 +101,7 @@ export function derivedProviderFields(
 	return {
 		baseUrl: route?.base_url ?? preset?.base_url ?? meta.defaultBaseUrl,
 		apiMode: route?.api_mode ?? preset?.api_mode ?? meta.defaultApiMode,
-		runtimeEnv:
-			route?.runtime_env_name ?? (preset ? presetRuntimeEnvName(preset) : meta.defaultRuntimeEnv),
-		modelsText: "",
+		runtimeEnv: route?.runtime_env_name ?? preset?.runtime_env_name ?? meta.defaultRuntimeEnv,
 	};
 }
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -10,6 +10,7 @@ import {
 import type {
 	AiProvider,
 	AiProviderConnectionTestResponse,
+	AiProviderPatch,
 	AiProviderUpsert,
 	AiProviderUpsertAuth,
 } from "@/hosted/v2/ai-providers/types";
@@ -48,7 +49,8 @@ export async function runPostSaveProviderConnectionTest(
 		Partial<Pick<AiProvider, "configuration_mode">>,
 	execute: (input: SavedProviderConnectionTestInput) => Promise<SavedProviderConnectionTestResult>,
 ): Promise<SavedProviderConnectionTestResult | null> {
-	if (provider.configuration_mode === "native") return null;
+	if (provider.configuration_mode === "native" || provider.configuration_mode === "connection")
+		return null;
 	if (provider.auth.type !== "api_key" || provider.auth.source !== "managed") return null;
 	const model = provider.models?.[0]?.id;
 	try {
@@ -60,6 +62,24 @@ export async function runPostSaveProviderConnectionTest(
 		// Saving is authoritative. A follow-up test failure must not turn it into a failed mutation.
 		return null;
 	}
+}
+
+/** Connection edits never carry stored model metadata or change credential identity. */
+export function connectionProviderPatch(
+	provider: AiProvider,
+	fields: { label: string | null; baseUrl: string; apiMode: ApiMode; apiKey: string },
+): AiProviderPatch {
+	if (provider.configuration_mode !== "connection")
+		throw new Error("Expected an existing connection");
+	return {
+		configuration_mode: "connection",
+		label: fields.label,
+		base_url: fields.baseUrl.trim(),
+		api_mode: fields.apiMode,
+		...(fields.apiKey.trim()
+			? { credential: { type: "api_key", value: fields.apiKey.trim() } }
+			: {}),
+	};
 }
 
 export function modelsToText(models: ReadonlyArray<{ id: string }> | null | undefined): string {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -22,6 +22,7 @@ import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	type AuthMethod,
 	authFor,
+	connectionProviderPatch,
 	derivedProviderFields,
 	modelsFromText,
 	modelsToText,
@@ -37,6 +38,7 @@ import {
 	usePatchProvider,
 	useTestDraftProviderConnection,
 	useTestProviderConnection,
+	useUpdateConnectionProvider,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { codexProviderBody } from "@/hosted/v2/ai-providers/codex-oauth";
 import { type ProviderChoice, ProviderChooser } from "@/hosted/v2/ai-providers/provider-chooser";
@@ -84,6 +86,7 @@ export function AddProviderDialog({
 	const providers = useAiProviders();
 	const acceptProvider = useAcceptProvider();
 	const patchProvider = usePatchProvider();
+	const updateConnection = useUpdateConnectionProvider();
 	const testDraft = useTestDraftProviderConnection();
 	const testSaved = useTestProviderConnection();
 	const oauthDeviceStart = useOAuthDeviceStart();
@@ -375,6 +378,23 @@ export function AddProviderDialog({
 		if (!canSubmit) return;
 		if (editing) {
 			const replacementKey = form.apiKey.trim();
+			if (editing.configuration_mode === "connection") {
+				const saved = await updateConnection
+					.execute({
+						providerId: editing.provider_id,
+						body: connectionProviderPatch(editing, {
+							label: identity.label,
+							baseUrl: form.baseUrl,
+							apiMode: form.apiMode,
+							apiKey: replacementKey,
+						}),
+					})
+					.catch(() => null);
+				if (!saved) return;
+				toast.success("Provider updated");
+				requestClose(false);
+				return;
+			}
 			if (replacementKey) {
 				const body = {
 					provider: providerBody(),
@@ -487,6 +507,7 @@ export function AddProviderDialog({
 	const busy =
 		acceptProvider.isPending ||
 		patchProvider.isPending ||
+		updateConnection.isPending ||
 		testDraft.isPending ||
 		testSaved.isPending ||
 		oauthDeviceStart.isPending ||
@@ -624,7 +645,9 @@ export function AddProviderDialog({
 									{isEdit ? null : <ArrowLeft />}
 									{isEdit ? "Cancel" : "Back"}
 								</Button>
-								{form.authMethod === "api_key" && !nativeConnection ? (
+								{form.authMethod === "api_key" &&
+								!nativeConnection &&
+								form.configurationMode !== "connection" ? (
 									<Button
 										variant="outline"
 										onClick={() => void runAction(testDraftConnection)}

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -566,20 +566,6 @@ export function AddProviderDialog({
 							) : null}
 							<ProviderFieldsForm
 								nativeConnection={nativeConnection}
-								onUseNative={
-									nativeRoute && !nativeConnection && !isOAuthEdit
-										? () => {
-												updateForm({
-													configurationMode: "native",
-													modelsText: "",
-													baseUrl: nativeRoute.base_url,
-													apiMode: nativeRoute.api_mode,
-													runtimeEnv: nativeRoute.runtime_env_name,
-												});
-												setDraftTestResult(null);
-											}
-										: undefined
-								}
 								form={form}
 								editing={editing ?? null}
 								preset={selectedPreset}

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -47,7 +47,6 @@ import {
 	providerPresetById,
 	providerPresetForSavedProvider,
 	providerPresetRegion,
-	providerTypeForPreset,
 } from "@/hosted/v2/ai-providers/provider-presets";
 import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type {
@@ -186,8 +185,7 @@ export function AddProviderDialog({
 				type,
 				label: editing.label ?? "",
 				baseUrl: editing.base_url || defaults.baseUrl,
-				modelsText:
-					(editing.models?.length ?? 0) > 0 ? modelsToText(editing.models) : defaults.modelsText,
+				modelsText: modelsToText(editing.models),
 				apiMode: editing.api_mode ?? defaults.apiMode,
 				runtimeEnv: editing.runtime_env_name ?? defaults.runtimeEnv,
 				authMethod,
@@ -205,7 +203,7 @@ export function AddProviderDialog({
 			type: "openai",
 			label: "",
 			baseUrl: defaults.baseUrl,
-			modelsText: defaults.modelsText,
+			modelsText: "",
 			apiMode: defaults.apiMode,
 			runtimeEnv: defaults.runtimeEnv,
 			authMethod: "api_key",
@@ -219,7 +217,7 @@ export function AddProviderDialog({
 	function selectProvider(choice: ProviderChoice) {
 		acceptAttemptRef.current = null;
 		if (choice.kind === "preset") {
-			const type = providerTypeForPreset(choice.preset);
+			const type = choice.preset.provider_type;
 			const defaults = derivedProviderFields(type, "api_key", choice.preset);
 			const region = providerPresetRegion(choice.preset, null);
 			resetForm({
@@ -227,7 +225,7 @@ export function AddProviderDialog({
 				type,
 				label: "",
 				baseUrl: region?.base_url ?? defaults.baseUrl,
-				modelsText: defaults.modelsText,
+				modelsText: "",
 				apiMode: defaults.apiMode,
 				runtimeEnv: defaults.runtimeEnv,
 				authMethod: "api_key",
@@ -242,7 +240,7 @@ export function AddProviderDialog({
 				type: choice.type,
 				label: "",
 				baseUrl: defaults.baseUrl,
-				modelsText: defaults.modelsText,
+				modelsText: "",
 				apiMode: defaults.apiMode,
 				runtimeEnv: defaults.runtimeEnv,
 				authMethod: "api_key",
@@ -262,7 +260,7 @@ export function AddProviderDialog({
 			authMethod,
 			apiKey: "",
 			baseUrl: defaults.baseUrl,
-			modelsText: defaults.modelsText,
+			modelsText: "",
 			apiMode: defaults.apiMode,
 			runtimeEnv: defaults.runtimeEnv,
 		});

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -78,10 +78,12 @@ export function buildAiBindingFields(
 		managedModels,
 		mode,
 		providers,
+		currentProviderIds,
 	}: {
 		managedModels: readonly ManagedModelCatalogItem[];
 		mode: AiBindingOperationMode;
 		providers: readonly AiProvider[];
+		currentProviderIds?: readonly string[];
 	},
 ): AiBindingFields {
 	if (draft.bindingMode === "unmanaged") {
@@ -115,6 +117,7 @@ export function buildAiBindingFields(
 			managedModels,
 			mode,
 			providers,
+			currentProviderIds,
 			selection: {
 				mode: "saved",
 				model: draft.primaryModel,

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -14,6 +14,7 @@ import type {
 	AiProviderList,
 	AiProviderOAuthDevicePollResponse,
 	AiProviderOAuthDeviceStartResponse,
+	AiProviderPatch,
 } from "@/hosted/v2/ai-providers/types";
 import { toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -75,6 +76,28 @@ export function usePatchProvider() {
 		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
 		onError: toastApiError("Couldn't update provider"),
 	});
+}
+
+export function useUpdateConnectionProvider() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useSensitiveAction(
+		async ({ providerId, body }: { providerId: string; body: AiProviderPatch }) => {
+			try {
+				const saved = unwrap(
+					await api.PATCH("/v1/ai-providers/{provider_id}", {
+						params: { path: { provider_id: providerId } },
+						body,
+					}),
+				);
+				void qc.invalidateQueries({ queryKey: KEY });
+				return saved;
+			} catch (error) {
+				toastApiError("Couldn't update provider")(error);
+				throw error;
+			}
+		},
+	);
 }
 
 export function useDeleteProvider() {

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -50,7 +50,8 @@ export function ModelBindingPicker({
 		(item) => item.provider_id === primaryProviderChoice || item.id === primaryProviderChoice,
 	);
 	if (primaryProviderChoice !== MANAGED_AI_CHOICE && !provider) return null;
-	if (provider?.configuration_mode === "native") return null;
+	if (provider?.configuration_mode === "native" || provider?.configuration_mode === "connection")
+		return null;
 	const catalogInputId = `${idPrefix}-catalog-model`;
 	const modelInputId = `${idPrefix}-primary-model`;
 	const modelListId = `${idPrefix}-model-options`;

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -60,6 +60,25 @@ const savedOpenAiProvider = {
 	label: "OpenAI",
 } satisfies AiProvider;
 
+test("connection metadata never seeds a model or permits selection onto a fresh agent", () => {
+	const provider = {
+		...savedOpenAiProvider,
+		configuration_mode: "connection",
+	} satisfies AiProvider;
+	expect(firstModelForProvider(provider.provider_id, [provider])).toBe("");
+	expect(modelOptionsForProvider(provider.provider_id, [provider])).toEqual([]);
+	expect(
+		providerAvailabilityIssue(provider, { runtime: "openclaw", environmentId: null }),
+	).not.toBeNull();
+	expect(
+		providerAvailabilityIssue(provider, {
+			runtime: "openclaw",
+			environmentId: "current-agent",
+			currentProviderIds: [provider.provider_id],
+		}),
+	).toBeNull();
+});
+
 describe("model binding", () => {
 	test("native identity and product stay visible even with a custom connection name", () => {
 		const route = nativeAiProvider("tencent", "tokenplan");

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -47,6 +47,7 @@ export type PrimaryModelInput = string | PrimaryModelRef | null | undefined;
 export type ProviderAvailabilityContext = {
 	runtime: HostedRuntime;
 	environmentId: string | null;
+	currentProviderIds?: readonly string[];
 };
 
 export type ProviderAvailabilityIssue = ReturnType<typeof hostedAiProviderAvailabilityIssue>;
@@ -209,7 +210,10 @@ export function modelOptionsForProvider(
 		models = managedModels;
 	} else {
 		const provider = providers.find((item) => item.id === choice || item.provider_id === choice);
-		models = provider?.configuration_mode === "native" ? [] : (provider?.models ?? []);
+		models =
+			provider?.configuration_mode === "native" || provider?.configuration_mode === "connection"
+				? []
+				: (provider?.models ?? []);
 	}
 
 	const seen = new Set<string>();
@@ -252,7 +256,7 @@ export function providerPresetSummary(preset: ProviderPreset): string {
 }
 
 function providerModelSummary(provider: AiProvider, preset: ProviderPreset | null): string {
-	if (provider.configuration_mode === "native") {
+	if (provider.configuration_mode === "native" || provider.configuration_mode === "connection") {
 		const variant = preset?.region_variants?.find((item) => item.id === provider.native_variant);
 		return variant ? `${variant.label} · Models managed in agent` : "Models managed in agent";
 	}

--- a/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-connection-test.tsx
@@ -31,6 +31,7 @@ export function ProviderConnectionTest({
 	const [open, setOpen] = useState(false);
 	const testable =
 		provider.configuration_mode !== "native" &&
+		provider.configuration_mode !== "connection" &&
 		provider.auth.type === "api_key" &&
 		provider.auth.source === "managed";
 	const testedModel = provider.models?.[0]?.id;

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -55,7 +55,6 @@ function isApiMode(value: string | null): value is ApiMode {
 export function ProviderFieldsForm({
 	form,
 	nativeConnection,
-	onUseNative,
 	editing,
 	preset,
 	region,
@@ -70,7 +69,6 @@ export function ProviderFieldsForm({
 }: {
 	form: ProviderFormState;
 	nativeConnection: boolean;
-	onUseNative?: () => void;
 	editing: AiProvider | null;
 	preset: ProviderPreset | null;
 	region: ProviderPresetRegionVariant | null;
@@ -245,11 +243,6 @@ export function ProviderFieldsForm({
 				</div>
 			) : null}
 
-			{onUseNative ? (
-				<Button variant="outline" onClick={onUseNative}>
-					Manage models in the agent
-				</Button>
-			) : null}
 			{form.authMethod === "api_key" && !nativeConnection ? (
 				<details ref={initializeAdvancedDetails} className="group rounded-lg border bg-muted/20">
 					<summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2.5 text-sm font-medium marker:hidden">

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -235,7 +235,7 @@ export function ProviderFieldsForm({
 							</InputGroupButton>
 						</InputGroupAddon>
 					</InputGroup>
-					{!nativeConnection ? (
+					{!nativeConnection && form.configurationMode !== "connection" ? (
 						<p className="text-xs text-muted-foreground">
 							Testing sends one minimal inference request and may incur a small provider charge.
 						</p>
@@ -309,6 +309,7 @@ export function ProviderFieldsForm({
 									<Label htmlFor="provider-env">Agent environment variable</Label>
 									<Input
 										id="provider-env"
+										readOnly={form.configurationMode === "connection"}
 										value={form.runtimeEnv}
 										onChange={(event) => onUpdate({ runtimeEnv: event.target.value.toUpperCase() })}
 										placeholder="OPENAI_API_KEY"
@@ -318,21 +319,25 @@ export function ProviderFieldsForm({
 								</div>
 							) : null}
 						</div>
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="provider-models">Model catalog</Label>
-							<Textarea
-								id="provider-models"
-								value={form.modelsText}
-								onChange={(event) => onUpdate({ modelsText: event.target.value })}
-								placeholder="model name"
-								className="min-h-24 resize-y"
-								autoComplete="off"
-								spellCheck={false}
-							/>
-							<p className="text-xs text-muted-foreground">
-								One model id per line. The first is used by connection testing.
-							</p>
-						</div>
+						{form.configurationMode === "connection" ? (
+							<p className="text-xs text-muted-foreground">Models are managed in the agent.</p>
+						) : (
+							<div className="flex flex-col gap-1.5">
+								<Label htmlFor="provider-models">Model catalog</Label>
+								<Textarea
+									id="provider-models"
+									value={form.modelsText}
+									onChange={(event) => onUpdate({ modelsText: event.target.value })}
+									placeholder="model name"
+									className="min-h-24 resize-y"
+									autoComplete="off"
+									spellCheck={false}
+								/>
+								<p className="text-xs text-muted-foreground">
+									One model id per line. The first is used by connection testing.
+								</p>
+							</div>
+						)}
 					</div>
 				</details>
 			) : null}

--- a/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-fields-form.tsx
@@ -331,7 +331,7 @@ export function ProviderFieldsForm({
 								id="provider-models"
 								value={form.modelsText}
 								onChange={(event) => onUpdate({ modelsText: event.target.value })}
-								placeholder={meta.modelPlaceholder}
+								placeholder="model name"
 								className="min-h-24 resize-y"
 								autoComplete="off"
 								spellCheck={false}

--- a/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
@@ -160,11 +160,3 @@ export function providerPresetForSavedProvider({
 		) ?? null
 	);
 }
-
-export function providerTypeForPreset(preset: ProviderPreset): ProviderTypeId {
-	return preset.provider_type;
-}
-
-export function presetRuntimeEnvName(preset: ProviderPreset): string {
-	return preset.runtime_env_name;
-}

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -7,8 +7,7 @@ import type { AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 /**
  * The six AI provider types (backend `ProviderType`) with the defaults the
- * add flow prefills: base URL, allowed API modes, runtime env var, and a
- * model placeholder.
+ * add flow prefills: base URL, allowed API modes, and runtime env var.
  */
 export const PROVIDER_TYPES = [
 	"openai",
@@ -29,7 +28,6 @@ export interface ProviderTypeMeta {
 	apiModes: ApiMode[];
 	defaultApiMode: ApiMode;
 	defaultRuntimeEnv: string;
-	modelPlaceholder: string;
 	apiKeyUrl?: string;
 	/** base_url + api_mode are user-supplied / required. */
 	custom?: boolean;
@@ -38,7 +36,6 @@ export interface ProviderTypeMeta {
 }
 
 const CUSTOM_OPENAI_COMPATIBLE_RUNTIME_ENV = "CUSTOM_API_KEY";
-const CUSTOM_OPENAI_COMPATIBLE_MODEL_PLACEHOLDER = "model name";
 
 export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 	openai: {
@@ -48,7 +45,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat", "openai_responses"],
 		defaultApiMode: defaultAiProviderApiMode("openai") ?? "openai_responses",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("openai") ?? "",
-		modelPlaceholder: "model name",
 		apiKeyUrl: "https://platform.openai.com/settings/organization/api-keys",
 		oauth: true,
 	},
@@ -59,7 +55,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["anthropic_messages"],
 		defaultApiMode: defaultAiProviderApiMode("anthropic") ?? "anthropic_messages",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("anthropic") ?? "",
-		modelPlaceholder: "model name",
 		apiKeyUrl: "https://platform.claude.com/settings/keys",
 	},
 	openrouter: {
@@ -69,7 +64,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat"],
 		defaultApiMode: defaultAiProviderApiMode("openrouter") ?? "openai_chat",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("openrouter") ?? "",
-		modelPlaceholder: "model name",
 		apiKeyUrl: "https://openrouter.ai/keys",
 	},
 	gemini: {
@@ -79,7 +73,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["google_generate_content"],
 		defaultApiMode: defaultAiProviderApiMode("gemini") ?? "google_generate_content",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("gemini") ?? "",
-		modelPlaceholder: "model name",
 		apiKeyUrl: "https://aistudio.google.com/apikey",
 	},
 	mistral: {
@@ -89,7 +82,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat"],
 		defaultApiMode: defaultAiProviderApiMode("mistral") ?? "openai_chat",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("mistral") ?? "",
-		modelPlaceholder: "model name",
 		apiKeyUrl: "https://console.mistral.ai/api-keys",
 	},
 	custom_openai_compatible: {
@@ -99,7 +91,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat", "openai_responses"],
 		defaultApiMode: "openai_chat",
 		defaultRuntimeEnv: CUSTOM_OPENAI_COMPATIBLE_RUNTIME_ENV,
-		modelPlaceholder: CUSTOM_OPENAI_COMPATIBLE_MODEL_PLACEHOLDER,
 		custom: true,
 	},
 };

--- a/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
@@ -24,7 +24,9 @@ export function selectAiBindingProvider(
 ): AiProviderBindingDraft {
 	if (
 		context.providers.some(
-			(provider) => provider.provider_id === choice && provider.configuration_mode === "native",
+			(provider) =>
+				provider.provider_id === choice &&
+				(provider.configuration_mode === "native" || provider.configuration_mode === "connection"),
 		)
 	) {
 		return { ...draft, bindingMode: "configured", primaryProviderChoice: choice, primaryModel: "" };

--- a/apps/web/src/hosted/v2/ai-providers/use-provider-form.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-provider-form.ts
@@ -5,7 +5,7 @@ import type { AuthMethod } from "@/hosted/v2/ai-providers/add-provider-dialog.lo
 import type { ApiMode, ProviderTypeId } from "@/hosted/v2/ai-providers/provider-types";
 
 export interface ProviderFormState {
-	configurationMode: "native" | "catalog";
+	configurationMode: "native" | "catalog" | "connection";
 	type: ProviderTypeId;
 	label: string;
 	baseUrl: string;

--- a/apps/web/src/hosted/v2/ai-providers/use-provider-form.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-provider-form.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useReducer } from "react";
+import { useCallback, useState } from "react";
 import type { AuthMethod } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import type { ApiMode, ProviderTypeId } from "@/hosted/v2/ai-providers/provider-types";
 
@@ -32,22 +32,10 @@ const INITIAL_STATE: ProviderFormState = {
 	regionId: null,
 };
 
-type ProviderFormAction =
-	| { type: "reset"; value: ProviderFormState }
-	| { type: "update"; value: Partial<ProviderFormState> };
-
-function reducer(state: ProviderFormState, action: ProviderFormAction): ProviderFormState {
-	if (action.type === "reset") return action.value;
-	return { ...state, ...action.value };
-}
-
 export function useProviderForm() {
-	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
-	const reset = useCallback((value: ProviderFormState) => {
-		dispatch({ type: "reset", value });
-	}, []);
+	const [state, setState] = useState(INITIAL_STATE);
 	const update = useCallback((value: Partial<ProviderFormState>) => {
-		dispatch({ type: "update", value });
+		setState((current) => ({ ...current, ...value }));
 	}, []);
-	return { state, reset, update };
+	return { state, reset: setState, update };
 }

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -76,6 +76,7 @@ from app.services.ai_provider_capabilities import (
     provider_readiness,
 )
 from app.services.ai_provider_connection import test_ai_provider_connection
+from app.services.ai_provider_connection_ownership import require_connection_ownership_migration
 from app.services.ai_provider_credentials import (
     OAuthCredentialClaimConflict,
     OAuthCredentialConsumer,
@@ -670,7 +671,40 @@ async def patch_ai_provider(
     previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(provider)
     auth_event_queued = False
     merged = await _to_response(db, auth, provider)
-    update = {field: getattr(body, field) for field in body.model_fields_set}
+    update = {
+        field: getattr(body, field) for field in body.model_fields_set if field != "credential"
+    }
+    if body.credential is not None and provider.configuration_mode != "connection":
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Inline key replacement requires an existing connection"
+        )
+    if provider.configuration_mode == "connection":
+        if (
+            ("configuration_mode" in update and update["configuration_mode"] != "connection")
+            or "models" in update
+            or ("auth" in update and update["auth"] != merged.auth)
+            or (
+                "runtime_env_name" in update
+                and update["runtime_env_name"] != provider.runtime_env_name
+            )
+        ):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Agent-owned models and credential environment cannot be replaced.",
+            )
+    elif update.get("configuration_mode") == "connection":
+        if provider.configuration_mode != "catalog" or set(update) != {"configuration_mode"}:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Transfer model ownership separately from connection changes.",
+            )
+        if merged.readiness is None or not merged.readiness.deployable:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "Model ownership transfer requires a deliverable API key"
+            )
+        await require_connection_ownership_migration(
+            db, owner_user_id=auth.user_id, provider_id=provider.provider_id
+        )
     null_errors = _validate_patch_nulls(update)
     if null_errors:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, {"errors": null_errors})
@@ -705,7 +739,7 @@ async def patch_ai_provider(
     )
     await _validate_runtime_env_unique(db, auth, merged, exclude_provider_id=provider.provider_id)
     _apply_provider_body(provider, merged, apply_auth=False)
-    if "auth" in body.model_fields_set:
+    if "auth" in body.model_fields_set or body.credential is not None:
         auth_ref, auth_metadata = merged.auth.persistence_fields()
         try:
             transition = await transition_ai_provider_auth(
@@ -715,6 +749,16 @@ async def patch_ai_provider(
                 auth_type=merged.auth.type,
                 auth_ref=auth_ref,
                 auth_metadata=auth_metadata,
+                credential=(
+                    AuthCredentialWrite(
+                        profile=str((auth_metadata or {}).get("profile") or "default"),
+                        kind="api_key",
+                        plaintext=body.credential.value.get_secret_value(),
+                        metadata=auth_metadata,
+                    )
+                    if body.credential is not None
+                    else None
+                ),
             )
         except OAuthCredentialClaimConflict as exc:
             raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
@@ -794,6 +838,14 @@ async def set_ai_provider_api_key(
     if runtime_env_name is not None and not _is_runtime_env_name(runtime_env_name):
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "invalid runtime_env_name")
     proposed_runtime_env_name = runtime_env_name or provider.runtime_env_name
+    if (
+        provider.configuration_mode == "connection"
+        and runtime_env_name is not None
+        and runtime_env_name != provider.runtime_env_name
+    ):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection credential environment is immutable"
+        )
     if provider.configuration_mode == "native":
         try:
             routing = native_provider_routing(provider.native_provider, provider.native_variant)
@@ -849,6 +901,10 @@ async def import_ai_provider_auth(
     await lock_ai_provider_owner(db, auth.user_id)
     provider = await _get_provider_or_404_for_update(db, auth, provider_id)
     auth_import = body.root
+    if provider.configuration_mode == "connection":
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection providers require API-key authentication"
+        )
     profile = _normalize_profile(auth_import.profile)
     if auth_import.type == "oauth_profile":
         raise HTTPException(
@@ -1616,6 +1672,10 @@ def _apply_provider_body(
     *,
     apply_auth: bool = True,
 ) -> None:
+    if provider.configuration_mode == "connection" and body.configuration_mode != "connection":
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection ownership cannot be replaced through upsert"
+        )
     provider.type = body.type
     provider.configuration_mode = body.configuration_mode or "catalog"
     provider.native_provider = body.native_provider
@@ -1624,7 +1684,8 @@ def _apply_provider_body(
     provider.base_url = body.base_url
     provider.api_mode = managed_provider_api_mode(body.provider_id) or body.api_mode
     provider.capabilities = body.capabilities
-    provider.models = _provider_models_payload(body.models)
+    if body.configuration_mode != "connection":
+        provider.models = _provider_models_payload(body.models)
     provider.managed_by = body.managed_by
     provider.runtime_env_name = body.runtime_env_name
     if apply_auth:
@@ -1887,6 +1948,12 @@ def _connection_test_failure_with_readiness(
 
 def _validate_provider(body: AiProviderUpsert | AiProviderResponse) -> list[str]:
     errors: list[str] = []
+    if body.configuration_mode == "connection" and (
+        body.managed_by != "user"
+        or body.auth.type not in {"api_key", "secret_ref"}
+        or not body.runtime_env_name
+    ):
+        errors.append("connection management requires a user API-key connection")
     if body.configuration_mode != "native" and (body.native_provider or body.native_variant):
         errors.append("catalog configuration cannot include native provider identity")
     if body.configuration_mode == "native":
@@ -1896,7 +1963,8 @@ def _validate_provider(body: AiProviderUpsert | AiProviderResponse) -> list[str]
     errors.extend(_validate_base_url(body.base_url, body.auth))
     if body.runtime_env_name is not None and not _is_runtime_env_name(body.runtime_env_name):
         errors.append("runtime_env_name must be an uppercase environment variable name")
-    errors.extend(_validate_provider_models(body))
+    if body.configuration_mode != "connection":
+        errors.extend(_validate_provider_models(body))
     allowed_modes = ALLOWED_API_MODES[body.type]
     if body.api_mode is not None and body.api_mode not in allowed_modes:
         errors.append(f"type {body.type} is incompatible with api_mode {body.api_mode}")

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -338,7 +338,7 @@ class AiProviderModel(BaseModel):
 
 
 class AiProviderBase(BaseModel):
-    configuration_mode: Literal["native", "catalog"] | SkipJsonSchema[None] = None
+    configuration_mode: Literal["native", "catalog", "connection"] | SkipJsonSchema[None] = None
     native_provider: AuthProfile | None = None
     native_variant: AuthProfile | None = None
     type: ProviderType
@@ -376,6 +376,12 @@ class AiProviderBase(BaseModel):
 
 
 class AiProviderUpsert(AiProviderBase):
+    @model_validator(mode="after")
+    def _require_existing_connection(self) -> "AiProviderUpsert":
+        if self.configuration_mode == "connection":
+            raise ValueError("connection management requires an existing provider migration")
+        return self
+
     provider_id: str = Field(min_length=2, max_length=80, pattern=r"^[a-z][a-z0-9._-]{1,62}$")
     auth: AiProviderUpsertAuth
 
@@ -385,8 +391,25 @@ class AiProviderUpsert(AiProviderBase):
         return _reject_normal_upsert_oauth(value)
 
 
+class AiProviderApiKeyAcceptCredential(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    type: Literal["api_key"]
+    value: SecretStr
+
+    @field_validator("value")
+    @classmethod
+    def _reject_blank_value(cls, value: SecretStr) -> SecretStr:
+        if not value.get_secret_value().strip():
+            raise ValueError("credential cannot be blank")
+        return value
+
+
 class AiProviderPatch(BaseModel):
-    configuration_mode: Literal["native", "catalog"] | None = None
+    model_config = ConfigDict(hide_input_in_errors=True)
+
+    credential: AiProviderApiKeyAcceptCredential | SkipJsonSchema[None] = None
+    configuration_mode: Literal["native", "catalog", "connection"] | None = None
     native_provider: AuthProfile | None = None
     native_variant: AuthProfile | None = None
     type: ProviderType | None = None
@@ -402,6 +425,7 @@ class AiProviderPatch(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_unsupported_oauth_profile(cls, value: object) -> object:
+        _reject_explicit_nulls(value, frozenset({"credential"}))
         return _reject_normal_upsert_oauth(value)
 
 
@@ -477,20 +501,6 @@ class AiProviderManagedApiKeyRequest(BaseModel):
 
     value: SecretStr
     runtime_env_name: str | None = Field(default=None, max_length=128)
-
-    @field_validator("value")
-    @classmethod
-    def _reject_blank_value(cls, value: SecretStr) -> SecretStr:
-        if not value.get_secret_value().strip():
-            raise ValueError("credential cannot be blank")
-        return value
-
-
-class AiProviderApiKeyAcceptCredential(BaseModel):
-    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
-
-    type: Literal["api_key"]
-    value: SecretStr
 
     @field_validator("value")
     @classmethod

--- a/backend/app/services/ai_provider_auth_transition.py
+++ b/backend/app/services/ai_provider_auth_transition.py
@@ -19,6 +19,7 @@ from app.models.ai_provider import (
     AiProviderOAuthRevokeTombstone,
 )
 from app.services.ai_provider_credentials import (
+    OAuthCredentialClaimConflict,
     claim_unique_bound_runtime,
     lock_ai_provider_owner,
     validate_prospective_bound_runtime_auth,
@@ -343,6 +344,16 @@ async def transition_ai_provider_auth(
     """Apply one auth identity/material transition inside the caller's transaction."""
 
     await lock_ai_provider_owner(db, owner_user_id)
+    if (
+        provider.configuration_mode == "connection"
+        and not archive_provider
+        and (
+            auth_type != "api_key"
+            or auth_ref is not None
+            or (auth_metadata or {}).get("source") != "managed"
+        )
+    ):
+        raise OAuthCredentialClaimConflict("Connection providers require a managed API key")
     if auth_type != provider.auth_type:
         await validate_prospective_bound_runtime_auth(
             db,

--- a/backend/app/services/ai_provider_capabilities.py
+++ b/backend/app/services/ai_provider_capabilities.py
@@ -62,6 +62,17 @@ def provider_runtime_compatibility(
     """Return runtime projection support from the same fields agents consume."""
 
     api_mode = effective_provider_api_mode(provider.provider_type, provider.api_mode)
+    if provider.configuration_mode == "connection":
+        valid = (
+            provider.auth_type == "api_key"
+            and provider.auth_source == "managed"
+            and bool(provider.runtime_env_name)
+        )
+        return AiProviderRuntimeCompatibility(
+            openclaw=valid and api_mode in _RUNTIME_API_MODES["openclaw"],
+            hermes=valid and api_mode in _RUNTIME_API_MODES["hermes"],
+            codex=False,
+        )
     if provider.configuration_mode == "native":
         try:
             routing = native_provider(provider.native_provider, provider.native_variant)

--- a/backend/app/services/ai_provider_connection_ownership.py
+++ b/backend/app/services/ai_provider_connection_ownership.py
@@ -1,0 +1,121 @@
+"""Admission for the one-way, existing-runtime provider ownership handoff."""
+
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from pydantic import ValidationError
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.session import AgentEnvironment
+from app.schemas.runtime import validate_hosted_runtime_desired_state
+from app.schemas.runtime_observation import (
+    RuntimeDriftBindingRequest,
+    RuntimeDriftSummaryReadRequest,
+)
+from app.services.app_setting_registry import SUPPORTED_CONNECTION_CLI_VERSIONS_SPEC
+from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
+from app.services.runtime_drift_summary import read_runtime_drift_summaries
+
+
+async def require_connection_ownership_migration(
+    db: AsyncSession, *, owner_user_id: UUID, provider_id: str
+) -> None:
+    """The caller holds the provider-owner lock shared by runtime-state mutations."""
+    try:
+        versions = await resolve_app_setting(db, SUPPORTED_CONNECTION_CLI_VERSIONS_SPEC)
+    except AppSettingUnavailable as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection ownership migration is not enabled"
+        ) from exc
+    if not versions:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection ownership migration is not enabled"
+        )
+    states = list(
+        (
+            await db.scalars(
+                select(HostedRuntimeState)
+                .join(AgentEnvironment, AgentEnvironment.id == HostedRuntimeState.environment_id)
+                .where(
+                    AgentEnvironment.user_id == owner_user_id,
+                    AgentEnvironment.archived_at.is_(None),
+                    or_(
+                        *(
+                            HostedRuntimeState.runtimes[name]["provider_ids"].contains(
+                                [provider_id]
+                            )
+                            for name in ("openclaw", "hermes", "codex")
+                        )
+                    ),
+                )
+                .order_by(HostedRuntimeState.environment_id)
+                .with_for_update(of=HostedRuntimeState)
+            )
+        ).all()
+    )
+    if not states:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Model ownership transfer requires an existing Hosted connection",
+        )
+    for state in states:
+        for name, value in state.runtimes.items():
+            try:
+                runtime = validate_hosted_runtime_desired_state(value)
+            except ValidationError as exc:
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT, "Existing runtime binding is invalid"
+                ) from exc
+            if provider_id in runtime.provider_ids and name not in {"openclaw", "hermes"}:
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT,
+                    "Connection ownership supports only OpenClaw and Hermes",
+                )
+    # Use the existing accepted-v2 evidence reader, including boot ambiguity and retirement fences.
+    for offset in range(0, len(states), 100):
+        batch = states[offset : offset + 100]
+        summaries = await read_runtime_drift_summaries(
+            db,
+            RuntimeDriftSummaryReadRequest(
+                bindings=[
+                    RuntimeDriftBindingRequest(
+                        environmentId=state.environment_id, deploymentId=state.deployment_id
+                    )
+                    for state in batch
+                ]
+            ),
+        )
+        by_environment = {state.environment_id: state for state in batch}
+        for summary in summaries.items:
+            state = by_environment[summary.environment_id]
+            authority = summary.source_authority
+            head = summary.observation.head
+            applied = head.diagnostics.applied if head is not None else None
+            if (
+                summary.binding != "active"
+                or summary.observation.status != "fresh"
+                or authority.status != "present"
+                or head is None
+                or applied is None
+                or head.captured_at > summaries.observed_at
+                or head.freshness_deadline <= summaries.observed_at
+                or head.health != "ok"
+                or head.diagnostics.active_cli_version not in versions
+                or state.cli_package_spec != f"clawdi@{head.diagnostics.active_cli_version}"
+                or authority.instance_id != state.instance_id
+                or applied.instance_id != authority.instance_id
+                or applied.source_revision != authority.source_revision
+                or applied.etag != authority.etag
+                or applied.generation != (state.apply_generation or state.generation)
+                or provider_id not in applied.applied_provider_ids
+                or head.runtime_identity.generation != (state.apply_generation or state.generation)
+                or not head.runtime_identity.apply_receipt_id
+                or not head.runtime_identity.boot_nonce
+            ):
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT,
+                    "Every bound runtime must have fresh, current evidence "
+                    "from a qualified running CLI",
+                )

--- a/backend/app/services/ai_provider_oauth_attempt.py
+++ b/backend/app/services/ai_provider_oauth_attempt.py
@@ -288,6 +288,10 @@ async def purge_expired_oauth_records(
 
 
 def validate_codex_oauth_provider_shape(provider: AiProvider | object) -> None:
+    if getattr(provider, "configuration_mode", None) == "connection":
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, "Connection providers require API-key authentication"
+        )
     provider_type = getattr(provider, "type", None)
     api_mode = getattr(provider, "api_mode", None)
     base_url = getattr(provider, "base_url", "")

--- a/backend/app/services/app_setting_registry.py
+++ b/backend/app/services/app_setting_registry.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import JsonValue, TypeAdapter, ValidationError
+from pydantic import Field, JsonValue, TypeAdapter, ValidationError
 
 from app.services.clerk_cli_oauth_settings import (
     CLERK_CLI_OAUTH_SETTING_ADAPTER,
@@ -30,7 +30,22 @@ CLERK_CLI_OAUTH_SPEC = AppSettingSpec[ClerkCliOAuthSetting](
     adapter=CLERK_CLI_OAUTH_SETTING_ADAPTER,
     description="Global Clerk Public OAuth Application configuration for the Clawdi CLI",
 )
-APP_SETTING_SPECS: tuple[AppSettingSpec[Any], ...] = (CLERK_CLI_OAUTH_SPEC,)
+SUPPORTED_CONNECTION_CLI_VERSIONS_SPEC = AppSettingSpec[list[str]](
+    key="supported_connection_cli_versions",
+    adapter=TypeAdapter(
+        list[
+            Annotated[
+                str,
+                Field(strict=True, pattern=r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"),
+            ]
+        ]
+    ),
+    description="Qualified exact CLI releases for existing-runtime connection ownership handoff",
+)
+APP_SETTING_SPECS: tuple[AppSettingSpec[Any], ...] = (
+    CLERK_CLI_OAUTH_SPEC,
+    SUPPORTED_CONNECTION_CLI_VERSIONS_SPEC,
+)
 APP_SETTING_SPEC_BY_KEY = {spec.key: spec for spec in APP_SETTING_SPECS}
 _JSON_VALUE_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -58,6 +58,7 @@ from app.schemas.runtime import (
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
 )
+from app.services.ai_provider_capabilities import effective_provider_api_mode
 from app.services.channels import (
     HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS,
     channel_runtime_account_key,
@@ -770,14 +771,22 @@ def render_runtime_source(
     providers = {
         provider_id: provider_material[provider_id] for provider_id in runtime["provider_ids"]
     }
+    if (
+        primary_model
+        and providers.get(primary_model["provider_id"], {}).get("configurationMode") == "connection"
+    ):
+        runtime["primary_model"] = None
+        primary_model = None
     if runtime.get("providerMode") == "configured" and not primary_model:
         native_chat = [
-            entry for entry in providers.values() if entry.get("configurationMode") == "native"
+            entry
+            for entry in providers.values()
+            if entry.get("configurationMode") in {"native", "connection"}
         ]
         catalog_chat = [
             entry
             for entry in providers.values()
-            if entry.get("configurationMode") != "native"
+            if entry.get("configurationMode") not in {"native", "connection"}
             and not (
                 entry.get("managed_by") == "clawdi"
                 and entry.get("models")
@@ -1175,12 +1184,27 @@ def _provider_entry(
         result["configurationMode"] = "native"
         result["nativeProvider"] = runtime_routing.provider
         runtime_env = runtime_routing.env or routing.runtime_env_name
+    if provider.configuration_mode == "connection":
+        api_mode = effective_provider_api_mode(provider.type, api_mode)
+        if (
+            managed
+            or provider.managed_by != "user"
+            or provider.auth_type not in {"api_key", "secret_ref"}
+            or not runtime_env
+            or not api_mode
+            or not secret_ref
+            or provider.native_provider
+            or provider.native_variant
+        ):
+            raise RuntimeSourceError("Connection management requires user API-key routing")
+        result["configurationMode"] = "connection"
+        result["managed_by"] = "user"
     if api_mode:
         result["apiMode"] = api_mode
     if provider.managed_by == "clawdi":
         result["managed_by"] = provider.managed_by
     models: list[dict[str, Any]] = []
-    if provider.models is not None:
+    if provider.models is not None and provider.configuration_mode != "connection":
         try:
             models = [
                 model.model_dump(exclude_none=True)
@@ -1189,7 +1213,7 @@ def _provider_entry(
         except ValidationError as exc:
             raise RuntimeSourceError("Stored AI provider model metadata is invalid") from exc
     if (
-        provider.configuration_mode != "native"
+        provider.configuration_mode not in {"native", "connection"}
         and selected_model
         and not any(model["id"] == selected_model for model in models)
     ):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -242,6 +242,7 @@ strict = [
     "app/services/ai_provider_auth_transition.py",
     "app/services/ai_provider_capabilities.py",
     "app/services/ai_provider_connection.py",
+    "app/services/ai_provider_connection_ownership.py",
     "app/services/ai_provider_credentials.py",
     "app/services/ai_provider_oauth_attempt.py",
     "app/services/ai_provider_oauth_lifecycle.py",

--- a/backend/tests/test_ai_provider_connection_ownership.py
+++ b/backend/tests/test_ai_provider_connection_ownership.py
@@ -1,0 +1,276 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.ai_provider import AiProviderAuthPayload
+from app.models.app_setting import AppSetting
+from app.models.hosted_runtime import HostedRuntimeState
+from app.schemas.runtime_observation import RuntimeObservationEventV2
+from app.services.runtime_observation import (
+    ingest_runtime_observation,
+    provision_runtime_environment_fence,
+)
+from app.services.runtime_source_revision import runtime_source_contract_revision
+from app.services.vault_crypto import decrypt
+from tests.conftest import create_env_with_project
+
+PROVIDER = "connection-test"
+ENV_NAME = "CONNECTION_API_KEY"
+REVISION = "a" * 64
+VERSION = "99.1.0"  # Synthetic qualified release; production allowlist remains empty.
+MODELS = [{"id": "saved-model", "context_window": 8192, "capabilities": {"tools": True}}]
+
+
+async def create_provider(client):
+    body = {
+        "provider_id": PROVIDER,
+        "type": "openai",
+        "base_url": "https://api.openai.com/v1",
+        "api_mode": "openai_responses",
+        "runtime_env_name": ENV_NAME,
+        "models": MODELS,
+        "auth": {"type": "api_key", "source": "managed"},
+    }
+    response = await client.post("/v1/ai-providers", json=body)
+    assert response.status_code == 200, response.text
+    response = await client.post(
+        f"/v1/ai-providers/{PROVIDER}/auth/api-key", json={"value": "original-test-key"}
+    )
+    assert response.status_code == 200, response.text
+    return body
+
+
+async def consumer(
+    db,
+    owner_id,
+    *,
+    version=VERSION,
+    captured_at=None,
+    source_revision=REVISION,
+    boot="boot-connection-test",
+):
+    env = await create_env_with_project(
+        db,
+        user_id=owner_id,
+        machine_id=str(uuid4()),
+        machine_name="Connection migration",
+        agent_type="openclaw",
+    )
+    deployment = f"dep-{env.id}"
+    state = HostedRuntimeState(
+        environment_id=env.id,
+        deployment_id=deployment,
+        instance_id=f"instance-{env.id}",
+        generation=1,
+        apply_generation=1,
+        source_revision=REVISION,
+        source_revision_contract=runtime_source_contract_revision(),
+        cli_package_spec=f"clawdi@{VERSION}",
+        locale={"language": "en", "timezone": "UTC"},
+        system={},
+        live_sync={},
+        recovery={},
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "providerMode": "configured",
+                "provider_ids": [PROVIDER],
+                "primary_model": {"provider_id": PROVIDER, "model": "saved-model"},
+                "install": {"source": "official"},
+            }
+        },
+    )
+    db.add(state)
+    await provision_runtime_environment_fence(
+        db, environment_id=env.id, owner_id=owner_id, deployment_id=deployment
+    )
+    now = captured_at or datetime.now(UTC)
+    observation = RuntimeObservationEventV2.model_validate(
+        {
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": now,
+            "capturedAt": now,
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": version,
+            "applied": {
+                "etag": f'"sha256:{source_revision}"',
+                "sourceRevision": source_revision,
+                "generation": 1,
+                "instanceId": state.instance_id,
+                "appliedProviderIds": [PROVIDER],
+            },
+            "boot": None,
+            "cli": None,
+            "applyReceiptId": "apply-connection-0001",
+            "bootNonce": "boot-nonce-connection-0001",
+            "bootSessionId": boot,
+            "sequence": 1,
+            "eventId": str(uuid4()),
+        }
+    )
+    await ingest_runtime_observation(
+        db,
+        environment_id=env.id,
+        credential_deployment_id=deployment,
+        value=observation,
+        received_at=now,
+    )
+    await db.commit()
+    return state
+
+
+@pytest.mark.asyncio
+async def test_mode_only_handoff_and_atomic_key_edit_preserve_identity_metadata_and_credentials(
+    client, db_session, seed_user
+):
+    original_body = await create_provider(client)
+    await consumer(db_session, seed_user.id)
+    db_session.add(AppSetting(key="supported_connection_cli_versions", value_json=[VERSION]))
+    await db_session.commit()
+    payload = await db_session.scalar(
+        select(AiProviderAuthPayload).where(
+            AiProviderAuthPayload.owner_user_id == seed_user.id,
+            AiProviderAuthPayload.provider_id == PROVIDER,
+        )
+    )
+    assert payload is not None
+    before = (payload.encrypted_payload, payload.nonce, payload.credential_revision)
+    migrated = await client.patch(
+        f"/v1/ai-providers/{PROVIDER}", json={"configuration_mode": "connection"}
+    )
+    assert migrated.status_code == 200, migrated.text
+    assert migrated.json()["models"] == MODELS
+    await db_session.refresh(payload)
+    assert (payload.encrypted_payload, payload.nonce, payload.credential_revision) == before
+    edited = await client.patch(
+        f"/v1/ai-providers/{PROVIDER}",
+        json={
+            "configuration_mode": "connection",
+            "label": "Edited connection",
+            "base_url": "https://proxy.example/v1",
+            "credential": {"type": "api_key", "value": "replacement-test-key"},
+        },
+    )
+    assert edited.status_code == 200, edited.text
+    assert edited.json()["configuration_mode"] == "connection"
+    assert edited.json()["base_url"] == "https://proxy.example/v1"
+    assert edited.json()["runtime_env_name"] == ENV_NAME
+    assert edited.json()["models"] == MODELS
+    assert "replacement-test-key" not in edited.text
+    await db_session.refresh(payload)
+    assert decrypt(payload.encrypted_payload, payload.nonce) == "replacement-test-key"
+
+    for patch in (
+        {"models": []},
+        {"models": None},
+        {"runtime_env_name": "OTHER_KEY"},
+        {"configuration_mode": "catalog"},
+        {"auth": {"type": "secret_ref", "ref": "env:OTHER_KEY"}},
+        {"auth": {"type": "agent_profile", "tool": "codex", "profile": "default"}},
+    ):
+        response = await client.patch(f"/v1/ai-providers/{PROVIDER}", json=patch)
+        assert response.status_code == 409, response.text
+    for path, body in (
+        (
+            f"/v1/ai-providers/{PROVIDER}/auth/api-key",
+            {"value": "wrong-key", "runtime_env_name": "OTHER_KEY"},
+        ),
+        (
+            f"/v1/ai-providers/{PROVIDER}/auth/import",
+            {"type": "agent_profile", "tool": "codex", "payload": "{}"},
+        ),
+        (f"/v1/ai-providers/{PROVIDER}/auth/oauth/start", {"provider": "codex"}),
+        (f"/v1/ai-providers/{PROVIDER}/auth/oauth/device/start", {"provider": "codex"}),
+        ("/v1/ai-providers?replace=true", original_body),
+        (
+            "/v1/ai-providers/accept",
+            {
+                "provider": original_body,
+                "credential": {"type": "api_key", "value": "wrong-key"},
+                "replace": True,
+            },
+        ),
+    ):
+        response = await client.post(path, json=body, headers={"Idempotency-Key": str(uuid4())})
+        assert response.status_code == 409, (path, response.text)
+        # /accept rolls back its request transaction on rejection; refresh the shared auth fixture.
+        await db_session.refresh(seed_user)
+    replaced = await client.post(
+        f"/v1/ai-providers/{PROVIDER}/auth/api-key", json={"value": "dedicated-replacement-key"}
+    )
+    assert replaced.status_code == 200, replaced.text
+    assert replaced.json()["configuration_mode"] == "connection"
+    assert replaced.json()["runtime_env_name"] == ENV_NAME
+    assert replaced.json()["models"] == MODELS
+    phantom = {
+        **original_body,
+        "provider_id": "phantom-connection",
+        "configuration_mode": "connection",
+    }
+    rejected = await client.post("/v1/ai-providers", json=phantom)
+    assert rejected.status_code == 422
+    rejected = await client.post(
+        "/v1/ai-providers/accept",
+        headers={"Idempotency-Key": str(uuid4())},
+        json={"provider": phantom, "credential": {"type": "api_key", "value": "unused-test-key"}},
+    )
+    assert rejected.status_code == 422
+    assert (await client.get("/v1/ai-providers/phantom-connection")).status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    [
+        "disabled",
+        "empty",
+        "fresh-agent",
+        "old-cli",
+        "pending-cli",
+        "stale",
+        "future",
+        "wrong-source",
+        "other-consumer",
+    ],
+)
+async def test_handoff_requires_all_existing_consumers_to_have_qualified_current_evidence(
+    client, db_session, seed_user, case
+):
+    await create_provider(client)
+    if case != "disabled":
+        db_session.add(
+            AppSetting(
+                key="supported_connection_cli_versions",
+                value_json=[] if case == "empty" else [VERSION],
+            )
+        )
+        await db_session.commit()
+    if case != "fresh-agent":
+        state = await consumer(
+            db_session,
+            seed_user.id,
+            version="0.14.56" if case == "old-cli" else VERSION,
+            captured_at=(
+                datetime.now(UTC) + timedelta(hours=1)
+                if case == "future"
+                else datetime.now(UTC) - timedelta(hours=1)
+                if case == "stale"
+                else None
+            ),
+            source_revision="b" * 64 if case == "wrong-source" else REVISION,
+        )
+        if case == "pending-cli":
+            state.cli_package_spec = "clawdi@0.14.56"
+            await db_session.commit()
+        if case == "other-consumer":
+            await consumer(db_session, seed_user.id, version="0.14.56")
+    response = await client.patch(
+        f"/v1/ai-providers/{PROVIDER}", json={"configuration_mode": "connection"}
+    )
+    assert response.status_code == 409, response.text
+    saved = (await client.get(f"/v1/ai-providers/{PROVIDER}")).json()
+    assert saved["configuration_mode"] == "catalog"
+    assert saved["models"] == MODELS

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -385,6 +385,38 @@ def _render(batch: RuntimeSourceBatch):
     )
 
 
+def connection_source_fixture() -> RuntimeSourceBatch:
+    batch = _batch()
+    _replace_runtime_provider(
+        batch, provider_id="saved-connection", provider_row_id=uuid4(), auth_row_id=uuid4()
+    )
+    provider = batch.providers[(USER_ID, "saved-connection")]
+    provider.configuration_mode = "connection"
+    provider.managed_by = "user"
+    provider.api_mode = "openai_responses"
+    provider.runtime_env_name = "SAVED_CONNECTION_KEY"
+    provider.models = [{"id": "historic-model", "context_window": 8192}]
+    return batch
+
+
+def test_connection_source_emits_only_owned_routing_and_credentials() -> None:
+    batch = connection_source_fixture()
+    source = _render(batch)
+    provider = source.manifest["providers"]["saved-connection"]
+    assert provider["configurationMode"] == "connection"
+    assert provider["managed_by"] == "user"
+    assert provider["runtimeEnvName"] == "SAVED_CONNECTION_KEY"
+    assert provider["apiKeySecretRef"]
+    assert "models" not in provider
+    assert "nativeProvider" not in provider
+    assert source.manifest["runtimes"]["openclaw"]["primary_model"] is None
+    assert batch.providers[(USER_ID, "saved-connection")].models == [
+        {"id": "historic-model", "context_window": 8192}
+    ]
+    batch.providers[(USER_ID, "saved-connection")].api_mode = None
+    assert _render(batch).manifest["providers"]["saved-connection"]["apiMode"] == "openai_responses"
+
+
 def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sources() -> None:
     initial = _render(_batch())
     irrelevant = _render(_batch(provider_label="Renamed", channel_name="Renamed bot"))

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
         "eventsource-parser": "^4.1.0",
+        "json5": "2.2.3",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.22",
         "typescript": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.57",
+      "version": "0.14.58",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -19,6 +19,11 @@ Clawdi does not pick a default model or copy a catalog for these connections.
 Credentials can be deployable while inference remains `not_tested` and
 `primary_model` is null.
 
+The Web editor preserves existing catalog connections. It does not convert them
+in place: removing an old custom provider while preserving its model selector
+can leave an invalid runtime selection. To move to native model management,
+create a separate native connection and select its provider/model inside the agent.
+
 `native_provider` identifies the connection and `native_variant` optionally
 identifies its region or plan. The shared
 [`native-ai-providers.json`](../packages/shared/src/native-ai-providers.json) contains only

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -19,10 +19,32 @@ Clawdi does not pick a default model or copy a catalog for these connections.
 Credentials can be deployable while inference remains `not_tested` and
 `primary_model` is null.
 
-The Web editor preserves existing catalog connections. It does not convert them
-in place: removing an old custom provider while preserving its model selector
-can leave an invalid runtime selection. To move to native model management,
-create a separate native connection and select its provider/model inside the agent.
+The Web editor preserves each saved connection's ownership mode. Existing
+catalog connections can migrate in place through a mode-only
+`PATCH /v1/ai-providers/{provider_id}` with `configuration_mode: "connection"`.
+This one-way handoff keeps the saved ID, endpoint, protocol, key, and historical
+model metadata. It requires an already-bound runtime with the existing native
+provider row; it never creates a provider or seeds models on a fresh agent.
+
+For `connection`, the agent owns model selection, model metadata, and model
+parameters. Core retains historical metadata for reference but emits neither
+provider models nor a primary model for this connection. Web hides its model
+editor and automatic inference tests. Connection edits may change the endpoint,
+protocol, or label; an optional `credential: {type: "api_key", value: "..."}`
+in the same PATCH replaces the key atomically. The runtime environment name and
+API-key auth identity remain fixed. Upsert/accept cannot replace a connection,
+and OAuth conversion and model updates are rejected. Unbinding removes only
+owned credential references and retains the native provider's routing and models.
+
+First migration is disabled unless the registered database setting
+`supported_connection_cli_versions` contains a qualified exact stable CLI
+version. Missing or empty settings deny migration. Every existing consumer
+must have a fresh, unambiguous accepted v2 observation with that running CLI
+version and matching current source/applied identity. Installed-version metadata
+alone is insufficient. The allowlist is managed through the audited admin settings
+API and must remain empty until a supporting release is qualified and published.
+Include files whose native inspection redacts credential ownership are excluded
+from this migration rather than guessed.
 
 `native_provider` identifies the connection and `native_variant` optionally
 identifies its region or plan. The shared

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
 		"chalk": "^6.0.0",
 		"commander": "^15.0.0",
 		"eventsource-parser": "^4.1.0",
+		"json5": "2.2.3",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.22",
 		"typescript": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.57",
+	"version": "0.14.58",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	type AiProviderAuth,
 	type AiProviderCatalog,
 	CLAWDI_MANAGED_PROVIDER_ID,
 	CODEX_OAUTH_MODEL_CATALOG,
@@ -292,8 +293,43 @@ describe("AI provider projection", () => {
 		}
 	});
 
+	test("requires an explicit chat primary even when catalog defaults and models exist", () => {
+		for (const target of ["openclaw", "hermes", "codex"] as const) {
+			expect(() => buildAgentTargetProjection(target, byokOpenAiCatalog, null)).toThrow(
+				"No primary model is configured",
+			);
+		}
+	});
+
+	test("binds each explicit env credential as API-key auth", () => {
+		const auths: AiProviderAuth[] = [
+			{ type: "api_key", source: "env", ref: "env:SELECTED_KEY" },
+			{ type: "secret_ref", ref: "env:SELECTED_KEY" },
+		];
+		for (const auth of auths) {
+			const catalog: AiProviderCatalog = {
+				...byokOpenAiCatalog,
+				providers: byokOpenAiCatalog.providers.map((provider) => ({
+					...provider,
+					auth,
+					runtime_env_name: "SELECTED_KEY",
+				})),
+			};
+			const projection = buildAgentTargetProjection("openclaw", catalog, {
+				provider_id: "openai-main",
+				model: "gpt-5.6-sol",
+			});
+			const patch = JSON.parse(projection.files[0]?.content ?? "{}");
+			expect(patch.models.providers["openai-main"]).toMatchObject({
+				auth: "api-key",
+				apiKey: { source: "env", provider: "default", id: "SELECTED_KEY" },
+			});
+		}
+	});
+
 	test("maps known BYOK OpenAI providers to all runtime targets without extra user fields", () => {
-		const openclaw = buildAgentTargetProjection("openclaw", byokOpenAiCatalog);
+		const primaryModel = { provider_id: "openai-main", model: "gpt-5.6-sol" };
+		const openclaw = buildAgentTargetProjection("openclaw", byokOpenAiCatalog, primaryModel);
 		expect(openclaw.provider_ids).toEqual(["openai-main"]);
 		expect(openclaw.primary_model).toEqual({
 			provider_id: "openai-main",
@@ -302,7 +338,7 @@ describe("AI provider projection", () => {
 		expect(openclaw.files[0]?.content).toContain('"baseUrl": "https://api.openai.com/v1"');
 		expect(openclaw.files[0]?.content).toContain('"api": "openai-responses"');
 		expect(openclaw.files[0]?.content).toContain('"id": "OPENAI_API_KEY"');
-		expect(openclaw.files[0]?.content).not.toContain('"auth": "api-key"');
+		expect(openclaw.files[0]?.content).toContain('"auth": "api-key"');
 		expect(openclaw.files[0]?.content).not.toContain('"memory"');
 		const managedToByokPatch = JSON.parse(
 			buildOpenClawHostedProviderPatch(
@@ -324,13 +360,13 @@ describe("AI provider projection", () => {
 		});
 		expect(managedToByokPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toBeNull();
 
-		const hermes = buildAgentTargetProjection("hermes", byokOpenAiCatalog);
+		const hermes = buildAgentTargetProjection("hermes", byokOpenAiCatalog, primaryModel);
 		expect(hermes.files[0]?.content).toContain('provider: "custom:openai-main"');
 		expect(hermes.files[0]?.content).toContain('api: "https://api.openai.com/v1"');
 		expect(hermes.files[0]?.content).toContain('transport: "codex_responses"');
 		expect(hermes.files[0]?.content).toContain('key_env: "OPENAI_API_KEY"');
 
-		const codex = buildAgentTargetProjection("codex", byokOpenAiCatalog);
+		const codex = buildAgentTargetProjection("codex", byokOpenAiCatalog, primaryModel);
 		expect(codex.files[0]?.content).toContain('model = "gpt-5.6-sol"');
 		expect(codex.files[0]?.content).toContain('model_provider = "openai-main"');
 		expect(codex.files[0]?.content).toContain('[model_providers."openai-main"]');
@@ -338,6 +374,7 @@ describe("AI provider projection", () => {
 	});
 
 	test("projects Gemini only to the runtime with a verified transport", () => {
+		const primaryModel = { provider_id: "gemini-main", model: "gemini-2.5-pro" };
 		const catalog: AiProviderCatalog = {
 			schema_version: 1,
 			providers: [
@@ -363,15 +400,16 @@ describe("AI provider projection", () => {
 			},
 		};
 
-		const openclaw = buildAgentTargetProjection("openclaw", catalog);
+		const openclaw = buildAgentTargetProjection("openclaw", catalog, primaryModel);
 		expect(openclaw.provider_ids).toEqual(["gemini-main"]);
 		expect(JSON.parse(openclaw.files[0]?.content ?? "{}").agents.defaults.memorySearch).toBeNull();
-		expect(() => buildAgentTargetProjection("hermes", catalog)).toThrow(
+		expect(() => buildAgentTargetProjection("hermes", catalog, primaryModel)).toThrow(
 			"does not map to a verified Hermes custom-provider transport",
 		);
 	});
 
 	test("rejects non-canonical Codex auth profiles from Codex projection", () => {
+		const primaryModel = { provider_id: "openai-codex", model: "gpt-5.6-sol" };
 		const catalog: AiProviderCatalog = {
 			...codexOAuthCatalog,
 			providers: [
@@ -382,28 +420,31 @@ describe("AI provider projection", () => {
 			],
 		};
 
-		expect(() => buildAgentTargetProjection("codex", catalog)).toThrow(
+		expect(() => buildAgentTargetProjection("codex", catalog, primaryModel)).toThrow(
 			"provider protocol and auth shape are not runtime-compatible",
 		);
 	});
 
 	test("keeps native Codex OAuth projections on the verified OpenAI/Codex path", () => {
-		const openclaw = buildAgentTargetProjection("openclaw", codexOAuthCatalog);
+		const primaryModel = { provider_id: "openai-codex", model: "gpt-5.6-sol" };
+		const openclaw = buildAgentTargetProjection("openclaw", codexOAuthCatalog, primaryModel);
 		expect(openclaw.files[0]?.content).toContain('"plugins": {');
 		expect(openclaw.files[0]?.content).toContain('"primary": "openai/gpt-5.6-sol"');
+		expect(openclaw.files[0]?.content).not.toContain('"auth": "api-key"');
 
-		const hermes = buildAgentTargetProjection("hermes", codexOAuthCatalog);
+		const hermes = buildAgentTargetProjection("hermes", codexOAuthCatalog, primaryModel);
 		expect(hermes.files[0]?.content).toContain('provider: "openai-codex"');
 		expect(hermes.files[0]?.content).toContain('default: "gpt-5.6-sol"');
 		expect(hermes.files[0]?.content).not.toContain("base_url:");
 
-		const codex = buildAgentTargetProjection("codex", codexOAuthCatalog);
+		const codex = buildAgentTargetProjection("codex", codexOAuthCatalog, primaryModel);
 		expect(codex.files[0]?.content).toContain('model = "gpt-5.6-sol"');
 		expect(codex.files[0]?.content).toContain('model_provider = "openai"');
 		expect(codex.files[0]?.content).not.toContain('[model_providers."openai-codex"]');
 	});
 
 	test("projects model alias and cost metadata to runtime-native fields", () => {
+		const primaryModel = { provider_id: "custom-main", model: "example-model" };
 		const catalog: AiProviderCatalog = {
 			schema_version: 1,
 			providers: [
@@ -427,13 +468,13 @@ describe("AI provider projection", () => {
 			defaults: { chat_provider_id: "custom-main" },
 		};
 
-		const openclaw = buildAgentTargetProjection("openclaw", catalog);
+		const openclaw = buildAgentTargetProjection("openclaw", catalog, primaryModel);
 		expect(openclaw.files[0]?.content).toContain('"name": "Example Model"');
 		expect(openclaw.files[0]?.content).toContain('"cost": {');
 		expect(openclaw.files[0]?.content).toContain('"cacheRead": 0.06');
 		expect(openclaw.files[0]?.content).toContain('"cacheWrite": 0');
 
-		const hermes = buildAgentTargetProjection("hermes", catalog);
+		const hermes = buildAgentTargetProjection("hermes", catalog, primaryModel);
 		expect(hermes.files[0]?.content).toContain("input_cost_per_million: 0.3");
 		expect(hermes.files[0]?.content).toContain("output_cost_per_million: 1.2");
 		expect(hermes.files[0]?.content).toContain("cache_read_cost_per_million: 0.06");
@@ -441,6 +482,7 @@ describe("AI provider projection", () => {
 	});
 
 	test("preserves opaque OpenClaw compat fields with explicit values taking precedence", () => {
+		const primaryModel = { provider_id: "custom-main", model: "k3" };
 		const catalog: AiProviderCatalog = {
 			schema_version: 1,
 			providers: [
@@ -468,7 +510,7 @@ describe("AI provider projection", () => {
 			defaults: { chat_provider_id: "custom-main" },
 		};
 
-		const projection = buildAgentTargetProjection("openclaw", catalog);
+		const projection = buildAgentTargetProjection("openclaw", catalog, primaryModel);
 		const patch = JSON.parse(projection.files[0]?.content ?? "{}") as {
 			models?: { providers?: Record<string, { models?: Array<Record<string, unknown>> }> };
 		};

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -98,7 +98,7 @@ const HERMES_TRANSPORT_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 export function buildAgentTargetProjection(
 	target: AgentTarget,
 	catalog: AiProviderCatalog,
-	primaryModel?: AgentPrimaryModel | null,
+	primaryModel: AgentPrimaryModel | null,
 	options: { freezeManagedModelCatalog?: boolean } = {},
 ): AgentTargetProjection {
 	if (catalog.providers.some((provider) => provider.configuration_mode === "native"))
@@ -153,7 +153,7 @@ export function buildAgentTargetProjection(
 function selectProjectionProviders(
 	target: AgentTarget,
 	catalog: AiProviderCatalog,
-	primaryModel: AgentPrimaryModel | null | undefined,
+	primaryModel: AgentPrimaryModel | null,
 ): {
 	providers: ProjectionProvider[];
 	primaryProvider: ProjectionProvider | null;
@@ -183,15 +183,14 @@ function selectProjectionProviders(
 	) {
 		return { providers, primaryProvider: null, primaryModel: null, warnings };
 	}
-	const selectedPrimaryModelInput = primaryModel ?? legacyCatalogPrimaryModel(catalog, providers);
-	if (!selectedPrimaryModelInput) {
+	if (!primaryModel) {
 		throw new Error(
 			`No primary model is configured for ${target}; pass agent primary_model {provider_id, model} before agent config apply.`,
 		);
 	}
 	const selectedPrimaryModel = {
-		...selectedPrimaryModelInput,
-		provider_id: agentFacingProviderId(selectedPrimaryModelInput.provider_id),
+		...primaryModel,
+		provider_id: agentFacingProviderId(primaryModel.provider_id),
 	};
 	if (hasLegacyOpenAiCodexModelPrefix(selectedPrimaryModel.model)) {
 		throw new Error(
@@ -265,24 +264,6 @@ function normalizeProjectionProvider(
 	return projectionProvider;
 }
 
-function legacyCatalogPrimaryModel(
-	catalog: AiProviderCatalog,
-	providers: ProjectionProvider[],
-): AgentPrimaryModel | undefined {
-	const preferredProviderId = agentFacingProviderId(
-		catalog.defaults?.chat_provider_id ?? catalog.providers[0]?.id ?? "",
-	);
-	const preferredProvider =
-		providers.find((provider) => provider.id === preferredProviderId) ?? providers[0];
-	if (!preferredProvider) return undefined;
-	const source = catalog.providers.find(
-		(provider) => agentFacingProviderId(provider.id) === preferredProvider.id,
-	);
-	const model = source ? (legacyProviderDefaultModel(source) ?? source.models?.[0]?.id) : undefined;
-	if (!model) return undefined;
-	return { provider_id: preferredProvider.id, model };
-}
-
 function agentFacingProviderId(providerId: string): string {
 	return isClawdiManagedV2ProviderId(providerId) ? CLAWDI_MANAGED_PROVIDER_ID : providerId;
 }
@@ -336,7 +317,7 @@ function buildOpenClawProjection(
 					compactObject({
 						baseUrl: openClawBaseUrlForProvider(provider),
 						api: openClawProviderApiLabel(provider.api_mode),
-						auth: apiKeyEnv && provider.id === CLAWDI_MANAGED_PROVIDER_ID ? "api-key" : undefined,
+						auth: apiKeyEnv ? "api-key" : undefined,
 						apiKey: apiKeyEnv ? { source: "env", provider: "default", id: apiKeyEnv } : undefined,
 						models: openClawModels(
 							provider,

--- a/packages/cli/src/runtime/connection-provider-config.test.ts
+++ b/packages/cli/src/runtime/connection-provider-config.test.ts
@@ -1,0 +1,412 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseDocument } from "yaml";
+import {
+	applyConnectionProviderTransfers,
+	type ConnectionProviderOwnership,
+	prepareConnectionProviderTransfers,
+} from "./connection-provider-config";
+import { getHermesRawConfigValue, type HermesConfigTransaction } from "./hermes-config";
+import { createOpenClawHostedContext } from "./hosted-openclaw-context";
+import {
+	hostedProviderConfiguration,
+	hostedProviderEnvironment,
+} from "./hosted-provider-resolution";
+import type { RuntimeManifest } from "./manifest-contract";
+import type { RuntimeInstallObservation } from "./manifest-install";
+import { applyHostedAiProviderProjection } from "./manifest-providers";
+import { recordValue } from "./manifest-shared";
+import { getRuntimePaths } from "./paths";
+import { readProviderOwnership, writeProviderOwnership } from "./provider-ownership";
+
+const id = "saved-provider";
+const envName = "SAVED_PROVIDER_API_KEY";
+const baseUrl = "https://provider.example/v1";
+
+function fixture(runtime: "openclaw" | "hermes") {
+	const home = mkdtempSync(join(tmpdir(), "clawdi-connection-"));
+	const manifest: RuntimeManifest = {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "test",
+		environmentId: "test",
+		instanceId: "test",
+		generation: 1,
+		issuedAt: "2026-09-08T00:00:00Z",
+		runtime,
+		controlPlane: { apiUrl: "https://core.example.test" },
+		recovery: {},
+		runtimes: {
+			[runtime]: {
+				enabled: true,
+				providerMode: "configured",
+				provider_ids: [id],
+				primary_model: null,
+				services: {},
+			},
+		},
+		projection: {
+			providers: {
+				[id]: {
+					kind: "openai-compatible",
+					type: "custom_openai_compatible",
+					configurationMode: "connection",
+					managed_by: "user",
+					baseUrl,
+					apiMode: "openai_chat",
+					runtimeEnvName: envName,
+					apiKeySecretRef: "secret://provider.saved-provider.apiKey",
+				},
+			},
+		},
+	};
+	const openClawContext = createOpenClawHostedContext(manifest, home);
+	if (runtime === "openclaw")
+		manifest.openclawGatewayAuth = {
+			mode: "token",
+			tokenRef: "secret://runtime/openclaw/gateway-token",
+			deviceAuthRequired: false,
+			activation: { enabled: true, capability: "openclaw-native-auth-v1" },
+		};
+	mkdirSync(openClawContext.stateRoot, { recursive: true });
+	const command = join(home, "native-config");
+	writeFileSync(
+		command,
+		`#!/usr/bin/env python3
+import json, os, sys
+assert sys.argv[1:] == ["config", "patch", "--stdin"]
+path = os.path.join(os.path.dirname(__file__), ".openclaw", "openclaw.json")
+with open(path) as file: config = json.load(file)
+def merge(target, patch):
+    for key, value in patch.items():
+        if value is None: target.pop(key, None)
+        elif isinstance(value, dict): merge(target.setdefault(key, {}), value)
+        else: target[key] = value
+merge(config, json.load(sys.stdin))
+with open(path, "w") as file: json.dump(config, file)
+`,
+		{ mode: 0o755 },
+	);
+	const provider =
+		runtime === "openclaw"
+			? {
+					baseUrl,
+					auth: "api-key",
+					apiKey: { source: "env", provider: "default", id: envName },
+					models: [{ id: "existing", name: "Existing", params: { temperature: 0.4 } }],
+					params: { custom: true },
+				}
+			: {
+					api: baseUrl,
+					transport: "chat_completions",
+					key_env: envName,
+					models: { existing: { context_length: 8192 } },
+					extra_body: { custom: true },
+				};
+	writeFileSync(
+		openClawContext.configPath,
+		JSON.stringify({
+			models: { mode: "replace", providers: { [id]: provider } },
+			agents: { defaults: { model: { primary: `${id}/existing` } } },
+		}),
+	);
+	const document = parseDocument(
+		JSON.stringify({
+			providers: { [id]: provider },
+			model: { provider: `custom:${id}`, default: "existing" },
+		}),
+	);
+	const hermesConfig: HermesConfigTransaction = {
+		context: { command, home, cwd: home },
+		path: join(home, ".hermes/config.yaml"),
+		sourceContent: document.toString(),
+		document,
+		changed: false,
+	};
+	if (runtime === "hermes") {
+		const app = join(home, ".hermes/hermes-agent");
+		for (const directory of ["agent", "hermes_cli", ".venv/bin"])
+			mkdirSync(join(app, directory), { recursive: true });
+		// Public API contract doubles; no private pool layout knowledge in the adapter.
+		writeFileSync(
+			join(app, "agent/credential_pool.py"),
+			"def custom_provider_pool_key_candidates(base_url, provider_name=None):\n    return [provider_name]\n",
+		);
+		writeFileSync(
+			join(app, "hermes_cli/auth.py"),
+			"import os\ndef read_credential_pool(key):\n    return [object()] if os.path.exists(os.path.join(os.environ['HERMES_HOME'], 'pool-conflict')) else []\n",
+		);
+		symlinkSync("/usr/bin/python3", join(app, ".venv/bin/python"));
+	}
+	const observation: RuntimeInstallObservation = {
+		runtime,
+		enabled: true,
+		status: "present",
+		commandPath: command,
+		executionUser: null,
+		appRoot: null,
+		install: null,
+		installerUrl: null,
+		executedInstallerUrl: null,
+		exitCode: null,
+		error: null,
+	};
+	let ownership: ConnectionProviderOwnership = { providers: {} };
+	const secretValues: Record<string, string> = {
+		"secret://provider.saved-provider.apiKey": "test-key-one",
+		"secret://runtime/openclaw/gateway-token": "test-gateway-token",
+	};
+	const input = () => ({
+		runtime,
+		manifest,
+		observation,
+		home,
+		openClawContext,
+		workspaceRoot: home,
+		hermesConfig,
+		secretValues,
+		ownership,
+	});
+	const prepare = () => {
+		const prepared = prepareConnectionProviderTransfers(input());
+		ownership = { providers: prepared.providers, prepared };
+		return prepared;
+	};
+	const read = () =>
+		runtime === "hermes"
+			? recordValue(getHermesRawConfigValue(hermesConfig, "providers").value)?.[id]
+			: JSON.parse(readFileSync(openClawContext.configPath, "utf8")).models.providers[id];
+	const set = (value: unknown) => {
+		if (runtime === "hermes") document.setIn(["providers", id], value);
+		else {
+			const config = JSON.parse(readFileSync(openClawContext.configPath, "utf8"));
+			config.models.providers[id] = value;
+			writeFileSync(openClawContext.configPath, JSON.stringify(config));
+		}
+	};
+	return {
+		home,
+		manifest,
+		input,
+		prepare,
+		read,
+		set,
+		secretValues,
+		restoreOwnership: (providers: ConnectionProviderOwnership["providers"]) => {
+			ownership = { providers };
+		},
+		cleanup: () => rmSync(home, { recursive: true, force: true }),
+	};
+}
+
+function applyProjector(f: ReturnType<typeof fixture>, previousProviderIds: string[] = [id]) {
+	const input = f.input();
+	return applyHostedAiProviderProjection(
+		input.runtime,
+		input.observation,
+		input.manifest,
+		input.secretValues,
+		input.home,
+		input.openClawContext,
+		input.workspaceRoot,
+		previousProviderIds,
+		false,
+		input.hermesConfig,
+		"test-revision",
+		[],
+		input.ownership,
+	);
+}
+
+for (const runtime of ["openclaw", "hermes"] as const) {
+	test(`${runtime}: explicit catalog primary supersedes connection selection despite permanent tombstone`, () => {
+		const f = fixture(runtime);
+		try {
+			const original = recordValue(f.read());
+			f.prepare();
+			applyProjector(f);
+			const nextId = "next-provider";
+			f.manifest.runtimes[runtime].provider_ids = [nextId];
+			f.manifest.runtimes[runtime].primary_model = { provider_id: nextId, model: "next-model" };
+			f.manifest.projection = {
+				providers: {
+					[nextId]: {
+						kind: "openai-compatible",
+						type: "custom_openai_compatible",
+						configurationMode: "catalog",
+						managed_by: "user",
+						baseUrl: "https://next.example/v1",
+						apiMode: "openai_chat",
+						runtimeEnvName: "NEXT_PROVIDER_KEY",
+						apiKeySecretRef: "secret://provider.next.apiKey",
+						models: [{ id: "next-model" }],
+					},
+				},
+			};
+			f.secretValues["secret://provider.next.apiKey"] = "next-test-key";
+			const input = f.input();
+			if (runtime === "openclaw") {
+				const config = JSON.parse(readFileSync(input.openClawContext.configPath, "utf8"));
+				config.models.mode = "merge";
+				writeFileSync(input.openClawContext.configPath, JSON.stringify(config));
+				const sdkPath = join(f.home, "config-mutation.mjs");
+				writeFileSync(
+					sdkPath,
+					`import {readFileSync, writeFileSync} from "node:fs";
+const path = ${JSON.stringify(input.openClawContext.configPath)};
+export async function readConfigFileSnapshotForWrite() {
+    return {snapshot: {valid: true, sourceConfig: JSON.parse(readFileSync(path, "utf8"))}};
+}
+export async function mutateConfigFile(options) {
+    const config = JSON.parse(readFileSync(path, "utf8"));
+    await options.mutate(config);
+    writeFileSync(path, JSON.stringify(config));
+}
+`,
+				);
+				input.openClawContext.sdk.configMutation = sdkPath;
+			}
+			f.prepare();
+			const result = applyProjector(f);
+			expect(result.providerIds).toEqual([nextId]);
+			expect(f.input().ownership.providers[id]).toBeDefined();
+			const retained = recordValue(f.read());
+			expect(retained?.models).toEqual(original?.models);
+			expect(retained?.apiKey ?? retained?.key_env).toBeUndefined();
+			expect(runtime === "openclaw" ? retained?.baseUrl : retained?.api).toBe(baseUrl);
+			if (runtime === "hermes") {
+				expect(getHermesRawConfigValue(input.hermesConfig, "model.provider").value).toBe(
+					`custom:${nextId}`,
+				);
+				expect(getHermesRawConfigValue(input.hermesConfig, "model.default").value).toBe(
+					"next-model",
+				);
+			} else {
+				const config = JSON.parse(readFileSync(input.openClawContext.configPath, "utf8"));
+				expect(config.agents.defaults.model.primary).toBe(`${nextId}/next-model`);
+				expect(config.models.mode).toBe("replace");
+			}
+		} finally {
+			f.cleanup();
+		}
+	});
+
+	test(`${runtime}: journal persisted before any config write still permits auth-only unbind`, () => {
+		const f = fixture(runtime);
+		try {
+			const before = f.read();
+			const plan = f.prepare();
+			const paths = { ...getRuntimePaths(), serviceStateRoot: join(f.home, "journal") };
+			mkdirSync(paths.serviceStateRoot);
+			const journal = readProviderOwnership(paths, "test", f.home, { [runtime]: [id] });
+			journal.transfers[runtime] = plan.providers;
+			writeProviderOwnership(paths, "test", f.home, journal);
+			// Simulate process loss here: do not apply the prepared native config patch.
+			expect(f.read()).toEqual(before);
+			const recovered = readProviderOwnership(paths, "test", f.home, { [runtime]: [id] });
+			f.restoreOwnership(recovered.transfers[runtime] ?? {});
+			f.manifest.runtimes[runtime].provider_ids = [];
+			f.manifest.runtimes[runtime].providerMode = "unmanaged";
+			f.prepare();
+			applyProjector(f);
+			const after = recordValue(f.read());
+			expect(after?.models).toEqual(recordValue(before)?.models);
+			expect(runtime === "openclaw" ? after?.baseUrl : after?.api).toBe(baseUrl);
+			expect(after?.apiKey ?? after?.key_env).toBeUndefined();
+			expect(recovered.providers[runtime]).toEqual([]);
+		} finally {
+			f.cleanup();
+		}
+	});
+
+	test(`${runtime}: migration, failed authority and unbind retain the handed-off provider`, () => {
+		const f = fixture(runtime);
+		try {
+			const before = f.read();
+			expect(hostedProviderConfiguration(f.manifest, runtime).catalog).toBeNull();
+			const plan = f.prepare();
+			const paths = { ...getRuntimePaths(), serviceStateRoot: join(f.home, "journal") };
+			mkdirSync(paths.serviceStateRoot);
+			const journal = readProviderOwnership(paths, "test", f.home, { [runtime]: [id] });
+			journal.transfers[runtime] = plan.providers;
+			writeProviderOwnership(paths, "test", f.home, journal);
+			applyConnectionProviderTransfers(f.input());
+			// The previous applied state never advanced. Durable transfer still defeats its stale catalog ID.
+			const recovered = readProviderOwnership(paths, "test", f.home, { [runtime]: [id] });
+			expect(recovered.providers[runtime]).toEqual([]);
+			f.manifest.runtimes[runtime].provider_ids = [];
+			f.manifest.runtimes[runtime].providerMode = "unmanaged";
+			f.prepare();
+			applyConnectionProviderTransfers(f.input());
+			const after = recordValue(f.read());
+			const original = recordValue(before);
+			expect(after?.models).toEqual(original?.models);
+			expect(runtime === "openclaw" ? after?.baseUrl : after?.api).toBe(baseUrl);
+			expect(after?.apiKey ?? after?.key_env).toBeUndefined();
+		} finally {
+			f.cleanup();
+		}
+	});
+
+	test(`${runtime}: rotation preserves user model edits; preflight rejects route/auth conflicts without writes`, () => {
+		const f = fixture(runtime);
+		try {
+			const original = recordValue(f.read()) ?? {};
+			f.set(undefined);
+			expect(() => f.prepare()).toThrow("must already exist");
+			f.set({
+				...original,
+				...(runtime === "openclaw" ? { apiKey: "foreign-key" } : { key_cmd: "foreign-command" }),
+			});
+			expect(() => f.prepare()).toThrow("credential ownership conflict");
+			f.set({
+				...original,
+				...(runtime === "openclaw"
+					? { baseUrl: "https://changed.example/v1" }
+					: { api: "https://changed.example/v1" }),
+			});
+			const conflict = f.read();
+			expect(() => f.prepare()).toThrow("routing changed");
+			expect(f.read()).toEqual(conflict);
+			f.set(original);
+			f.prepare();
+			applyConnectionProviderTransfers(f.input());
+			const edited = {
+				...recordValue(f.read()),
+				models:
+					runtime === "openclaw"
+						? [{ id: "user-model", name: "User model" }]
+						: { "user-model": {} },
+			};
+			f.set(edited);
+			f.prepare();
+			applyConnectionProviderTransfers({
+				...f.input(),
+				secretValues: { "secret://provider.saved-provider.apiKey": "test-key-rotated" },
+			});
+			expect(f.read()).toEqual(edited);
+			expect(hostedProviderEnvironment(f.manifest, runtime).secretEnv).toEqual({
+				[envName]: "secret://provider.saved-provider.apiKey",
+			});
+			f.prepare();
+			f.set({ ...edited, models: [] });
+			expect(() => applyConnectionProviderTransfers(f.input())).toThrow("changed after preflight");
+		} finally {
+			f.cleanup();
+		}
+	});
+}
+
+test("Hermes public pool conflict prevents ownership transfer and config mutation", () => {
+	const f = fixture("hermes");
+	try {
+		writeFileSync(join(f.home, ".hermes/pool-conflict"), "present");
+		const before = f.read();
+		expect(() => f.prepare()).toThrow("credential conflict");
+		expect(f.read()).toEqual(before);
+		expect(f.input().ownership.providers).toEqual({});
+	} finally {
+		f.cleanup();
+	}
+});

--- a/packages/cli/src/runtime/connection-provider-config.ts
+++ b/packages/cli/src/runtime/connection-provider-config.ts
@@ -1,0 +1,284 @@
+import { join } from "node:path";
+import type { AiProviderApiMode } from "@clawdi/shared";
+import {
+	getHermesRawConfigValue,
+	type HermesConfigTransaction,
+	reconcileHermesConfigValue,
+} from "./hermes-config";
+import type { OpenClawHostedContext } from "./hosted-openclaw-context";
+import { customProviderConnections, hostedProviderEnvironment } from "./hosted-provider-resolution";
+import type { RuntimeManifest } from "./manifest-contract";
+import { type RuntimeInstallObservation, runtimeAppRoot } from "./manifest-install";
+import { canonicalJsonEqual, recordValue } from "./manifest-shared";
+import { readOpenClawProviderConfig } from "./openclaw-native-provider";
+import { runtimeImpactRevision } from "./runtime-impact-revision";
+import { spawnRuntimeUserCommand } from "./runtime-user-command";
+import { runtimeSecretValue } from "./secret-values";
+
+export interface ConnectionProviderTransfer {
+	envName: string;
+	baseUrl: string;
+	apiMode: AiProviderApiMode;
+}
+
+export interface ConnectionProviderOwnership {
+	providers: Record<string, ConnectionProviderTransfer>;
+	prepared?: PreparedConnectionProviderTransfers;
+}
+
+export interface PreparedConnectionProviderTransfers {
+	runtime: string;
+	providers: Record<string, ConnectionProviderTransfer>;
+	sourceRevision: string;
+	patch: Record<string, Record<string, unknown>>;
+}
+
+interface ConnectionContext {
+	runtime: string;
+	manifest: RuntimeManifest;
+	observation: RuntimeInstallObservation;
+	home: string;
+	openClawContext: OpenClawHostedContext;
+	workspaceRoot: string;
+	hermesConfig: HermesConfigTransaction | null;
+	secretValues?: Record<string, string>;
+	ownership: ConnectionProviderOwnership;
+}
+
+const OPENCLAW_API: Record<AiProviderApiMode, string> = {
+	openai_chat: "openai-completions",
+	openai_responses: "openai-responses",
+	anthropic_messages: "anthropic-messages",
+	google_generate_content: "google-generative-ai",
+};
+const HERMES_API: Partial<Record<AiProviderApiMode, string>> = {
+	openai_chat: "chat_completions",
+	openai_responses: "codex_responses",
+	anthropic_messages: "anthropic_messages",
+};
+
+// Public installed APIs only. Never load_pool(): it can seed/write credentials.
+// NousResearch/hermes-agent@0d08cd295fd73427833ee349eb858569d4d0dd3a.
+const HERMES_POOL_GUARD = `
+import contextlib, io, json, sys
+sys.path.insert(0, sys.argv[1])
+with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+    from agent.credential_pool import custom_provider_pool_key_candidates
+    from hermes_cli.auth import read_credential_pool
+    for connection in json.load(sys.stdin):
+        for key in custom_provider_pool_key_candidates(connection["baseUrl"], provider_name=connection["id"]):
+            rows = read_credential_pool(key)
+            if not isinstance(rows, list) or rows:
+                raise ValueError("Custom provider credential pool conflicts with connection ownership")
+print("ok")
+`;
+
+function environment(input: ConnectionContext): Record<string, string> {
+	const { placeholderEnv, configEnv, secretEnv } = hostedProviderEnvironment(
+		input.manifest,
+		input.runtime,
+	);
+	const result = { ...placeholderEnv, ...configEnv };
+	for (const [key, ref] of Object.entries(secretEnv)) {
+		const value = runtimeSecretValue(input.secretValues ?? {}, ref);
+		if (!value) throw new Error("Connection provider credential is unavailable");
+		result[key] = value;
+	}
+	return result;
+}
+
+function readProviders(input: ConnectionContext): Record<string, unknown> {
+	if (input.runtime === "openclaw") {
+		if (!input.observation.commandPath) throw new Error("OpenClaw config command is unavailable");
+		return readOpenClawProviderConfig(
+			input.observation.commandPath,
+			input.openClawContext,
+			input.workspaceRoot,
+			environment(input),
+		).providers;
+	}
+	if (input.runtime !== "hermes" || !input.hermesConfig)
+		throw new Error("Connection runtime config is unavailable");
+	const current = getHermesRawConfigValue(input.hermesConfig, "providers");
+	if (!current.exists) return {};
+	const providers = recordValue(current.value);
+	if (!providers) throw new Error("Hermes providers must be an object");
+	return providers;
+}
+
+function revision(providers: Record<string, unknown>, ids: string[]): string {
+	return runtimeImpactRevision(
+		Object.fromEntries(ids.sort().map((id) => [id, providers[id] ?? null])),
+	);
+}
+
+function guardHermesPools(input: ConnectionContext): void {
+	const connections = customProviderConnections(input.manifest, input.runtime);
+	if (input.runtime !== "hermes" || connections.length === 0) return;
+	const appRoot = runtimeAppRoot("hermes", input.home);
+	if (!appRoot) throw new Error("Hermes application path is unavailable");
+	const result = spawnRuntimeUserCommand(
+		join(appRoot, ".venv", "bin", "python"),
+		["-c", HERMES_POOL_GUARD, appRoot],
+		input.home,
+		input.workspaceRoot,
+		{
+			environmentOverrides: { HERMES_HOME: join(input.home, ".hermes") },
+			input: JSON.stringify(connections.map(({ id, baseUrl }) => ({ id, baseUrl }))),
+			timeoutMs: 30_000,
+			maxBufferBytes: 64 * 1024,
+		},
+	);
+	if (result.status !== 0 || String(result.stdout).trim() !== "ok")
+		throw new Error("Hermes custom provider credential conflict or unsupported public pool API");
+}
+
+function ownedOpenClawRef(value: unknown, envName: string): boolean {
+	const ref = recordValue(value);
+	return (
+		ref?.source === "env" &&
+		(ref.provider === "clawdi-connection" || ref.provider === "default") &&
+		ref.id === envName
+	);
+}
+
+/** Read-only preflight. The root coordinator must durably persist providers before apply. */
+export function prepareConnectionProviderTransfers(
+	input: ConnectionContext,
+): PreparedConnectionProviderTransfers {
+	const connections = customProviderConnections(input.manifest, input.runtime);
+	for (const connection of connections) {
+		if (!runtimeSecretValue(input.secretValues ?? {}, connection.secretRef))
+			throw new Error("Connection provider credential is unavailable");
+	}
+	const current = readProviders(input);
+	const providers = { ...input.ownership.providers };
+	const patch: Record<string, Record<string, unknown>> = {};
+	for (const connection of connections) {
+		const { id, baseUrl, apiMode, envName } = connection;
+		const existing = recordValue(current[id]);
+		if (!existing) throw new Error(`Connection provider ${id} must already exist`);
+		const previous = providers[id];
+		if (previous && previous.envName !== envName)
+			throw new Error("Connection credential environment is immutable");
+		const endpoint =
+			input.runtime === "openclaw"
+				? existing.baseUrl
+				: (existing.api ?? existing.url ?? existing.base_url);
+		const protocol =
+			input.runtime === "openclaw"
+				? (existing.api ?? "openai-completions")
+				: (existing.api_mode ?? existing.transport);
+		const expectedApi = input.runtime === "openclaw" ? OPENCLAW_API[apiMode] : HERMES_API[apiMode];
+		if (!expectedApi) throw new Error("Connection protocol is unsupported by this runtime");
+		if (!previous && (endpoint !== baseUrl || protocol !== expectedApi))
+			throw new Error(`Connection provider ${id} routing changed before handoff`);
+		const fields: Record<string, unknown> = {};
+		if (input.runtime === "openclaw") {
+			if (!Array.isArray(existing.models))
+				throw new Error("Custom OpenClaw provider must retain its models array");
+			if (existing.apiKey !== undefined && !ownedOpenClawRef(existing.apiKey, envName))
+				throw new Error("OpenClaw connection credential ownership conflict");
+			if (existing.auth !== undefined && existing.auth !== "api-key")
+				throw new Error("OpenClaw connection auth mode conflict");
+			fields.auth = "api-key";
+			fields.apiKey = { source: "env", provider: "clawdi-connection", id: envName };
+			if (previous && endpoint !== baseUrl) fields.baseUrl = baseUrl;
+			if (previous && protocol !== expectedApi) fields.api = expectedApi;
+		} else {
+			if (
+				existing.api_key ||
+				existing.key_cmd ||
+				(existing.key_env && existing.key_env !== envName) ||
+				(existing.api_key_env && existing.api_key_env !== envName)
+			)
+				throw new Error("Hermes connection credential ownership conflict");
+			fields.key_env = envName;
+			if (previous && endpoint !== baseUrl)
+				fields[
+					Object.hasOwn(existing, "api")
+						? "api"
+						: Object.hasOwn(existing, "url")
+							? "url"
+							: "base_url"
+				] = baseUrl;
+			if (previous && protocol !== expectedApi)
+				fields[Object.hasOwn(existing, "api_mode") ? "api_mode" : "transport"] = expectedApi;
+		}
+		providers[id] = { envName, baseUrl, apiMode };
+		patch[id] = fields;
+	}
+	const active = new Set(connections.map((connection) => connection.id));
+	for (const [id, previous] of Object.entries(providers)) {
+		if (active.has(id)) continue;
+		const existing = recordValue(current[id]);
+		if (!existing) continue;
+		if (input.runtime === "openclaw" && ownedOpenClawRef(existing.apiKey, previous.envName))
+			patch[id] = { apiKey: null, ...(existing.auth === "api-key" ? { auth: null } : {}) };
+		if (input.runtime === "hermes") {
+			const refs = Object.fromEntries(
+				["key_env", "api_key_env"]
+					.filter((key) => existing[key] === previous.envName)
+					.map((key) => [key, null]),
+			);
+			if (Object.keys(refs).length) patch[id] = refs;
+		}
+	}
+	guardHermesPools(input);
+	return {
+		runtime: input.runtime,
+		providers,
+		sourceRevision: revision(current, Object.keys(providers)),
+		patch,
+	};
+}
+
+export function applyConnectionProviderTransfers(input: ConnectionContext): boolean {
+	const plan = input.ownership.prepared;
+	if (
+		!plan ||
+		plan.runtime !== input.runtime ||
+		!canonicalJsonEqual(plan.providers, input.ownership.providers)
+	)
+		throw new Error("Connection providers require a durably prepared ownership transfer");
+	const current = readProviders(input);
+	if (revision(current, Object.keys(plan.providers)) !== plan.sourceRevision)
+		throw new Error("Connection provider config changed after preflight");
+	guardHermesPools(input);
+	let changed = false;
+	const patches: Record<string, Record<string, unknown>> = {};
+	for (const [id, fields] of Object.entries(plan.patch)) {
+		const existing = recordValue(current[id]) ?? {};
+		const next = { ...existing };
+		for (const [key, value] of Object.entries(fields)) {
+			if (value === null) delete next[key];
+			else next[key] = value;
+		}
+		if (canonicalJsonEqual(existing, next)) continue;
+		changed = true;
+		patches[id] = fields;
+		current[id] = next;
+	}
+	if (!changed) return false;
+	if (input.runtime === "hermes") {
+		if (!input.hermesConfig) throw new Error("Hermes config command is unavailable");
+		reconcileHermesConfigValue(input.hermesConfig, "providers", current);
+	} else {
+		if (!input.observation.commandPath) throw new Error("OpenClaw config command is unavailable");
+		const config = {
+			models: { providers: patches },
+			...(customProviderConnections(input.manifest, input.runtime).length
+				? { secrets: { providers: { "clawdi-connection": { source: "env" } } } }
+				: {}),
+		};
+		const result = spawnRuntimeUserCommand(
+			input.observation.commandPath,
+			["config", "patch", "--stdin"],
+			input.home,
+			input.workspaceRoot,
+			{ input: JSON.stringify(config), environment: environment(input), timeoutMs: 30_000 },
+		);
+		if (result.status !== 0) throw new Error("OpenClaw connection configuration failed");
+	}
+	return true;
+}

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -1,4 +1,9 @@
-import type { AiProviderAuth, AiProviderCatalog, NativeAiProvider } from "@clawdi/shared";
+import type {
+	AiProviderApiMode,
+	AiProviderAuth,
+	AiProviderCatalog,
+	NativeAiProvider,
+} from "@clawdi/shared";
 import {
 	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
@@ -25,6 +30,45 @@ export interface NativeProviderConnection {
 	id: string;
 	routing: NativeAiProvider;
 	auth: { kind: "api-key"; secretRef: string; envName: string } | { kind: "codex" };
+}
+
+export interface CustomProviderConnection {
+	id: string;
+	baseUrl: string;
+	apiMode: AiProviderApiMode;
+	envName: string;
+	secretRef: string;
+}
+
+export function customProviderConnections(
+	manifest: RuntimeManifest,
+	runtimeName: string,
+): CustomProviderConnection[] {
+	const entries = hostedProviderEntries(
+		manifest.projection?.providers ?? {},
+		runtimeName,
+		manifest,
+	).filter(([, input]) => input.configurationMode === "connection");
+	return entries.map(([id, input]) => {
+		if (
+			(runtimeName !== "openclaw" && runtimeName !== "hermes") ||
+			input.managed_by !== "user" ||
+			!input.apiKeySecretRef ||
+			input.auth ||
+			input.nativeProvider ||
+			!input.baseUrl ||
+			!input.apiMode ||
+			input.status === "error"
+		)
+			throw new Error("Invalid custom provider connection");
+		return {
+			id,
+			baseUrl: input.baseUrl,
+			apiMode: input.apiMode,
+			envName: hostedProviderRuntimeEnvName(id, input, runtimeName),
+			secretRef: input.apiKeySecretRef,
+		};
+	});
 }
 
 /** Native credentials go directly from the manifest to their runtime adapter. */
@@ -69,19 +113,21 @@ export function nativeProviderConnections(
 export function hostedProviderConfiguration(manifest: RuntimeManifest, runtimeName: string) {
 	hostedProviderEnvironment(manifest, runtimeName, { validateOverlap: true });
 	const native = nativeProviderConnections(manifest, runtimeName);
+	const connections = customProviderConnections(manifest, runtimeName);
 	const nativeIds = native.map(({ routing }) =>
 		runtimeName === "hermes" ? routing.hermes.provider : routing.openclaw.provider,
 	);
-	if (new Set(nativeIds).size !== nativeIds.length)
+	const runtimeIds = [...nativeIds, ...connections.map((connection) => connection.id)];
+	if (new Set(runtimeIds).size !== runtimeIds.length)
 		throw new Error("Native provider credential identity is selected more than once");
 	const catalog = agentTargetProjectionInput(hostedAiProviderCatalog(manifest, runtimeName));
 	if (
 		manifest.runtimes[runtimeName]?.providerMode === "unmanaged" &&
-		(catalog || native.length > 0)
+		(catalog || native.length > 0 || connections.length > 0)
 	) {
 		throw new Error(`runtime ${runtimeName} unmanaged provider mode has a provider projection`);
 	}
-	return { native, catalog };
+	return { native, catalog, connections };
 }
 
 export function agentTargetProjectionInput(
@@ -141,7 +187,7 @@ export function hostedAiProviderCatalog(
 	const providers = manifest.projection?.providers;
 	if (!providers || Object.keys(providers).length === 0) return null;
 	const providerEntries = hostedProviderEntries(providers, runtimeName, manifest).filter(
-		([, input]) => input.configurationMode !== "native",
+		([, input]) => input.configurationMode !== "native" && input.configurationMode !== "connection",
 	);
 	const requestedModel = hostedRuntimePrimaryModel(manifest, runtimeName);
 	const primaryModel =

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -493,7 +493,7 @@ const hostedProviderAuthSchema = z
 const hostedProviderBaseSchema = z
 	.object({
 		kind: z.literal("openai-compatible"),
-		configurationMode: z.enum(["native", "catalog"]).optional(),
+		configurationMode: z.enum(["native", "catalog", "connection"]).optional(),
 		nativeProvider: z.string().min(1).max(120).optional(),
 		type: z.enum(AI_PROVIDER_TYPES).optional(),
 		baseUrl: z.string().url().optional(),
@@ -519,6 +519,21 @@ function validateHostedProvider(
 	provider: z.infer<typeof hostedProviderBaseSchema>,
 	ctx: z.RefinementCtx,
 ): void {
+	if (
+		provider.configurationMode === "connection" &&
+		(provider.managed_by !== "user" ||
+			!provider.apiKeySecretRef ||
+			provider.auth ||
+			!provider.baseUrl ||
+			!provider.apiMode ||
+			provider.nativeProvider)
+	) {
+		ctx.addIssue({
+			code: "custom",
+			message: "Connection providers require user ownership, routing and an API key reference",
+			path: [],
+		});
+	}
 	if (
 		provider.configurationMode === "native" &&
 		(provider.managed_by === "clawdi" || provider.models?.length || !provider.nativeProvider)
@@ -902,10 +917,14 @@ function validateHostedRuntimeManifest(
 		if (
 			selectedRuntime.providerMode === "configured" &&
 			!selectedRuntime.primary_model &&
-			(nativeProviders.length !== 1 ||
+			(nativeProviders.length +
+				selectedProviders.filter((provider) => provider?.configurationMode === "connection")
+					.length !==
+				1 ||
 				selectedProviders.some(
 					(provider) =>
 						provider?.configurationMode !== "native" &&
+						provider?.configurationMode !== "connection" &&
 						!(
 							provider?.managed_by === "clawdi" &&
 							provider.models?.length &&

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1,7 +1,15 @@
 import { chmodSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readRuntimeAppliedState } from "./applied-state";
+import {
+	applyHostedHermesAiProviderProjection,
+	buildOpenClawHostedProviderPatch,
+} from "./catalog-provider-config";
 import { removeHostedCliPathExposure } from "./cli-update";
+import {
+	type PreparedConnectionProviderTransfers,
+	prepareConnectionProviderTransfers,
+} from "./connection-provider-config";
 import { buildEgressProfileBundle, hasEnabledEgressProfiles } from "./egress-profiles";
 import {
 	ensureFileBrowserCompanion,
@@ -24,6 +32,7 @@ import {
 	repairHostedOpenClawWorkspace,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
+import { hostedProviderConfiguration } from "./hosted-provider-resolution";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
 import type { HostedSkillEvidence } from "./hosted-skill-evidence";
 import { reconcileManagedBaileysCompatibility } from "./managed-baileys-compat";
@@ -96,6 +105,11 @@ import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { removeLegacyManagedOpenClawProviderPlugin } from "./openclaw-legacy-provider-plugin";
 import type { RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
+import {
+	type ProviderOwnership,
+	readProviderOwnership,
+	writeProviderOwnership,
+} from "./provider-ownership";
 import { runtimeRunConfigId, writeRuntimeRunConfig } from "./run-config";
 import { runtimeImpactRevision, runtimeProviderRevision } from "./runtime-impact-revision";
 import {
@@ -137,6 +151,8 @@ interface RuntimeConvergenceContext {
 	plannedEgressProfileBundlePath: string | null;
 	appliedState: ReturnType<typeof readRuntimeAppliedState>;
 	previousProjectedProviderIds: Record<string, string[]>;
+	providerOwnership: ProviderOwnership;
+	connectionPlans: Record<string, PreparedConnectionProviderTransfers>;
 	runtimeEntries: RuntimeEntry[];
 	preparedHostedSourcedSkills: NonNullable<
 		RuntimeConvergenceOptions["preparedHostedSourcedSkills"]
@@ -263,7 +279,13 @@ function initializeRuntimeConvergence(
 		? paths.egressProfileBundle
 		: null;
 	const appliedState = readRuntimeAppliedState(paths);
-	const previousProjectedProviderIds = appliedState?.projectedProviderIds ?? {};
+	const providerOwnership = readProviderOwnership(
+		paths,
+		manifest.instanceId,
+		projectionHome,
+		appliedState?.projectedProviderIds ?? {},
+	);
+	const previousProjectedProviderIds = providerOwnership.providers;
 	const retainPreviousProjectedProviderIds = () =>
 		Object.fromEntries(
 			Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
@@ -322,6 +344,8 @@ function initializeRuntimeConvergence(
 			plannedEgressProfileBundlePath,
 			appliedState,
 			previousProjectedProviderIds,
+			providerOwnership,
+			connectionPlans: {},
 			runtimeEntries,
 			preparedHostedSourcedSkills,
 			sourcedSkillsPrepared,
@@ -748,9 +772,51 @@ function applyRuntimeResourceProjections(
 		openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 	});
 	const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
+	const pendingProviderIds = { ...previousProjectedProviderIds };
 	for (const [name] of runtimeEntries) {
 		const observation = state.observations.get(name);
 		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+		if (
+			(name === "openclaw" || name === "hermes") &&
+			observation.enabled &&
+			observation.status !== "install_failed" &&
+			observation.commandPath &&
+			((manifest.runtimes[name]?.provider_ids ?? []).some(
+				(id) => manifest.projection?.providers?.[id]?.configurationMode === "connection",
+			) ||
+				Object.keys(context.providerOwnership.transfers[name] ?? {}).length > 0)
+		) {
+			const previous = context.providerOwnership.transfers[name] ?? {};
+			const prepared = withRuntimeUserFileAccess(
+				() =>
+					prepareConnectionProviderTransfers({
+						runtime: name,
+						manifest,
+						observation,
+						home: projectionHome,
+						openClawContext,
+						workspaceRoot,
+						hermesConfig,
+						secretValues,
+						ownership: { providers: previous },
+					}),
+				context.hostedRuntimeContract.identity,
+			);
+			if (
+				Object.entries(previous).some(
+					([id, value]) => prepared.providers[id]?.envName !== value.envName,
+				)
+			)
+				throw new Error(
+					"Connection transfer cannot remove ownership or change its credential environment",
+				);
+			context.connectionPlans[name] = prepared;
+			context.providerOwnership.transfers[name] = prepared.providers;
+			previousProjectedProviderIds[name] = (previousProjectedProviderIds[name] ?? []).filter(
+				(id) => !Object.hasOwn(prepared.providers, id),
+			);
+			pendingProviderIds[name] = previousProjectedProviderIds[name];
+		}
 		providerProjectionRevisions[name] = previewHostedAiProviderProjectionRevision(
 			name,
 			observation,
@@ -759,7 +825,26 @@ function applyRuntimeResourceProjections(
 			previousProjectedProviderIds[name] ?? [],
 			context.appliedState?.nativeCredentialProviderIds?.[name] ?? [],
 		);
+		if (
+			(name === "openclaw" || name === "hermes") &&
+			observation.enabled &&
+			observation.status !== "install_failed" &&
+			observation.commandPath
+		) {
+			const { catalog } = hostedProviderConfiguration(manifest, name);
+			const desired =
+				name === "openclaw"
+					? buildOpenClawHostedProviderPatch(catalog, []).providerIds
+					: applyHostedHermesAiProviderProjection(catalog, [], projectionHome, null, false)
+							.providerIds;
+			if (desired.some((id) => Object.hasOwn(context.providerOwnership.transfers[name] ?? {}, id)))
+				throw new Error("An agent-owned connection cannot return to catalog management");
+			pendingProviderIds[name] = [...new Set([...(pendingProviderIds[name] ?? []), ...desired])];
+		}
 	}
+	// Record ownership before either runtime can commit config independently.
+	context.providerOwnership.providers = pendingProviderIds;
+	writeProviderOwnership(paths, manifest.instanceId, projectionHome, context.providerOwnership);
 	try {
 		const codexProjection = withRuntimeUserFileAccess(
 			() => applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
@@ -904,6 +989,10 @@ function applyRuntimeEntryProjections(
 					hermesConfig,
 					runtimeProbeRevision(context, name),
 					context.appliedState?.nativeCredentialProviderIds?.[name] ?? [],
+					{
+						providers: context.providerOwnership.transfers[name] ?? {},
+						prepared: context.connectionPlans[name],
+					},
 				);
 				state.projectedProviderIds[name] = providerProjection.providerIds;
 				state.nativeCredentialProviderIds[name] =
@@ -1171,6 +1260,17 @@ function commitRuntimeConvergence(
 		activated: state.activated,
 		officialServiceCommandRevisions: state.officialServiceCommandRevisions,
 		skillEvidence: state.skillEvidence,
+	});
+	writeProviderOwnership(paths, manifest.instanceId, context.projectionHome, {
+		providers: {
+			...context.providerOwnership.providers,
+			...Object.fromEntries(
+				Object.entries(state.projectedProviderIds).filter(
+					([name]) => state.observations.get(name)?.enabled === true,
+				),
+			),
+		},
+		transfers: context.providerOwnership.transfers,
 	});
 	try {
 		gcFileBrowserCompanionCandidates(manifest, paths);

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -21,6 +21,7 @@ import { recordValue, stringValue } from "./manifest-shared";
 import {
 	applyOpenClawNativeProviders,
 	buildNativeOpenClawProviderPatch,
+	discoverNativeOpenClawProviderIds,
 	ensureNativeOpenClawProviderPlugins,
 } from "./openclaw-native-provider";
 import {
@@ -147,13 +148,24 @@ export function applyHostedAiProviderProjection(
 			workspaceRoot,
 			providerRevision,
 		);
+	const ownedNativeProviderIds = [
+		...new Set([
+			...previousNativeProviderIds,
+			...discoverNativeOpenClawProviderIds(
+				observation.commandPath,
+				openClawContext,
+				workspaceRoot,
+				environment,
+			),
+		]),
+	];
 	const nativePatch = buildNativeOpenClawProviderPatch(
 		native,
-		previousNativeProviderIds.filter(
+		ownedNativeProviderIds.filter(
 			(id) => !patch.providerIds.includes(id) && !previousProviderIds.includes(id),
 		),
 	);
-	if (native.length > 0 || previousNativeProviderIds.length > 0) {
+	if (native.length > 0 || ownedNativeProviderIds.length > 0) {
 		nativeChanged =
 			applyOpenClawNativeProviders({
 				patch: nativePatch,

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -6,6 +6,10 @@ import {
 	type CatalogProviderConfigurationResult,
 	providerProjectionProgramImpact,
 } from "./catalog-provider-config";
+import {
+	applyConnectionProviderTransfers,
+	type ConnectionProviderOwnership,
+} from "./connection-provider-config";
 import type { HermesConfigTransaction } from "./hermes-config";
 import { applyHermesNativeProviders } from "./hermes-native-provider";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
@@ -64,11 +68,40 @@ export function applyHostedAiProviderProjection(
 	hermesConfig: HermesConfigTransaction | null,
 	providerRevision: string,
 	previousNativeProviderIds: readonly string[] = [],
+	connectionOwnership?: ConnectionProviderOwnership,
 ): HostedAiProviderProjectionResult {
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath)
 		return { path: null, revision: null, providerIds: [] };
-	const { native, catalog } = hostedProviderConfiguration(manifest, name);
-	if (manifest.runtimes[name]?.providerMode === "configured" && !catalog && native.length === 0) {
+	const { native, catalog, connections } = hostedProviderConfiguration(manifest, name);
+	const transferredIds = new Set([
+		...Object.keys(connectionOwnership?.providers ?? {}),
+		...connections.map((connection) => connection.id),
+	]);
+	previousProviderIds = previousProviderIds.filter((id) => !transferredIds.has(id));
+	if (connections.length > 0 && !connectionOwnership)
+		throw new Error("Connection providers require durable ownership");
+	const hasTransfers = transferredIds.size > 0;
+	const preserveModelSelection = !catalog?.primaryModel && (native.length > 0 || hasTransfers);
+	let connectionChanged = false;
+	if (hasTransfers && connectionOwnership)
+		connectionChanged = applyConnectionProviderTransfers({
+			runtime: name,
+			manifest,
+			observation,
+			home,
+			openClawContext,
+			workspaceRoot,
+			hermesConfig,
+			secretValues,
+			ownership: connectionOwnership,
+		});
+	if (
+		manifest.runtimes[name]?.providerMode === "configured" &&
+		!catalog &&
+		native.length === 0 &&
+		connections.length === 0 &&
+		!hasTransfers
+	) {
 		if (name === "openclaw")
 			applyOpenClawGatewayHostedProjection(
 				observation.commandPath,
@@ -101,11 +134,11 @@ export function applyHostedAiProviderProjection(
 			home,
 			hermesConfig,
 			true,
-			native.length > 0,
+			preserveModelSelection,
 		);
 		return {
 			...projection,
-			nativeCredentialsChanged: auth.changed,
+			nativeCredentialsChanged: auth.changed || connectionChanged,
 			nativeCredentialProviderIds: auth.providerIds,
 		};
 	}
@@ -115,6 +148,15 @@ export function applyHostedAiProviderProjection(
 		previousProviderIds,
 		native.length > 0 ? "merge" : "replace",
 	);
+	// Tombstones protect old rows; an explicitly selected catalog still owns its primary model.
+	if (hasTransfers) {
+		const content = recordValue(JSON.parse(patch.content));
+		const models = recordValue(content?.models);
+		if (models && (connections.length > 0 || !catalog)) delete models.mode;
+		const defaults = recordValue(recordValue(content?.agents)?.defaults);
+		if (defaults && preserveModelSelection) delete defaults.model;
+		patch.content = JSON.stringify(content);
+	}
 	const { placeholderEnv, configEnv, secretEnv } = hostedProviderEnvironment(manifest, name);
 	const environment = { ...placeholderEnv, ...configEnv };
 	for (const [key, ref] of Object.entries(secretEnv)) {
@@ -122,13 +164,14 @@ export function applyHostedAiProviderProjection(
 		if (!value) throw new Error("OpenClaw provider credential is unavailable");
 		environment[key] = value;
 	}
-	let nativeChanged = ensureNativeOpenClawProviderPlugins(
-		native,
-		observation.commandPath,
-		openClawContext.home,
-		workspaceRoot,
-		environment,
-	);
+	let nativeChanged =
+		ensureNativeOpenClawProviderPlugins(
+			native,
+			observation.commandPath,
+			openClawContext.home,
+			workspaceRoot,
+			environment,
+		) || connectionChanged;
 	applyOpenClawGatewayHostedProjection(
 		observation.commandPath,
 		manifest,
@@ -204,24 +247,37 @@ export function previewHostedAiProviderProjectionRevision(
 		!observation.commandPath
 	)
 		return null;
-	const { native, catalog } = hostedProviderConfiguration(manifest, name);
-	if (manifest.runtimes[name]?.providerMode === "configured" && !catalog && native.length === 0)
+	const { native, catalog, connections } = hostedProviderConfiguration(manifest, name);
+	previousProviderIds = previousProviderIds.filter(
+		(id) => !connections.some((connection) => connection.id === id),
+	);
+	if (
+		manifest.runtimes[name]?.providerMode === "configured" &&
+		!catalog &&
+		native.length === 0 &&
+		connections.length === 0
+	)
 		return null;
-	if (name === "hermes")
-		return applyHostedHermesAiProviderProjection(
+	if (name === "hermes") {
+		const revision = applyHostedHermesAiProviderProjection(
 			catalog,
 			previousProviderIds,
 			home,
 			null,
 			false,
-			native.length > 0,
+			native.length > 0 || connections.length > 0,
 		).revision;
+		return connections.length
+			? runtimeImpactRevision({ connections, catalog: revision })
+			: revision;
+	}
 	const patch = buildOpenClawHostedProviderPatch(
 		catalog,
 		previousProviderIds,
 		native.length > 0 ? "merge" : "replace",
 	);
 	return runtimeImpactRevision({
+		...(connections.length ? { connections } : {}),
 		catalog: providerProjectionProgramImpact("openclaw", JSON.parse(patch.content), catalog),
 		native: buildNativeOpenClawProviderPatch(
 			native,
@@ -238,7 +294,10 @@ export function validateHostedProviderConfiguration(
 	name: string,
 	previousProviderIds: readonly string[],
 ): void {
-	const { native, catalog } = hostedProviderConfiguration(manifest, name);
+	const { native, catalog, connections } = hostedProviderConfiguration(manifest, name);
+	previousProviderIds = previousProviderIds.filter(
+		(id) => !connections.some((connection) => connection.id === id),
+	);
 	if (name === "openclaw") {
 		buildOpenClawHostedProviderPatch(
 			catalog,
@@ -282,6 +341,7 @@ export function providerHealthReasons(
 	}
 	if (
 		provider.configurationMode !== "native" &&
+		provider.configurationMode !== "connection" &&
 		!stringValue(provider.model) &&
 		!providerHasModels(provider)
 	) {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2536,7 +2536,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(envFile).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 	});
 
-	test("connects a native key without replacing models or native user provider settings", () => {
+	test.each(["switch", "unbind"])("recovers a native key after failed commit then %s", (action) => {
 		const paths = tempRuntimePaths();
 		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
 			initialConfig: {
@@ -2546,7 +2546,10 @@ describe("runtime manifest reconciliation invariants", () => {
 					providers: { default: { source: "file", path: "/user/secrets.json" } },
 					defaults: { file: "default" },
 				},
-				models: { mode: "replace", providers: { google: { timeoutSeconds: 45 } } },
+				models: {
+					mode: "replace",
+					providers: { google: { timeoutSeconds: 45, models: [{ id: "user-selected-model" }] } },
+				},
 				plugins: { entries: { google: { config: { webSearch: { enabled: false } } } } },
 			},
 		});
@@ -2611,24 +2614,27 @@ fi
 				runtimes: { openclaw: hostedRuntimeFixture({ primary_model: null }) },
 			}),
 		);
+		const egressEngine = installCachedTestEgressEngine(paths, "12.2.3-native-google");
 		const connected = convergeRuntimeManifest(
-			manifestLoad(
-				{ ...manifest, egressEngine: installCachedTestEgressEngine(paths, "12.2.3-native-google") },
-				"native-google",
-				{
-					...TEST_HOSTED_SECRET_VALUES,
-					"secret://provider.google.apiKey": "native-google-test-key",
-				},
-			),
+			manifestLoad({ ...manifest, egressEngine }, "native-google", {
+				...TEST_HOSTED_SECRET_VALUES,
+				"secret://provider.google.apiKey": "native-google-test-key",
+			}),
 			paths,
+			{
+				commitAuthority: () => {
+					throw new Error("Injected authority commit failure");
+				},
+			},
 		);
-		expect(connected.installErrors).toEqual([]);
-		expect(connected.nativeCredentialProviderIds).toEqual({ openclaw: ["google"] });
+		expect(connected.installErrors.join("\n")).toContain("Injected authority commit failure");
+		expect(readRuntimeAppliedState(paths)).toBeNull();
 		const configured = JSON.parse(readFileSync(configPath, "utf8"));
 		expect(configured.agents.defaults.model.primary).toBe("google/user-selected-model");
 		expect(configured.auth.profiles.personal).toEqual({ provider: "google", mode: "api_key" });
 		expect(configured.models.providers.google).toEqual({
 			timeoutSeconds: 45,
+			models: [{ id: "user-selected-model" }],
 			baseUrl: provider.baseUrl,
 			auth: "api-key",
 			apiKey: { source: "env", provider: "clawdi-native", id: "GEMINI_API_KEY" },
@@ -2645,6 +2651,64 @@ fi
 		expect(readFileSync(pluginLog, "utf8")).toContain("config patch --stdin");
 		expect(readFileSync(pluginLog, "utf8")).not.toContain("native-google-test-key");
 		expect(readFileSync(configPath, "utf8")).not.toContain("native-google-test-key");
+
+		writeFileSync(
+			pluginState,
+			JSON.stringify({
+				plugins: [{ id: "anthropic", enabled: true, status: "loaded" }],
+			}),
+		);
+		const nextProvider = {
+			...provider,
+			type: "anthropic",
+			nativeProvider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			apiMode: "anthropic_messages",
+			runtimeEnvName: "ANTHROPIC_API_KEY",
+			apiKeySecretRef: "secret://provider.anthropic.apiKey",
+		};
+		const nextRuntime = hostedRuntimeFixture({
+			primary_model: null,
+			...(action === "unbind" ? { providerMode: "unmanaged", provider_ids: [] } : {}),
+		});
+		if (action === "unbind") delete nextRuntime.primary_model;
+		const nextManifest = hostedRuntimeBundleV2ManifestSchema.parse(
+			hostedOpenClawV2ManifestFixture({
+				providers: action === "switch" ? { default: nextProvider } : {},
+				runtimes: { openclaw: nextRuntime },
+			}),
+		);
+		const nextLoad = manifestLoad(
+			{ ...nextManifest, generation: 2, egressEngine },
+			"native-recovery",
+			{
+				...TEST_HOSTED_SECRET_VALUES,
+				...(action === "switch"
+					? { "secret://provider.anthropic.apiKey": "next-native-test-key" }
+					: {}),
+			},
+		);
+		const recovered = convergeRuntimeManifest(nextLoad, paths);
+		expect(recovered.installErrors).toEqual([]);
+		expect(recovered.nativeCredentialProviderIds?.openclaw).toEqual(
+			action === "switch" ? ["anthropic"] : [],
+		);
+		const restored = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(restored.models.providers.google).toEqual({
+			timeoutSeconds: 45,
+			models: [{ id: "user-selected-model" }],
+		});
+		expect(restored.agents.defaults.model).toEqual(configured.agents.defaults.model);
+		expect(restored.auth).toEqual(configured.auth);
+		if (action === "switch")
+			expect(restored.models.providers.anthropic.apiKey).toEqual({
+				source: "env",
+				provider: "clawdi-native",
+				id: "ANTHROPIC_API_KEY",
+			});
+		const retried = convergeRuntimeManifest(nextLoad, paths);
+		expect(retried.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(restored);
 	});
 
 	test("repairs legacy managed memory config and keeps the provider key out of agent env", () => {

--- a/packages/cli/src/runtime/native-provider-credentials.test.ts
+++ b/packages/cli/src/runtime/native-provider-credentials.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	type AiProviderCatalog,
 	NATIVE_AI_PROVIDERS,
 	nativeAiProvider,
 	nativeAiProviderRuntime,
 } from "@clawdi/shared";
+import { createOpenClawHostedContext } from "./hosted-openclaw-context";
 import {
 	agentTargetProjectionInput,
 	hostedAiProviderCatalog,
@@ -14,7 +18,10 @@ import {
 } from "./hosted-provider-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
 import { buildOpenClawHostedProviderPatch, providerHealthReasons } from "./manifest-providers";
-import { buildNativeOpenClawProviderPatch } from "./openclaw-native-provider";
+import {
+	buildNativeOpenClawProviderPatch,
+	discoverNativeOpenClawProviderIds,
+} from "./openclaw-native-provider";
 
 function bundle(
 	identity: string,
@@ -69,6 +76,170 @@ function nativePatch(identity: string, variant?: string) {
 }
 
 describe("native provider credentials", () => {
+	test("discovers only valid owned routing and env references, preserving foreign or modified entries", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-native-discovery-"));
+		const context = createOpenClawHostedContext(bundle("gemini"), root);
+		const path = context.configPath;
+		mkdirSync(context.stateRoot, { recursive: true });
+		const discover = () =>
+			discoverNativeOpenClawProviderIds("unavailable-openclaw", context, root, {});
+		try {
+			expect(discover()).toEqual([]);
+			const owned = {
+				baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+				auth: "api-key",
+				apiKey: { source: "env", provider: "clawdi-native", id: "GEMINI_API_KEY" },
+				models: [{ id: "user-model" }],
+			};
+			const candidates = [
+				[owned, ["google"]],
+				[{ ...owned, apiKey: "user-key" }, []],
+				[{ ...owned, apiKey: { ...owned.apiKey, provider: "default" } }, []],
+				[{ ...owned, apiKey: { ...owned.apiKey, source: "file" } }, []],
+				[{ ...owned, apiKey: { ...owned.apiKey, id: "OTHER_KEY" } }, []],
+				[{ ...owned, apiKey: { ...owned.apiKey, extra: true } }, []],
+				[{ ...owned, baseUrl: "https://user.example/v1" }, []],
+				[{ ...owned, auth: "oauth" }, []],
+			] as const;
+			for (const [provider, expected] of candidates) {
+				writeFileSync(path, JSON.stringify({ models: { providers: { google: provider } } }));
+				expect(discover()).toEqual([...expected]);
+			}
+			writeFileSync(
+				path,
+				`{
+  // A failed convergence can leave authored native JSON5 behind.
+  models: { providers: { google: ${JSON.stringify(owned)}, }, },
+}`,
+			);
+			expect(discover()).toEqual(["google"]);
+			writeFileSync(path, "invalid config");
+			expect(() => discover()).toThrow("ownership could not be inspected");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+	test("uses native include resolution and accepts only namespaced env references after redaction", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-native-includes-"));
+		const context = createOpenClawHostedContext(bundle("gemini"), root);
+		mkdirSync(context.stateRoot, { recursive: true });
+		const command = join(root, "openclaw");
+		const report = join(root, "report.json");
+		writeFileSync(
+			command,
+			`#!/usr/bin/env node
+const fs = require("node:fs");
+if (process.argv.slice(2).join(" ") !== "config get models --json") process.exit(42);
+process.stdout.write(fs.readFileSync(${JSON.stringify(report)}, "utf8"));
+`,
+			{ mode: 0o700 },
+		);
+		try {
+			writeFileSync(context.configPath, "{models: {$include: './providers.json',},}");
+			const owned = {
+				baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+				auth: "api-key",
+				apiKey: { source: "env", provider: "clawdi-native", id: "__OPENCLAW_REDACTED__" },
+			};
+			writeFileSync(
+				report,
+				JSON.stringify({
+					providers: {
+						google: owned,
+						openai: {
+							...owned,
+							baseUrl: "https://api.openai.com/v1",
+							apiKey: { ...owned.apiKey, provider: "personal" },
+						},
+					},
+				}),
+			);
+			expect(discoverNativeOpenClawProviderIds(command, context, root, {})).toEqual(["google"]);
+			writeFileSync(report, '{"mode":"merge"}');
+			expect(discoverNativeOpenClawProviderIds(command, context, root, {})).toEqual([]);
+
+			writeFileSync(report, "private native diagnostic");
+			expect(() => discoverNativeOpenClawProviderIds(command, context, root, {})).toThrow(
+				"OpenClaw native provider ownership could not be inspected",
+			);
+			writeFileSync(command, "#!/bin/sh\nprintf 'private native error' >&2\nexit 1\n", {
+				mode: 0o700,
+			});
+			expect(() => discoverNativeOpenClawProviderIds(command, context, root, {})).toThrow(
+				"OpenClaw native provider ownership could not be inspected",
+			);
+			writeFileSync(context.configPath, "{$include: './gateway.json5'}");
+			expect(context.sdk.configMutation).toBeNull();
+			const missingStderr =
+				"Config path not found: models. Run openclaw config validate to inspect config shape.\n";
+			const missingStdout = `${JSON.stringify(
+				{
+					ok: false,
+					error: {
+						type: "cli_error",
+						message:
+							"Config path is valid but unset: models. The runtime default applies until you set an authored value with openclaw config set models <value>.",
+					},
+				},
+				null,
+				2,
+			)}\n`;
+			const reports = [
+				{ status: 1, stdout: "", stderr: missingStderr, missing: true },
+				{ status: 1, stdout: missingStdout, stderr: "", missing: true },
+				{
+					status: 1,
+					stdout: JSON.stringify({ error: JSON.parse(missingStdout).error, ok: false }),
+					stderr: "",
+					missing: true,
+				},
+				{
+					status: 1,
+					stdout: JSON.stringify({ ...JSON.parse(missingStdout), diagnostic: "unexpected" }),
+					stderr: "",
+					missing: false,
+				},
+				{
+					status: 1,
+					stdout: missingStdout.replace('"cli_error"', '"other_error"'),
+					stderr: "",
+					missing: false,
+				},
+				{ status: 2, stdout: "", stderr: missingStderr, missing: false },
+				{ status: 1, stdout: "unexpected diagnostic", stderr: missingStderr, missing: false },
+				{ status: 1, stdout: missingStdout, stderr: "unexpected diagnostic", missing: false },
+				{ status: 1, stdout: "", stderr: `private diagnostic\n${missingStderr}`, missing: false },
+				{
+					status: 1,
+					stdout: missingStdout.replace("models.", "models.providers."),
+					stderr: "",
+					missing: false,
+				},
+				{ status: 1, stdout: "", stderr: "Config path not found: models\n", missing: false },
+			];
+			for (const report of reports) {
+				writeFileSync(
+					command,
+					`#!/usr/bin/env node
+if (process.env.NO_COLOR !== "1" || process.env.FORCE_COLOR !== undefined || process.env.CLICOLOR_FORCE !== undefined) process.exit(42);
+process.stdout.write(${JSON.stringify(report.stdout)});
+process.stderr.write(${JSON.stringify(report.stderr)});
+process.exit(${report.status});
+`,
+					{ mode: 0o700 },
+				);
+				const discover = () =>
+					discoverNativeOpenClawProviderIds(command, context, root, {
+						FORCE_COLOR: "1",
+						CLICOLOR_FORCE: "1",
+					});
+				if (report.missing) expect(discover()).toEqual([]);
+				else expect(discover).toThrow("OpenClaw native provider ownership could not be inspected");
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 	test("routes all native connections directly without creating catalogs or model selections", () => {
 		for (const route of NATIVE_AI_PROVIDERS) {
 			for (const runtime of ["hermes", "openclaw"] as const) {

--- a/packages/cli/src/runtime/openclaw-native-provider.ts
+++ b/packages/cli/src/runtime/openclaw-native-provider.ts
@@ -1,9 +1,117 @@
+import { readFileSync } from "node:fs";
+import { nativeAiProviderForRuntime } from "@clawdi/shared";
+import JSON5 from "json5";
+import { z } from "zod";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
 import type { NativeProviderConnection } from "./hosted-provider-resolution";
 import { openClawPluginCapabilityConsentArgs } from "./openclaw-plugin-cli";
 import { openClawPluginListSchema } from "./openclaw-plugin-observation";
 import { openClawConfigPatchIsApplied } from "./openclaw-provider-config";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
+
+const nativeProviderConfigSchema = z.object({
+	baseUrl: z.string(),
+	auth: z.literal("api-key"),
+	apiKey: z.strictObject({
+		source: z.literal("env"),
+		provider: z.literal("clawdi-native"),
+		id: z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
+	}),
+});
+
+// Exact absence reports from published OpenClaw 2026.7.1-2 and 2026.9.2.
+// Both are emitted only after config validation, when the requested path is absent.
+const MISSING_MODELS_STDERR =
+	"Config path not found: models. Run openclaw config validate to inspect config shape.\n";
+const missingModelsReportSchema = z.strictObject({
+	ok: z.literal(false),
+	error: z.strictObject({
+		type: z.literal("cli_error"),
+		message: z.literal(
+			"Config path is valid but unset: models. The runtime default applies until you set an authored value with openclaw config set models <value>.",
+		),
+	}),
+});
+
+function containsConfigInclude(value: unknown): boolean {
+	if (Array.isArray(value)) return value.some(containsConfigInclude);
+	if (value === null || typeof value !== "object") return false;
+	return Object.hasOwn(value, "$include") || Object.values(value).some(containsConfigInclude);
+}
+
+/** Recover owned writes when service activation failed before authority commit. */
+export function discoverNativeOpenClawProviderIds(
+	command: string,
+	context: OpenClawHostedContext,
+	workspaceRoot: string,
+	environment: Record<string, string>,
+): string[] {
+	let content: string;
+	try {
+		content = readFileSync(context.configPath, "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+		throw new Error("OpenClaw native provider ownership could not be inspected");
+	}
+	try {
+		const record = z.record(z.string(), z.unknown());
+		const root = record.parse(JSON5.parse(content));
+		const models = root.models === undefined ? {} : record.parse(root.models);
+		const included = Object.hasOwn(root, "$include") || containsConfigInclude(models);
+		let providers: Record<string, unknown>;
+		if (included) {
+			// Native patch can write into includes. Let OpenClaw resolve them; config
+			// get preserves env SecretRef source/provider while redacting only its ID.
+			const childEnvironment: Record<string, string> = {
+				...environment,
+				NO_COLOR: "1",
+				CLICOLOR: "0",
+			};
+			delete childEnvironment.FORCE_COLOR;
+			delete childEnvironment.CLICOLOR_FORCE;
+			const result = spawnRuntimeUserCommand(
+				command,
+				["config", "get", "models", "--json"],
+				context.home,
+				workspaceRoot,
+				{
+					environment: childEnvironment,
+					environmentOverrides: { FORCE_COLOR: undefined, CLICOLOR_FORCE: undefined },
+					timeoutMs: 30_000,
+					maxBufferBytes: 16 * 1024 * 1024,
+				},
+			);
+			if (result.status !== 0) {
+				if (
+					result.status === 1 &&
+					!result.error &&
+					((result.stdout === "" && result.stderr === MISSING_MODELS_STDERR) ||
+						(result.stderr === "" &&
+							missingModelsReportSchema.safeParse(JSON.parse(String(result.stdout))).success))
+				)
+					return [];
+				throw new Error("Included provider config is unavailable");
+			}
+			const resolvedModels = record.parse(JSON.parse(String(result.stdout)));
+			providers =
+				resolvedModels.providers === undefined ? {} : record.parse(resolvedModels.providers);
+		} else {
+			providers = models.providers === undefined ? {} : record.parse(models.providers);
+		}
+		return Object.entries(providers).flatMap(([id, value]) => {
+			const parsed = nativeProviderConfigSchema.safeParse(value);
+			if (!parsed.success) return [];
+			const routing = nativeAiProviderForRuntime("openclaw", id, parsed.data.baseUrl);
+			return routing &&
+				(routing.runtime_env_name === parsed.data.apiKey.id ||
+					(included && parsed.data.apiKey.id === "__OPENCLAW_REDACTED__"))
+				? [id]
+				: [];
+		});
+	} catch {
+		throw new Error("OpenClaw native provider ownership could not be inspected");
+	}
+}
 
 function runNativeCommand(
 	command: string,

--- a/packages/cli/src/runtime/openclaw-native-provider.ts
+++ b/packages/cli/src/runtime/openclaw-native-provider.ts
@@ -40,17 +40,18 @@ function containsConfigInclude(value: unknown): boolean {
 }
 
 /** Recover owned writes when service activation failed before authority commit. */
-export function discoverNativeOpenClawProviderIds(
+export function readOpenClawProviderConfig(
 	command: string,
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
 	environment: Record<string, string>,
-): string[] {
+): { providers: Record<string, unknown>; included: boolean } {
 	let content: string;
 	try {
 		content = readFileSync(context.configPath, "utf8");
 	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+		if (error instanceof Error && "code" in error && error.code === "ENOENT")
+			return { providers: {}, included: false };
 		throw new Error("OpenClaw native provider ownership could not be inspected");
 	}
 	try {
@@ -89,7 +90,7 @@ export function discoverNativeOpenClawProviderIds(
 						(result.stderr === "" &&
 							missingModelsReportSchema.safeParse(JSON.parse(String(result.stdout))).success))
 				)
-					return [];
+					return { providers: {}, included };
 				throw new Error("Included provider config is unavailable");
 			}
 			const resolvedModels = record.parse(JSON.parse(String(result.stdout)));
@@ -98,19 +99,34 @@ export function discoverNativeOpenClawProviderIds(
 		} else {
 			providers = models.providers === undefined ? {} : record.parse(models.providers);
 		}
-		return Object.entries(providers).flatMap(([id, value]) => {
-			const parsed = nativeProviderConfigSchema.safeParse(value);
-			if (!parsed.success) return [];
-			const routing = nativeAiProviderForRuntime("openclaw", id, parsed.data.baseUrl);
-			return routing &&
-				(routing.runtime_env_name === parsed.data.apiKey.id ||
-					(included && parsed.data.apiKey.id === "__OPENCLAW_REDACTED__"))
-				? [id]
-				: [];
-		});
+		return { providers, included };
 	} catch {
 		throw new Error("OpenClaw native provider ownership could not be inspected");
 	}
+}
+
+export function discoverNativeOpenClawProviderIds(
+	command: string,
+	context: OpenClawHostedContext,
+	workspaceRoot: string,
+	environment: Record<string, string>,
+): string[] {
+	const { providers, included } = readOpenClawProviderConfig(
+		command,
+		context,
+		workspaceRoot,
+		environment,
+	);
+	return Object.entries(providers).flatMap(([id, value]) => {
+		const parsed = nativeProviderConfigSchema.safeParse(value);
+		if (!parsed.success) return [];
+		const routing = nativeAiProviderForRuntime("openclaw", id, parsed.data.baseUrl);
+		return routing &&
+			(routing.runtime_env_name === parsed.data.apiKey.id ||
+				(included && parsed.data.apiKey.id === "__OPENCLAW_REDACTED__"))
+			? [id]
+			: [];
+	});
 }
 
 function runNativeCommand(

--- a/packages/cli/src/runtime/provider-ownership.test.ts
+++ b/packages/cli/src/runtime/provider-ownership.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getRuntimePaths } from "./paths";
+import { readProviderOwnership, writeProviderOwnership } from "./provider-ownership";
+
+test("failed authority preserves pending catalog ownership, but never reclaims transferred models", () => {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-provider-ownership-"));
+	const paths = { ...getRuntimePaths(), serviceStateRoot: root };
+	try {
+		const ownership = readProviderOwnership(paths, "instance", "/home/agent", {});
+		ownership.providers = { openclaw: ["custom-provider"], hermes: ["custom-provider"] };
+		writeProviderOwnership(paths, "instance", "/home/agent", ownership);
+		// Config committed, but authority did not: the next process still owns cleanup.
+		const retry = readProviderOwnership(paths, "instance", "/home/agent", {});
+		expect(retry.providers).toEqual(ownership.providers);
+		for (const runtime of ["openclaw", "hermes"]) {
+			retry.transfers[runtime] = {
+				"custom-provider": {
+					envName: "CUSTOM_API_KEY",
+					baseUrl: "https://provider.example/v1",
+					apiMode: "openai_chat",
+				},
+			};
+		}
+		writeProviderOwnership(paths, "instance", "/home/agent", retry);
+		// An old applied state must not restore whole-row ownership after handoff.
+		const unbound = readProviderOwnership(paths, "instance", "/home/agent", ownership.providers);
+		expect(unbound.providers).toEqual({ openclaw: [], hermes: [] });
+		writeProviderOwnership(paths, "instance", "/home/agent", unbound);
+		expect(readProviderOwnership(paths, "instance", "/home/agent", {}).transfers).toEqual(
+			retry.transfers,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("foreign or damaged ownership evidence cannot authorize config deletion", () => {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-provider-ownership-"));
+	const paths = { ...getRuntimePaths(), serviceStateRoot: root };
+	try {
+		const ownership = readProviderOwnership(paths, "instance", "/home/agent", {});
+		writeProviderOwnership(paths, "instance", "/home/agent", ownership);
+		expect(() => readProviderOwnership(paths, "other", "/home/agent", {})).toThrow(
+			"another runtime",
+		);
+		expect(() => readProviderOwnership(paths, "instance", "/home/other", {})).toThrow(
+			"another runtime",
+		);
+		writeFileSync(join(root, "provider-ownership.json"), "{broken");
+		expect(() => readProviderOwnership(paths, "instance", "/home/agent", {})).toThrow(
+			"journal is invalid",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/cli/src/runtime/provider-ownership.ts
+++ b/packages/cli/src/runtime/provider-ownership.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import type { ConnectionProviderTransfer } from "./connection-provider-config";
+import type { RuntimePaths } from "./paths";
+
+const PROVIDER_RUNTIMES = ["openclaw", "hermes"] as const;
+
+const transferSchema = z
+	.object({
+		envName: z.string().regex(/^[A-Z][A-Z0-9_]{0,127}$/),
+		baseUrl: z.string().url(),
+		apiMode: z.enum([
+			"openai_chat",
+			"openai_responses",
+			"anthropic_messages",
+			"google_generate_content",
+		]),
+	})
+	.strict();
+
+export interface ProviderOwnership {
+	providers: Record<string, string[]>;
+	transfers: Record<string, Record<string, ConnectionProviderTransfer>>;
+}
+
+const ownershipSchema = z
+	.object({
+		schemaVersion: z.literal(1),
+		instanceId: z.string().min(1),
+		home: z.string().min(1),
+		transfers: z.record(
+			z.enum(PROVIDER_RUNTIMES),
+			z.record(z.string().regex(/^[a-z][a-z0-9._-]{1,62}$/), transferSchema),
+		),
+		providers: z.record(z.enum(PROVIDER_RUNTIMES), z.array(z.string().min(1))),
+	})
+	.strict();
+
+/** Survives config writes that precede a failed service or authority commit. */
+export function readProviderOwnership(
+	paths: RuntimePaths,
+	instanceId: string,
+	home: string,
+	applied: Record<string, string[]>,
+): ProviderOwnership {
+	let content: string;
+	try {
+		content = readFileSync(join(paths.serviceStateRoot, "provider-ownership.json"), "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT")
+			return { providers: applied, transfers: { openclaw: {}, hermes: {} } };
+		throw new Error("Provider ownership journal is unreadable");
+	}
+	let journal: z.infer<typeof ownershipSchema>;
+	try {
+		journal = ownershipSchema.parse(JSON.parse(content));
+	} catch {
+		throw new Error("Provider ownership journal is invalid");
+	}
+	if (journal.instanceId !== instanceId || journal.home !== home)
+		throw new Error("Provider ownership journal belongs to another runtime");
+	const providers = { ...applied };
+	for (const runtime of PROVIDER_RUNTIMES) {
+		const ids = journal.providers[runtime];
+		providers[runtime] = [...new Set([...(applied[runtime] ?? []), ...ids])]
+			.filter((id) => !Object.hasOwn(journal.transfers[runtime] ?? {}, id))
+			.sort();
+	}
+	return { providers, transfers: journal.transfers };
+}
+
+export function writeProviderOwnership(
+	paths: RuntimePaths,
+	instanceId: string,
+	home: string,
+	ownership: ProviderOwnership,
+): void {
+	const journal = ownershipSchema.parse({
+		schemaVersion: 1,
+		instanceId,
+		home,
+		transfers: ownership.transfers,
+		providers: Object.fromEntries(
+			PROVIDER_RUNTIMES.map((runtime) => [
+				runtime,
+				[...new Set(ownership.providers[runtime] ?? [])]
+					.filter((id) => !Object.hasOwn(ownership.transfers[runtime] ?? {}, id))
+					.sort(),
+			]),
+		),
+	});
+	writePrivateFileAtomic(
+		join(paths.serviceStateRoot, "provider-ownership.json"),
+		`${JSON.stringify(journal)}\n`,
+		{ trustedRoot: paths.serviceStateRoot, durable: true },
+	);
+}

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -771,7 +771,7 @@ describe("ai-provider commands", () => {
 	});
 
 	it("projects Codex auth profiles to native Hermes config without key env", () => {
-		const projection = buildAgentTargetProjection("hermes", {
+		const catalog = {
 			schema_version: 1,
 			providers: [
 				{
@@ -784,6 +784,10 @@ describe("ai-provider commands", () => {
 					runtime_env_name: "OPENAI_API_KEY",
 				},
 			],
+		} as const;
+		const projection = buildAgentTargetProjection("hermes", catalog, {
+			provider_id: "openai-codex",
+			model: "gpt-5.2",
 		});
 
 		const patch = projection.files[0]?.content ?? "";
@@ -812,7 +816,10 @@ describe("ai-provider commands", () => {
 			defaults: { chat_provider_id: "clawdi-managed-v2" },
 		} as const;
 
-		const projection = buildAgentTargetProjection("openclaw", catalog);
+		const projection = buildAgentTargetProjection("openclaw", catalog, {
+			provider_id: "clawdi-managed-v2",
+			model: "gpt-5.5",
+		});
 		const patch = JSON.parse(projection.files[0]!.content);
 
 		expect(patch.agents.defaults.model.primary).toBe("clawdi/gpt-5.5");
@@ -833,7 +840,7 @@ describe("ai-provider commands", () => {
 	});
 
 	it("projects Clawdi-managed OpenAI chat providers directly to Hermes", () => {
-		const projection = buildAgentTargetProjection("hermes", {
+		const catalog = {
 			schema_version: 1,
 			providers: [
 				{
@@ -849,6 +856,10 @@ describe("ai-provider commands", () => {
 				},
 			],
 			defaults: { chat_provider_id: "clawdi-managed-v2" },
+		} as const;
+		const projection = buildAgentTargetProjection("hermes", catalog, {
+			provider_id: "clawdi-managed-v2",
+			model: "gpt-5.5",
 		});
 
 		const patch = projection.files[0]?.content ?? "";
@@ -926,7 +937,10 @@ describe("ai-provider commands", () => {
 			defaults: { chat_provider_id: "custom-openai" },
 		} as const;
 
-		const projection = buildAgentTargetProjection("openclaw", catalog);
+		const projection = buildAgentTargetProjection("openclaw", catalog, {
+			provider_id: "custom-openai",
+			model: "gpt-5.5",
+		});
 		const patch = JSON.parse(projection.files[0]!.content);
 
 		expect(patch.agents.defaults.model.primary).toBe("custom-openai/gpt-5.5");
@@ -949,7 +963,7 @@ describe("ai-provider commands", () => {
 	});
 
 	it("keeps the OpenClaw default model registered when catalog models omit it", () => {
-		const projection = buildAgentTargetProjection("openclaw", {
+		const catalog = {
 			schema_version: 1,
 			defaults: { chat_provider_id: "openai-main" },
 			providers: [
@@ -963,6 +977,10 @@ describe("ai-provider commands", () => {
 					models: [{ id: "gpt-4o", label: "GPT 4o", input_modalities: ["text", "image"] }],
 				},
 			],
+		} as const;
+		const projection = buildAgentTargetProjection("openclaw", catalog, {
+			provider_id: "openai-main",
+			model: "gpt-5.2",
 		});
 
 		const patch = JSON.parse(projection.files[0]?.content ?? "{}");
@@ -973,7 +991,7 @@ describe("ai-provider commands", () => {
 	});
 
 	it("projects multiple OpenClaw providers with merge mode and one default", () => {
-		const projection = buildAgentTargetProjection("openclaw", {
+		const catalog = {
 			schema_version: 1,
 			defaults: { chat_provider_id: "anthropic-main" },
 			providers: [
@@ -994,6 +1012,10 @@ describe("ai-provider commands", () => {
 					auth: { type: "secret_ref", ref: "env:ANTHROPIC_API_KEY" },
 				},
 			],
+		} as const;
+		const projection = buildAgentTargetProjection("openclaw", catalog, {
+			provider_id: "anthropic-main",
+			model: "claude-opus-4-6",
 		});
 
 		const patch = JSON.parse(projection.files[0]?.content ?? "{}");
@@ -1007,7 +1029,7 @@ describe("ai-provider commands", () => {
 	});
 
 	it("projects Codex OAuth to OpenClaw native OpenAI route without apiKey", () => {
-		const projection = buildAgentTargetProjection("openclaw", {
+		const catalog = {
 			schema_version: 1,
 			defaults: { chat_provider_id: "openai-codex" },
 			providers: [
@@ -1020,6 +1042,10 @@ describe("ai-provider commands", () => {
 					auth: { type: "agent_profile", tool: "codex", profile: "default" },
 				},
 			],
+		} as const;
+		const projection = buildAgentTargetProjection("openclaw", catalog, {
+			provider_id: "openai-codex",
+			model: "gpt-5.2",
 		});
 
 		const patch = JSON.parse(projection.files[0]?.content ?? "{}");
@@ -1113,7 +1139,7 @@ describe("ai-provider commands", () => {
 
 	it("imports provider metadata from the current OpenClaw patch shape", async () => {
 		const openclawConfig = join(tmpHome, "openclaw-config.json");
-		const projection = buildAgentTargetProjection("openclaw", {
+		const sourceCatalog = {
 			schema_version: 1,
 			defaults: { chat_provider_id: "anthropic-main" },
 			providers: [
@@ -1134,6 +1160,10 @@ describe("ai-provider commands", () => {
 					auth: { type: "secret_ref", ref: "env:ANTHROPIC_API_KEY" },
 				},
 			],
+		} as const;
+		const projection = buildAgentTargetProjection("openclaw", sourceCatalog, {
+			provider_id: "anthropic-main",
+			model: "claude-opus-4-6",
 		});
 		writeFileSync(openclawConfig, projection.files[0]?.content ?? "{}");
 		const { restore } = captureConsole();

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2040,6 +2040,7 @@ function hostedSingleProviderModeLoad(
 	runtimeName: "openclaw" | "hermes",
 	providerMode: "configured" | "unmanaged",
 	generation: number,
+	instanceId = "iid_provider_mode",
 ): RuntimeManifestLoad {
 	const configuredRuntime =
 		runtimeName === "openclaw"
@@ -2094,7 +2095,7 @@ function hostedSingleProviderModeLoad(
 			...hostedRequiredState(),
 			providers,
 			terminalTooling,
-			instanceId: "iid_provider_mode",
+			instanceId,
 			generation,
 			issuedAt: "2026-07-14T00:00:00Z",
 			locale: TEST_HOSTED_LOCALE,
@@ -4361,7 +4362,13 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			"post-reconnect-rotated-access",
 		);
 
-		const removedLoad = hostedSingleProviderModeLoad(home, "hermes", "unmanaged", 3);
+		const removedLoad = hostedSingleProviderModeLoad(
+			home,
+			"hermes",
+			"unmanaged",
+			3,
+			firstLoad.manifest.instanceId,
+		);
 		convergeRuntimeManifest(removedLoad, paths);
 		auth = JSON.parse(readFileSync(authPath, "utf8"));
 		expect(auth.providers["openai-codex"].tokens.access_token).toBe("user-access");
@@ -4515,7 +4522,13 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			"post-reconnect-rotated-access",
 		);
 
-		const removedLoad = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 3);
+		const removedLoad = hostedSingleProviderModeLoad(
+			home,
+			"openclaw",
+			"unmanaged",
+			3,
+			firstLoad.manifest.instanceId,
+		);
 		convergeRuntimeManifest(removedLoad, paths);
 		store = JSON.parse(readFileSync(storePath, "utf8"));
 		expect(store.profiles[nativeProfileId]).toBeUndefined();

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -89,7 +89,7 @@ export interface AiProviderModel {
 export interface AiProvider {
 	id: string;
 	type: AiProviderType;
-	configuration_mode?: "native" | "catalog";
+	configuration_mode?: "native" | "catalog" | "connection";
 	native_provider?: string;
 	native_variant?: string;
 	readiness?: NonNullable<components["schemas"]["AiProviderResponse"]["readiness"]>;
@@ -390,7 +390,8 @@ export function aiProviderRuntimeCompatibility(
 	return {
 		openclaw: RUNTIME_API_MODES.openclaw.includes(apiMode),
 		hermes: RUNTIME_API_MODES.hermes.includes(apiMode),
-		codex: RUNTIME_API_MODES.codex.includes(apiMode),
+		codex:
+			provider.configuration_mode !== "connection" && RUNTIME_API_MODES.codex.includes(apiMode),
 	};
 }
 
@@ -473,6 +474,15 @@ function validateProvider(
 	options: AiProviderValidationOptions,
 ): void {
 	const prefix = provider.id || "<missing>";
+	if (
+		provider.configuration_mode === "connection" &&
+		(provider.managed_by !== "user" ||
+			!["api_key", "secret_ref"].includes(provider.auth?.type) ||
+			!provider.runtime_env_name ||
+			provider.native_provider ||
+			provider.native_variant)
+	)
+		errors.push(`Provider ${prefix} connection management requires a user API-key connection.`);
 	if (provider.configuration_mode === "native") {
 		const native = nativeAiProvider(provider.native_provider, provider.native_variant);
 		if (

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4459,8 +4459,10 @@ export interface components {
         };
         /** AiProviderPatch */
         AiProviderPatch: {
+            /** Credential */
+            credential?: components["schemas"]["AiProviderApiKeyAcceptCredential"];
             /** Configuration Mode */
-            configuration_mode?: ("native" | "catalog") | null;
+            configuration_mode?: ("native" | "catalog" | "connection") | null;
             /** Native Provider */
             native_provider?: string | null;
             /** Native Variant */
@@ -4523,7 +4525,7 @@ export interface components {
              * Configuration Mode
              * @enum {string}
              */
-            configuration_mode?: "native" | "catalog";
+            configuration_mode?: "native" | "catalog" | "connection";
             /** Native Provider */
             native_provider?: string | null;
             /** Native Variant */
@@ -4610,7 +4612,7 @@ export interface components {
              * Configuration Mode
              * @enum {string}
              */
-            configuration_mode?: "native" | "catalog";
+            configuration_mode?: "native" | "catalog" | "connection";
             /** Native Provider */
             native_provider?: string | null;
             /** Native Variant */

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -75,6 +75,36 @@ const codexProvider = {
 	auth: { type: "agent_profile", tool: "codex", profile: "default" },
 } satisfies HostedSavedAiProvider;
 
+test("connection bindings cannot bootstrap a new agent or regain model authority", () => {
+	const provider = {
+		...apiKeyProvider,
+		configuration_mode: "connection",
+	} satisfies HostedSavedAiProvider;
+	const selection = {
+		mode: "saved",
+		providerId: provider.provider_id,
+		model: "old-model",
+	} as const;
+	for (const mode of ["create", "update"] as const) {
+		expect(() =>
+			buildHostedAiBindingFields({ managedModels, mode, providers: [provider], selection }),
+		).toThrow("existing agent");
+	}
+	const retained = buildHostedAiBindingFields({
+		managedModels,
+		mode: "update",
+		providers: [provider],
+		selection,
+		currentProviderIds: [provider.provider_id],
+	});
+	expect(retained.primary_model).toBeNull();
+	expect(retained.ai_provider_bootstrap?.catalog.providers[0]?.configuration_mode).toBe(
+		"connection",
+	);
+	expect(retained.ai_provider_bootstrap?.catalog.providers[0]?.models).toBeUndefined();
+	expect(provider.models).toEqual(apiKeyProvider.models);
+});
+
 test("native API key and OAuth bindings carry credential readiness without choosing a model", () => {
 	for (const saved of [apiKeyProvider, codexProvider]) {
 		const provider: HostedSavedAiProvider = {

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -60,8 +60,21 @@ export type HostedAiProviderAvailabilityIssue = {
 
 export function hostedAiProviderAvailabilityIssue(
 	provider: HostedSavedAiProvider,
-	context: { runtime: HostedAiProviderRuntime; environmentId: string | null },
+	context: {
+		runtime: HostedAiProviderRuntime;
+		environmentId: string | null;
+		currentProviderIds?: readonly string[];
+	},
 ): HostedAiProviderAvailabilityIssue | null {
+	if (
+		provider.configuration_mode === "connection" &&
+		(!context.environmentId || !context.currentProviderIds?.includes(provider.provider_id))
+	) {
+		return {
+			kind: "delivery",
+			message: "This connection can only remain on an agent that already uses it.",
+		};
+	}
 	if (
 		provider.consumer &&
 		(context.environmentId === null ||
@@ -159,7 +172,8 @@ function toHostedRuntimeAiProvider(provider: HostedSavedAiProvider): RuntimeAiPr
 			: {}),
 	};
 	if (provider.label) runtimeProvider.label = provider.label;
-	const models = toRuntimeModels(provider.models);
+	const models =
+		provider.configuration_mode === "connection" ? [] : toRuntimeModels(provider.models);
 	if (models.length > 0) runtimeProvider.models = models;
 	if (provider.api_mode) runtimeProvider.api_mode = provider.api_mode;
 	if (provider.runtime_env_name) runtimeProvider.runtime_env_name = provider.runtime_env_name;
@@ -174,11 +188,13 @@ export function buildHostedAiBindingFields({
 	mode,
 	providers,
 	selection,
+	currentProviderIds,
 }: {
 	managedModels: readonly HostedDeployManagedModel[];
 	mode: HostedAiBindingOperationMode;
 	providers: readonly HostedSavedAiProvider[];
 	selection: HostedAiBindingSelection;
+	currentProviderIds?: readonly string[];
 }): Omit<HostedDeployAiFields, "primary_model"> & {
 	primary_model?: Exclude<HostedDeployAiFields["primary_model"], string>;
 	ai_provider_bootstrap?: HostedAiProviderBootstrap | null;
@@ -223,7 +239,20 @@ export function buildHostedAiBindingFields({
 	}
 
 	const provider = savedProviderForId(selection.providerId, providers);
-	if (provider.configuration_mode !== "native" && !model) {
+	if (
+		provider.configuration_mode === "connection" &&
+		(mode !== "update" || !currentProviderIds?.includes(provider.provider_id))
+	) {
+		throw new HostedAiBindingError(
+			"provider_unusable",
+			"Connection ownership can only be retained on its existing agent.",
+		);
+	}
+	if (
+		provider.configuration_mode !== "native" &&
+		provider.configuration_mode !== "connection" &&
+		!model
+	) {
 		throw new HostedAiBindingError("model_required", "Choose a catalog model or enter a model id.");
 	}
 	const authKind = hostedAiProviderAuthKind(provider);
@@ -232,7 +261,7 @@ export function buildHostedAiBindingFields({
 		ai_provider_id: provider.provider_id,
 		provider_ids: [provider.provider_id],
 		primary_model:
-			provider.configuration_mode === "native"
+			provider.configuration_mode === "native" || provider.configuration_mode === "connection"
 				? null
 				: { provider_id: provider.provider_id, model },
 		ai_provider_bootstrap: buildHostedAiProviderBootstrap(provider),


### PR DESCRIPTION
Existing catalog BYOK connections can transfer model ownership to OpenClaw or Hermes without changing provider IDs, credentials, endpoints, selected models, or model metadata. The migration-only connection mode stops model projection, uses native configuration APIs for scoped credential updates, and retains a keyless ownership journal so failed convergence and later unbinding cannot delete transferred model rows.

Core admits the mode-only transition only when every bound runtime has fresh, current evidence from an exact CLI version in supported_connection_cli_versions. Missing or empty disables migration. Web preserves the mode, hides model controls, and submits edits plus key rotation in one sensitive atomic PATCH. Creation, reverse conversion, model overwrite, environment rename, and OAuth bypass are rejected. Managed catalogs and OAuth keep their existing contracts.

Also removes unused provider form/automatic-primary scaffolding and fixes explicit catalog API-key precedence and native ownership recovery. Hosted companion Clawdi-AI/clawdi-hosted#2139 is merged. CLI candidate: 0.14.58.

Validation in bounded isolated Docker:
- Backend 195 passed; Web/shared 129 passed; full CLI runtime/reconciliation plus migration/native/journal 321 passed, 2,268 assertions.
- Typechecks, generated API, strict changed Python checks, Ruff/Biome, Chromium atomic-edit regression, OSS build, and backend-to-CLI rendered contract passed.
- Actual official OpenClaw 2026.9.2 (3928bad) and Hermes 0.21.0 (0d08cd295fd73427833ee349eb858569d4d0dd3a): six offline scenarios passed for ownership handoff, key rotation, user model preservation, unbinding, pre-write interruption, and competing Hermes pool rejection. No real inference or real credentials.
- Packaged CLI reports 0.14.58. The production journal fence remains unchanged; two older OAuth fixtures now retain the same instance identity for unbinding.

Host commit hook reports Lefthook unavailable; checks were run explicitly in isolation. Final-head CI must pass before merge. Do not enable the migration allowlist until the exact published CLI/image combination is qualified and observed on consumers. Native include references whose ownership is hidden by redaction remain excluded. No production migration has run.
