### PR TITLE
Simplify resource sharing and clarify Agent Vault access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ database migration, CI, and implementation details.
 
 ### Changed
 
-- Projects and Vaults now share catalogs with Linked and Available groups and
-  direct Link or Unlink actions in Agent and Project context.
+- Agent Projects show Linked and Available groups with direct Link or Unlink
+  actions. Agent Vaults show the keys available through those Projects and the
+  existing Workspace, with their sources; Vaults are configured in Projects.
+- Project sharing uses a compact invitation and access view, with inactive
+  links and bulk sharing controls tucked away.
 - CLI 0.14.56 installs sourced Skills through Hermes and OpenClaw native
   capabilities, preserving supporting files and recovering interrupted changes.
 - CLI 0.14.54 delivers native BYOK credentials through OpenClaw configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ database migration, CI, and implementation details.
   actions. Agent Vaults show the keys available through those Projects and the
   existing Workspace, with their sources; Vaults are configured in Projects.
 - Project sharing uses a compact invitation and access view, with inactive
-  links and bulk sharing controls tucked away.
+  links and bulk sharing controls tucked away. Invitation previews explain access
+  once, and Session sharing prioritizes the latest link while keeping older
+  links available on demand.
 - CLI 0.14.56 installs sourced Skills through Hermes and OpenClaw native
   capabilities, preserving supporting files and recovering interrupted changes.
 - CLI 0.14.54 delivers native BYOK credentials through OpenClaw configuration

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3829,10 +3829,7 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	);
 	await expect(
 		overview.locator('[data-overview-module="vaults"]').getByRole("link", { name: "Vaults" }),
-	).toHaveAttribute(
-		"href",
-		`/agents/${railHostedEnvironmentId}/project-access/project-hosted/vaults`,
-	);
+	).toHaveAttribute("href", `/agents/${railHostedEnvironmentId}/vaults`);
 	await expect(overview.locator('[data-overview-module="memories"]')).toContainText("1 memory");
 	await expect(overview.locator('[data-overview-module="connectors"]')).toContainText("2 apps");
 	expect(overviewConnectorRequests).toEqual([]);
@@ -3852,11 +3849,11 @@ test("hosted agent overview uses the modular hierarchy", async ({ page }, testIn
 	const vaultsLink = projectGroup.getByRole("link", { name: "Vaults", exact: true });
 	const expectedProjectHub = `/agents/${railHostedEnvironmentId}/project-access/project-hosted`;
 	await expect(skillsLink).toHaveAttribute("href", `${expectedProjectHub}/skills`);
-	await expect(vaultsLink).toHaveAttribute("href", `${expectedProjectHub}/vaults`);
+	await expect(vaultsLink).toHaveAttribute("href", `/agents/${railHostedEnvironmentId}/vaults`);
 	await vaultsLink.focus();
 	await expect(vaultsLink).toBeFocused();
 	await vaultsLink.click();
-	await expect(page).toHaveURL(`${expectedProjectHub}/vaults`);
+	await expect(page).toHaveURL(`/agents/${railHostedEnvironmentId}/vaults`);
 	await expect(vaultsLink).toHaveAttribute("data-active", "");
 	await expect(skillsLink).not.toHaveAttribute("data-active", "");
 	await page.goto(`/agents/${railHostedEnvironmentId}`);

--- a/apps/web/e2e/project-detail.pw.ts
+++ b/apps/web/e2e/project-detail.pw.ts
@@ -214,13 +214,15 @@ test("Project detail uses explicit local pages at mobile and desktop", async ({ 
 	await projectTabs.getByRole("tab", { name: "Vaults" }).click();
 	await expect(page.getByRole("heading", { name: "Vaults", exact: true })).toBeVisible();
 	const catalog = page.getByTestId("project-vault-catalog");
-	const linked = catalog.getByRole("region", { name: "Linked Project Vaults", exact: true });
+	const linked = catalog.getByRole("region", { name: "In this Project Vaults", exact: true });
 	const available = catalog.getByRole("region", { name: "Available Project Vaults" });
 	await expect(catalog.getByRole("region").nth(0)).toHaveAttribute(
 		"aria-label",
-		"Linked Project Vaults",
+		"In this Project Vaults",
 	);
-	await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked1");
+	await expect(linked.getByText("In this Project", { exact: true }).locator("..")).toHaveText(
+		"In this Project1",
+	);
 	await expect(available.getByText("Available", { exact: true }).locator("..")).toHaveText(
 		"Available1",
 	);
@@ -228,7 +230,7 @@ test("Project detail uses explicit local pages at mobile and desktop", async ({ 
 		.getByTestId("project-vault-card")
 		.filter({ hasText: "Release archive" });
 	await expect(
-		catalog.getByRole("button", { name: "Unlink Already attached from Project" }),
+		catalog.getByRole("button", { name: "Remove Already attached from Project" }),
 	).toBeVisible();
 	await catalog.getByLabel("Search Vaults").fill("release");
 	await expect(catalog.getByTestId("project-vault-card")).toHaveCount(1);
@@ -245,17 +247,21 @@ test("Project detail uses explicit local pages at mobile and desktop", async ({ 
 		await route.fallback();
 	});
 	try {
-		await releaseVault.getByRole("button", { name: "Link Release archive to Project" }).click();
+		await releaseVault.getByRole("button", { name: "Add Release archive to Project" }).click();
 		await expect(linked.getByRole("link", { name: "Open vault Release archive" })).toBeVisible();
-		await expect(releaseVault.getByRole("button")).toHaveText(["Linking…"]);
-		await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked1");
+		await expect(releaseVault.getByRole("button")).toHaveText(["Adding…"]);
+		await expect(linked.getByText("In this Project", { exact: true }).locator("..")).toHaveText(
+			"In this Project1",
+		);
 		await expect(available).toHaveCount(0);
 	} finally {
 		releaseRefresh();
 	}
-	await expect(releaseVault.getByRole("button")).toHaveText(["Unlink"]);
+	await expect(releaseVault.getByRole("button")).toHaveText(["Remove"]);
 	await catalog.getByLabel("Search Vaults").fill("");
-	await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked2");
+	await expect(linked.getByText("In this Project", { exact: true }).locator("..")).toHaveText(
+		"In this Project2",
+	);
 	await expect(available).toHaveCount(0);
 	await expect.poll(() => vaultCreateRequests).toHaveLength(1);
 	expect(vaultCreateRequests[0]?.body).toEqual({
@@ -263,12 +269,14 @@ test("Project detail uses explicit local pages at mobile and desktop", async ({ 
 		name: "Release archive",
 	});
 	expect(vaultCreateRequests[0]?.url.searchParams.get("project_id")).toBe(projectId);
-	await releaseVault.getByRole("button", { name: "Unlink Release archive from Project" }).click();
+	await releaseVault.getByRole("button", { name: "Remove Release archive from Project" }).click();
 	await expect(
-		releaseVault.getByRole("button", { name: "Link Release archive to Project" }),
+		releaseVault.getByRole("button", { name: "Add Release archive to Project" }),
 	).toBeEnabled();
 	await expect(available.getByRole("link", { name: "Open vault Release archive" })).toBeVisible();
-	await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked1");
+	await expect(linked.getByText("In this Project", { exact: true }).locator("..")).toHaveText(
+		"In this Project1",
+	);
 	await expect(available.getByText("Available", { exact: true }).locator("..")).toHaveText(
 		"Available1",
 	);

--- a/apps/web/e2e/project-invitation.pw.ts
+++ b/apps/web/e2e/project-invitation.pw.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test("explains Project access once and opens the Project after accepting", async ({ page }) => {
+	let accepted = false;
+	await page.route("**/v1/**", async (route) => {
+		const path = new URL(route.request().url()).pathname;
+		if (path === "/v1/share/invitation-preview/preview") {
+			return route.fulfill({
+				json: {
+					project_id: "team-knowledge",
+					project_name: "Team Knowledge",
+					owner_display: "Alex",
+					owner_handle: "alex",
+					skill_count: 3,
+					vault_count: 1,
+					vault_locked: true,
+				},
+			});
+		}
+		if (path === "/v1/share/invitation-preview/upgrade") {
+			accepted = true;
+			return route.fulfill({ json: { project_id: "team-knowledge" } });
+		}
+		return route.fulfill({ json: {} });
+	});
+	await page.goto("/share/invitation-preview");
+	await expect(page.getByText("Team Knowledge", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText(/You can view this Project and link it to your Agents/),
+	).toBeVisible();
+	for (const width of [1280, 390]) {
+		await page.setViewportSize({ width, height: 900 });
+		await expect(page.getByRole("button", { name: "Accept invitation" })).toBeVisible();
+		expect(
+			await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+		).toBe(true);
+		await page.screenshot({ path: `test-results/invitation-${width}.png`, fullPage: true });
+	}
+	await page.getByRole("button", { name: "Accept invitation" }).click();
+	await expect(page).toHaveURL(/\/projects\/team-knowledge\?joined=share/);
+	expect(accepted).toBe(true);
+});

--- a/apps/web/e2e/session-sharing.pw.ts
+++ b/apps/web/e2e/session-sharing.pw.ts
@@ -47,6 +47,7 @@ test("uses direct message actions and keeps older live links revocable", async (
 	let legacyLinkActive = true;
 	let shares: Array<Record<string, unknown>> = [];
 	let createdBody: unknown;
+	let failRefresh = false;
 	let requestedTimelineCategories: string[] = [];
 
 	await page.route("**/v1/**", async (route) => {
@@ -90,7 +91,12 @@ test("uses direct message actions and keeps older live links revocable", async (
 			});
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/shares`) {
-			if (route.request().method() === "GET") return fulfillJson(route, { shares });
+			if (route.request().method() === "GET")
+				return fulfillJson(
+					route,
+					failRefresh ? { detail: "Unavailable" } : { shares },
+					failRefresh ? 503 : 200,
+				);
 			createdBody = route.request().postDataJSON();
 			const created = {
 				id: SHARE_ID,
@@ -103,6 +109,7 @@ test("uses direct message actions and keeps older live links revocable", async (
 				created_at: now,
 			};
 			shares = [created];
+			failRefresh = true;
 			return fulfillJson(route, created, 201);
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/permissions`) {
@@ -156,10 +163,15 @@ test("uses direct message actions and keeps older live links revocable", async (
 	await expect(responseDialog.getByLabel("Session share URL")).toHaveValue(
 		`http://127.0.0.1:3200/s/${SHARE_ID}`,
 	);
+	await expect(responseDialog.getByText("Couldn't load share links")).toBeVisible();
+	await expect(responseDialog.getByLabel("Session share URL")).toBeVisible();
+	failRefresh = false;
 	await responseDialog.getByRole("button", { name: "Close" }).click();
 
 	await page.getByRole("button", { name: "Share", exact: true }).click();
 	const sessionDialog = page.getByRole("dialog", { name: "Share session" });
+	await expect(sessionDialog.getByText("Older link")).not.toBeVisible();
+	await sessionDialog.getByText("Other active links (2)", { exact: true }).click();
 	await expect(sessionDialog.getByText("Older link")).toBeVisible();
 	const legacyRow = sessionDialog
 		.getByText("Live Session link", { exact: true })

--- a/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
+++ b/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
@@ -4,8 +4,8 @@ import { expect, type Page, type Route, test } from "@playwright/test";
 const now = "2026-08-02T12:00:00.000Z";
 const project = {
 	id: "project-sharing",
-	name: "Shared workspace",
-	slug: "shared-workspace",
+	name: "Team Knowledge",
+	slug: "team-knowledge",
 	kind: "workspace",
 	origin_environment_id: null,
 	archived_at: null,
@@ -140,7 +140,7 @@ async function stubSharingApi(page: Page, empty = false) {
 
 async function openSharing(page: Page) {
 	await page.goto("/projects");
-	await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
+	await page.getByRole("button", { name: "Actions for Team Knowledge" }).click();
 	await page.getByRole("menuitem", { name: "Share", exact: true }).click();
 	await expect(page.getByRole("dialog")).toBeVisible();
 }
@@ -184,7 +184,7 @@ test("sharing row mutations retain targets through Base UI exit and reopen clean
 
 	await page.keyboard.press("Escape");
 	await expect(page.getByRole("dialog")).toBeHidden();
-	await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
+	await page.getByRole("button", { name: "Actions for Team Knowledge" }).click();
 	await page.getByRole("menuitem", { name: "Share", exact: true }).click();
 	await expect(
 		page.getByRole("button", { name: /Turn off share link|Cancel invitation|Remove / }),
@@ -206,7 +206,9 @@ for (const viewport of [
 		await expect(
 			dialog.getByRole("button", { name: "Stop all sharing for this Project" }),
 		).toBeHidden();
-		await expect(dialog.getByText(/Their linked Agents can use its Vault values/)).toHaveCount(1);
+		await expect(
+			dialog.getByText(/People can view this Project and let their Agents use its keys/),
+		).toHaveCount(1);
 		const dimensions = await dialog.evaluate((element) => ({
 			width: element.clientWidth,
 			scrollWidth: element.scrollWidth,
@@ -233,7 +235,7 @@ for (const viewport of [
 		await expect(dialog.getByRole("button", { name: /Copy agent handoff prompt/ })).toBeVisible();
 		await page.keyboard.press("Escape");
 		await expect(dialog).toBeHidden();
-		await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
+		await page.getByRole("button", { name: "Actions for Team Knowledge" }).click();
 		await page.getByRole("menuitem", { name: "Share", exact: true }).click();
 		await expect(dialog.getByRole("textbox", { name: "New share link URL" })).toHaveCount(0);
 	});

--- a/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
+++ b/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
@@ -154,9 +154,9 @@ test("sharing row mutations retain targets through Base UI exit and reopen clean
 
 	const cases = [
 		{
-			trigger: "Turn off share link link-prefix",
-			action: "Turn Off Link",
-			retained: "Turn off this share link?",
+			trigger: "Turn off invite link link-prefix",
+			action: "Turn off link",
+			retained: "Turn off this invite link?",
 		},
 		{
 			trigger: "Cancel invitation for invitee@example.com",
@@ -165,7 +165,7 @@ test("sharing row mutations retain targets through Base UI exit and reopen clean
 		},
 		{
 			trigger: "Remove member member@example.com",
-			action: "Remove Member",
+			action: "Remove member",
 			retained: "member@example.com",
 		},
 	] as const;
@@ -187,7 +187,7 @@ test("sharing row mutations retain targets through Base UI exit and reopen clean
 	await page.getByRole("button", { name: "Actions for Team Knowledge" }).click();
 	await page.getByRole("menuitem", { name: "Share", exact: true }).click();
 	await expect(
-		page.getByRole("button", { name: /Turn off share link|Cancel invitation|Remove / }),
+		page.getByRole("button", { name: /Turn off invite link|Cancel invitation|Remove / }),
 	).toHaveCount(0);
 });
 
@@ -227,7 +227,7 @@ for (const viewport of [
 		await expect(dialog.getByText("new-person@example.com", { exact: true })).toBeVisible();
 		await expect(dialog.getByText("Pending", { exact: true })).toBeVisible();
 		await dialog.getByRole("button", { name: "Create invite link" }).click();
-		await expect(dialog.getByRole("textbox", { name: "New share link URL" })).toHaveValue(
+		await expect(dialog.getByRole("textbox", { name: "New invite link URL" })).toHaveValue(
 			"https://example.com/share/test-token",
 		);
 		await expect(dialog.getByRole("button", { name: /Copy agent handoff prompt/ })).toBeHidden();
@@ -237,7 +237,7 @@ for (const viewport of [
 		await expect(dialog).toBeHidden();
 		await page.getByRole("button", { name: "Actions for Team Knowledge" }).click();
 		await page.getByRole("menuitem", { name: "Share", exact: true }).click();
-		await expect(dialog.getByRole("textbox", { name: "New share link URL" })).toHaveCount(0);
+		await expect(dialog.getByRole("textbox", { name: "New invite link URL" })).toHaveCount(0);
 	});
 }
 
@@ -263,7 +263,7 @@ test("sharing management stays disclosed and failed actions remain retryable", a
 	await dialog.getByText("Inactive links (2)", { exact: true }).click();
 	await expect(dialog.getByText("Expired", { exact: true })).toBeVisible();
 	await expect(
-		dialog.getByRole("button", { name: "Turn off share link expired-prefix" }),
+		dialog.getByRole("button", { name: "Turn off invite link expired-prefix" }),
 	).toHaveCount(0);
 	await expect(dialog.getByText("Old invite link", { exact: true })).toBeVisible();
 	await page.route("**/v1/projects/project-sharing/share-links", async (route) => {
@@ -276,7 +276,7 @@ test("sharing management stays disclosed and failed actions remain retryable", a
 	await dialog.getByText("Manage sharing", { exact: true }).click();
 	await dialog.getByRole("button", { name: "Stop all sharing for this Project" }).press("Enter");
 	const confirmation = page.getByRole("alertdialog");
-	await confirmation.getByRole("button", { name: "Keep Sharing" }).click();
+	await confirmation.getByRole("button", { name: "Keep sharing" }).click();
 	await expect(confirmation).toBeHidden();
 	await expect(dialog.getByText("member@example.com", { exact: true })).toBeVisible();
 	await dialog.getByRole("button", { name: "Stop all sharing for this Project" }).press("Enter");
@@ -292,7 +292,7 @@ test("sharing management stays disclosed and failed actions remain retryable", a
 	await expect(confirmation).toBeHidden();
 	await expect(dialog.getByText("Only you have access", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("invitee@example.com", { exact: true })).toHaveCount(0);
-	await expect(dialog.getByRole("button", { name: /Turn off share link/ })).toHaveCount(0);
+	await expect(dialog.getByRole("button", { name: /Turn off invite link/ })).toHaveCount(0);
 });
 
 test("a newly created URL survives failed refresh and clipboard access", async ({ page }) => {
@@ -321,9 +321,9 @@ test("a newly created URL survives failed refresh and clipboard access", async (
 	);
 	await dialog.getByRole("button", { name: "Create invite link" }).click();
 	await failedRefresh;
-	const url = dialog.getByRole("textbox", { name: "New share link URL" });
+	const url = dialog.getByRole("textbox", { name: "New invite link URL" });
 	await expect(url).toHaveValue("https://example.com/share/test-token");
-	await dialog.getByRole("button", { name: "Copy Share Link", exact: true }).click();
+	await dialog.getByRole("button", { name: "Copy invite link", exact: true }).click();
 	await expect(
 		page.getByText("Select the text and copy it manually.", { exact: true }),
 	).toBeVisible();

--- a/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
+++ b/apps/web/e2e/share-project-dialog-lifecycle.pw.ts
@@ -1,3 +1,4 @@
+import type { components } from "@clawdi/shared/api";
 import { expect, type Page, type Route, test } from "@playwright/test";
 
 const now = "2026-08-02T12:00:00.000Z";
@@ -18,13 +19,14 @@ async function json(route: Route, body: unknown, status = 200) {
 	await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
 }
 
-async function stubSharingApi(page: Page) {
-	let links = [
+async function stubSharingApi(page: Page, empty = false) {
+	let links: components["schemas"]["ShareLinkResponse"][] = [
 		{
 			id: "link-one",
 			prefix: "link-prefix",
 			label: "Review link",
 			created_at: now,
+			expires_at: null,
 			revoked_at: null,
 			redeem_count: 0,
 			last_redeemed_at: null,
@@ -43,6 +45,32 @@ async function stubSharingApi(page: Page) {
 		},
 	];
 
+	links.push({
+		id: "old-link",
+		label: "Old invite link",
+		prefix: "old-prefix",
+		created_at: now,
+		expires_at: null,
+		revoked_at: now,
+		redeem_count: 0,
+		last_redeemed_at: null,
+	});
+	links.push({
+		id: "expired-link",
+		label: "Expired invite link",
+		prefix: "expired-prefix",
+		created_at: now,
+		expires_at: now,
+		revoked_at: null,
+		redeem_count: 0,
+		last_redeemed_at: null,
+	});
+	if (empty) {
+		links = [];
+		invitations = [];
+		members = [];
+	}
+
 	await page.route("**/v1/**", async (route) => {
 		const request = route.request();
 		const path = new URL(request.url()).pathname;
@@ -50,11 +78,52 @@ async function stubSharingApi(page: Page) {
 		if (path === "/v1/agents") return json(route, []);
 		if (path === "/v1/dashboard/stats") return json(route, {});
 		if (path === "/v1/skills") return json(route, { items: [], total: 0, page: 1, page_size: 25 });
-		if (path === "/v1/projects/project-sharing/share-links") return json(route, links);
-		if (path === "/v1/projects/project-sharing/invitations") return json(route, invitations);
+		if (path === "/v1/projects/project-sharing/share-links") {
+			if (request.method() === "POST") {
+				expect(request.postDataJSON()).toEqual({});
+				const link = {
+					id: "created-link",
+					prefix: "new-prefix",
+					label: null,
+					created_at: now,
+					expires_at: null,
+				};
+				links.push({ ...link, revoked_at: null, redeem_count: 0, last_redeemed_at: null });
+				return json(route, {
+					...link,
+					raw_token: "test-token",
+					url: "https://example.com/share/test-token",
+					owner_handle: "dev-user",
+				});
+			}
+			return json(route, links);
+		}
+		if (path === "/v1/projects/project-sharing/invitations") {
+			if (request.method() === "POST") {
+				const invitation = {
+					id: "new-invite",
+					invitee_email: request.postDataJSON().email,
+					created_at: now,
+				};
+				invitations.push(invitation);
+				return json(route, invitation);
+			}
+			return json(route, invitations);
+		}
 		if (path === "/v1/projects/project-sharing/members") return json(route, members);
+		if (path === "/v1/projects/project-sharing/unshare" && request.method() === "POST") {
+			links = links.map((link) => ({ ...link, revoked_at: now }));
+			invitations = [];
+			members = [];
+			return json(route, {
+				links_revoked: links.length,
+				members_removed: 1,
+				invitations_cancelled: 1,
+				agent_bindings_removed: 0,
+			});
+		}
 		if (request.method() === "DELETE" && path.endsWith("/share-links/link-one")) {
-			links = [];
+			links = links.map((link) => (link.id === "link-one" ? { ...link, revoked_at: now } : link));
 			return json(route, {});
 		}
 		if (request.method() === "DELETE" && path.endsWith("/invitations/invite-one")) {
@@ -69,14 +138,19 @@ async function stubSharingApi(page: Page) {
 	});
 }
 
+async function openSharing(page: Page) {
+	await page.goto("/projects");
+	await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
+	await page.getByRole("menuitem", { name: "Share", exact: true }).click();
+	await expect(page.getByRole("dialog")).toBeVisible();
+}
+
 test("sharing row mutations retain targets through Base UI exit and reopen cleanly", async ({
 	page,
 }) => {
 	await stubSharingApi(page);
 	await page.setViewportSize({ width: 320, height: 720 });
-	await page.goto("/projects");
-	await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
-	await page.getByRole("menuitem", { name: "Share", exact: true }).click();
+	await openSharing(page);
 
 	const cases = [
 		{
@@ -115,4 +189,143 @@ test("sharing row mutations retain targets through Base UI exit and reopen clean
 	await expect(
 		page.getByRole("button", { name: /Turn off share link|Cancel invitation|Remove / }),
 	).toHaveCount(0);
+});
+
+for (const viewport of [
+	{ width: 1280, height: 900 },
+	{ width: 320, height: 720 },
+]) {
+	test(`compact sharing flow at ${viewport.width}px`, async ({ page }) => {
+		await page.setViewportSize(viewport);
+		await stubSharingApi(page, true);
+		await openSharing(page);
+		const dialog = page.getByRole("dialog");
+		await expect(dialog.getByText("Only you have access", { exact: true })).toBeVisible();
+		await expect(dialog.getByRole("alert")).toHaveCount(0);
+		await expect(dialog.getByRole("textbox", { name: "Share link label" })).toHaveCount(0);
+		await expect(
+			dialog.getByRole("button", { name: "Stop all sharing for this Project" }),
+		).toBeHidden();
+		await expect(dialog.getByText(/Their linked Agents can use its Vault values/)).toHaveCount(1);
+		const dimensions = await dialog.evaluate((element) => ({
+			width: element.clientWidth,
+			scrollWidth: element.scrollWidth,
+			height: element.clientHeight,
+			scrollHeight: element.scrollHeight,
+		}));
+		expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.width);
+		expect(dimensions.scrollHeight).toBeLessThanOrEqual(dimensions.height);
+		if (process.env.SHARING_PREVIEW_DIR)
+			await page.screenshot({
+				path: `${process.env.SHARING_PREVIEW_DIR}/sharing-empty-${viewport.width}.png`,
+			});
+
+		await dialog.getByRole("textbox", { name: "Invitee email" }).fill("new-person@example.com");
+		await dialog.getByRole("button", { name: "Invite email to project" }).click();
+		await expect(dialog.getByText("new-person@example.com", { exact: true })).toBeVisible();
+		await expect(dialog.getByText("Pending", { exact: true })).toBeVisible();
+		await dialog.getByRole("button", { name: "Create invite link" }).click();
+		await expect(dialog.getByRole("textbox", { name: "New share link URL" })).toHaveValue(
+			"https://example.com/share/test-token",
+		);
+		await expect(dialog.getByRole("button", { name: /Copy agent handoff prompt/ })).toBeHidden();
+		await dialog.getByText("Send to an Agent", { exact: true }).click();
+		await expect(dialog.getByRole("button", { name: /Copy agent handoff prompt/ })).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(dialog).toBeHidden();
+		await page.getByRole("button", { name: "Actions for Shared workspace" }).click();
+		await page.getByRole("menuitem", { name: "Share", exact: true }).click();
+		await expect(dialog.getByRole("textbox", { name: "New share link URL" })).toHaveCount(0);
+	});
+}
+
+test("sharing management stays disclosed and failed actions remain retryable", async ({ page }) => {
+	await stubSharingApi(page);
+	await openSharing(page);
+	const dialog = page.getByRole("dialog");
+	await expect(dialog.getByText("member@example.com", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Old invite link", { exact: true })).toBeHidden();
+	if (process.env.SHARING_PREVIEW_DIR) {
+		for (const viewport of [
+			{ width: 1280, height: 900 },
+			{ width: 320, height: 720 },
+		]) {
+			await page.setViewportSize(viewport);
+			await page.screenshot({
+				path: `${process.env.SHARING_PREVIEW_DIR}/sharing-people-${viewport.width}.png`,
+			});
+		}
+	}
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await expect(dialog.getByText("Expired invite link", { exact: true })).toBeHidden();
+	await dialog.getByText("Inactive links (2)", { exact: true }).click();
+	await expect(dialog.getByText("Expired", { exact: true })).toBeVisible();
+	await expect(
+		dialog.getByRole("button", { name: "Turn off share link expired-prefix" }),
+	).toHaveCount(0);
+	await expect(dialog.getByText("Old invite link", { exact: true })).toBeVisible();
+	await page.route("**/v1/projects/project-sharing/share-links", async (route) => {
+		if (route.request().method() === "POST") return json(route, { detail: "Internal error" }, 500);
+		await route.fallback();
+	});
+	await dialog.getByRole("button", { name: "Create invite link" }).click();
+	await expect(page.getByText("Couldn't create link. Try again.", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Create invite link" })).toBeEnabled();
+	await dialog.getByText("Manage sharing", { exact: true }).click();
+	await dialog.getByRole("button", { name: "Stop all sharing for this Project" }).press("Enter");
+	const confirmation = page.getByRole("alertdialog");
+	await confirmation.getByRole("button", { name: "Keep Sharing" }).click();
+	await expect(confirmation).toBeHidden();
+	await expect(dialog.getByText("member@example.com", { exact: true })).toBeVisible();
+	await dialog.getByRole("button", { name: "Stop all sharing for this Project" }).press("Enter");
+	await page.route(
+		"**/v1/projects/project-sharing/unshare",
+		(route) => json(route, { detail: "Internal error" }, 500),
+		{ times: 1 },
+	);
+	await confirmation.getByRole("button", { name: "Stop all sharing", exact: true }).click();
+	await expect(page.getByText("Couldn't stop sharing", { exact: true })).toBeVisible();
+	await expect(confirmation).toBeVisible();
+	await confirmation.getByRole("button", { name: "Stop all sharing", exact: true }).click();
+	await expect(confirmation).toBeHidden();
+	await expect(dialog.getByText("Only you have access", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("invitee@example.com", { exact: true })).toHaveCount(0);
+	await expect(dialog.getByRole("button", { name: /Turn off share link/ })).toHaveCount(0);
+});
+
+test("a newly created URL survives failed refresh and clipboard access", async ({ page }) => {
+	await page.addInitScript(() => {
+		Object.defineProperty(navigator, "clipboard", {
+			value: {
+				writeText: async () => {
+					throw new DOMException("Clipboard denied", "NotAllowedError");
+				},
+			},
+		});
+	});
+	await stubSharingApi(page);
+	await openSharing(page);
+	const dialog = page.getByRole("dialog");
+	await expect(dialog.getByText("Review link", { exact: true })).toBeVisible();
+	await page.route("**/v1/projects/project-sharing/share-links", async (route) => {
+		if (route.request().method() === "GET") return json(route, { detail: "Internal error" }, 500);
+		await route.fallback();
+	});
+	const failedRefresh = page.waitForResponse(
+		(response) =>
+			response.request().method() === "GET" &&
+			response.url().endsWith("/share-links") &&
+			response.status() === 500,
+	);
+	await dialog.getByRole("button", { name: "Create invite link" }).click();
+	await failedRefresh;
+	const url = dialog.getByRole("textbox", { name: "New share link URL" });
+	await expect(url).toHaveValue("https://example.com/share/test-token");
+	await dialog.getByRole("button", { name: "Copy Share Link", exact: true }).click();
+	await expect(
+		page.getByText("Select the text and copy it manually.", { exact: true }),
+	).toBeVisible();
+	await expect(url).toBeVisible();
+	await dialog.getByRole("button", { name: "Done", exact: true }).click();
+	await expect(url).toHaveCount(0);
 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -2475,7 +2475,9 @@ test("Project card menu dialogs survive menu dismissal", async ({ page }) => {
 		await expect(page.getByRole("menu")).toBeHidden();
 		const share = page.getByRole("dialog", { name: "Share Unrelated Project", exact: true });
 		await expect(share).toBeVisible();
-		await expect(share.getByRole("heading", { name: "People", exact: true })).toBeVisible();
+		await expect(
+			share.getByRole("heading", { name: "People with access", exact: true }),
+		).toBeVisible();
 		await page.keyboard.press("Escape");
 		await expect(share).toBeHidden();
 		await trigger.click();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1385,7 +1385,6 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	page,
 }, testInfo) => {
 	const {
-		projectAccessVaults,
 		skillRequests,
 		projectCreateBodies,
 		projectLinkDeltaBodies,
@@ -1642,8 +1641,8 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(main.getByRole("heading", { name: "Agents", exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Install skill", exact: true })).toBeVisible();
 	await expect(
-		main.getByRole("button", { name: /^Link .* to (Workspace|Project)$/ }).first(),
-	).toBeVisible();
+		main.getByRole("button", { name: /^(Link|Unlink|Add|Remove) .* (Workspace|Project)$/ }),
+	).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /Add keys to / })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "View all Skills", exact: true })).toHaveAttribute(
 		"href",
@@ -1658,13 +1657,8 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(main.getByText("Team-only Skill", { exact: true })).toHaveCount(0);
 	await expect(main.getByText("Scoped Vault", { exact: true })).toBeVisible();
 	await expect(main.getByText("Shared Vault", { exact: true })).toBeVisible();
-	await expect(main.getByText("Team Vault", { exact: true })).toBeVisible();
-	await expect(
-		main.getByTestId("project-vault-card").filter({ hasText: "Team Vault" }),
-	).toContainText("Via linked Project");
-	await expect(
-		main.getByTestId("project-vault-card").filter({ hasText: "Unrelated Vault" }),
-	).toContainText("used by Unrelated Project");
+	await expect(main.getByText("Team Vault", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Unrelated Vault", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("link", { name: "Open Primary-only Skill" })).toHaveAttribute(
 		"href",
 		"/agents/11111111-1111-4111-8111-111111111111/skills/primary-only?project=project-smoke",
@@ -1749,8 +1743,8 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /Install skill/i })).toHaveCount(0);
 	await expect(
-		main.getByRole("button", { name: /^Link .* to (Workspace|Project)$/ }).first(),
-	).toBeVisible();
+		main.getByRole("button", { name: /^(Link|Unlink|Add|Remove) .* (Workspace|Project)$/ }),
+	).toHaveCount(0);
 	const desktopWorkspace = page
 		.getByTestId("app-sidebar")
 		.getByRole("group", { name: "Workspace", exact: true });
@@ -1761,46 +1755,11 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(
 		desktopWorkspace.getByRole("link", { name: "Skills", exact: true }),
 	).not.toHaveAttribute("data-active", "");
-	const linkedVaults = main.getByRole("region", { name: "Linked Workspace Vaults", exact: true });
-	const availableVaults = main.getByRole("region", { name: "Available Workspace Vaults" });
-	await expect(linkedVaults.getByText("Linked", { exact: true }).locator("..")).toHaveText(
-		"Linked2",
-	);
-	await expect(availableVaults.getByText("Available", { exact: true }).locator("..")).toHaveText(
-		"Available2",
-	);
-	await expect(
-		availableVaults.getByTestId("project-vault-card").filter({ hasText: "Team Vault" }),
-	).toContainText("Via linked Project");
-	const sharedVaultCard = main
-		.getByTestId("project-vault-card")
-		.filter({ hasText: "Shared Vault" });
-	await page.route("**/v1/vault/shared-vault?*", async (route) => {
-		const url = new URL(route.request().url());
-		expect(route.request().method()).toBe("DELETE");
-		expect(url.searchParams.get("project_id")).toBe("project-smoke");
-		expect(url.searchParams.get("vault_id")).toBe("vault-shared");
-		const vault = projectAccessVaults.find((vault) => vault.id === "vault-shared");
-		if (!vault) throw new Error("Missing shared Vault fixture");
-		vault.project_ids = ["project-context-first"];
-		await fulfillJson(route, { status: "deleted" });
-	});
-	await sharedVaultCard.getByRole("button", { name: "Unlink Shared Vault from Workspace" }).click();
-	await expect(sharedVaultCard).toContainText("Via linked Project");
-	await expect(sharedVaultCard).toContainText("used by Team Knowledge");
-	await expect(linkedVaults.getByText("Linked", { exact: true }).locator("..")).toHaveText(
-		"Linked1",
-	);
-	await expect(availableVaults.getByText("Available", { exact: true }).locator("..")).toHaveText(
-		"Available3",
-	);
-	await expect(
-		availableVaults.getByRole("link", { name: "Open vault Shared Vault" }),
-	).toBeVisible();
-	await expect(
-		sharedVaultCard.getByRole("button", { name: "Link Shared Vault to Workspace" }),
-	).toBeEnabled();
-	await expect(page.locator("[data-sonner-toast]")).toHaveCount(0);
+	const linkedVaults = main.getByRole("region", { name: "In this Workspace Vaults", exact: true });
+	await expect(linkedVaults.getByTestId("project-vault-card")).toHaveCount(2);
+	await expect(main.getByRole("region", { name: "Available Workspace Vaults" })).toHaveCount(0);
+	await expect(linkedVaults.getByRole("button")).toHaveCount(0);
+	await expect(main.getByRole("button", { name: "Create vault", exact: true })).toHaveCount(0);
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-vaults-desktop.png") });
 	await page.setViewportSize({ width: 390, height: 844 });
 	await main.screenshot({ path: testInfo.outputPath("connected-workspace-vaults-mobile.png") });
@@ -1818,7 +1777,7 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(main.getByText("Scoped Vault", { exact: true })).toHaveCount(0);
 	await expect(
 		main
-			.getByRole("region", { name: "Linked Project Vaults", exact: true })
+			.getByRole("region", { name: "In this Project Vaults", exact: true })
 			.getByTestId("project-vault-card"),
 	).toHaveCount(2);
 	await expect(main.getByRole("region", { name: "Available Project Vaults" })).toHaveCount(0);
@@ -1861,15 +1820,15 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(main.getByRole("heading", { name: longContextProjectName, level: 1 })).toBeVisible();
 	await expect(
 		main.getByTestId("project-vault-card").filter({ hasText: "Scoped Vault" }),
-	).toContainText("Via Workspace");
+	).toHaveCount(0);
 	await expect(
-		main.getByRole("region", { name: "Linked Project Vaults", exact: true }),
+		main.getByRole("region", { name: "In this Project Vaults", exact: true }),
 	).toHaveCount(0);
 	await expect(
 		main
 			.getByRole("region", { name: "Available Project Vaults" })
 			.getByTestId("project-vault-card"),
-	).toHaveCount(4);
+	).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "View all Skills" })).toHaveAttribute(
 		"href",
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later/skills",
@@ -1880,8 +1839,8 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later/vaults",
 	);
 	await expect(
-		main.getByRole("button", { name: /^Link .* to (Workspace|Project)$/ }).first(),
-	).toBeVisible();
+		main.getByRole("button", { name: /^(Link|Unlink|Add|Remove) .* (Workspace|Project)$/ }),
+	).toHaveCount(0);
 	const requestsBeforeInvalidScope = skillRequests.length;
 	await page.goto(
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-unrelated/skills",
@@ -1987,21 +1946,15 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 		]);
 	await expect(main.getByRole("button", { name: /Link Vault/i })).toHaveCount(0);
 
-	await page.goto("/agents/11111111-1111-4111-8111-111111111111/vaults");
-	await expect(page).toHaveURL(
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke/vaults",
-	);
-	await page.goto("/agents/11111111-1111-4111-8111-111111111111/vaults?project=project-unrelated");
-	await expect(page).toHaveURL("/agents/11111111-1111-4111-8111-111111111111/project-access");
-	await page.goto("/agents/11111111-1111-4111-8111-111111111111/vaults?project=project-smoke");
-	await expect(page).toHaveURL(
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke/vaults",
-	);
+	const vaultOrigin = "/agents/11111111-1111-4111-8111-111111111111/vaults";
+	await page.goto(`${vaultOrigin}?project=project-unrelated`);
+	await expect(main.getByRole("link", { name: /Open vault / })).toHaveCount(0);
+	await page.goto(vaultOrigin);
 	await expect(main.getByRole("heading", { name: "Vaults", level: 1 })).toBeVisible();
 	const scopedVaultLink = main.getByRole("link", { name: "Open vault Scoped Vault" });
 	await scopedVaultLink.click();
 	await expect(page).toHaveURL(
-		/\/agents\/11111111-1111-4111-8111-111111111111\/vaults\/scoped-vault\?project=project-smoke&vault=vault-scoped$/,
+		/\/agents\/11111111-1111-4111-8111-111111111111\/vaults\/scoped-vault\?project=project-smoke&vault=vault-scoped&from=/,
 	);
 	await expect(main.getByRole("heading", { name: "Scoped Vault", level: 1 })).toBeVisible();
 	await expect(
@@ -2009,15 +1962,12 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 			.getByRole("navigation", { name: "breadcrumb" })
 			.locator('[data-slot="breadcrumb-item"]:visible'),
 	).toHaveText(["Smoke Codex", "Vaults", "Scoped Vault"]);
-	await expect(main.getByRole("button", { name: "Vaults" })).toHaveCount(0);
+	await expect(main.getByRole("button", { name: "Vaults", exact: true })).toHaveCount(0);
 	await expect(
 		main
 			.getByRole("navigation", { name: "breadcrumb" })
 			.getByRole("link", { name: "Vaults", exact: true }),
-	).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke/vaults",
-	);
+	).toHaveAttribute("href", vaultOrigin);
 	await expect(main.getByRole("button", { name: "Open in resource library" })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: /^Delete$/ })).toBeVisible();
 	const addKeysButton = main.getByRole("button", { name: "Add keys", exact: true });
@@ -2034,18 +1984,19 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 	expect(vaultWriteUrl.searchParams.get("project_id")).toBe("project-smoke");
 	expect(vaultWriteUrl.searchParams.get("vault_id")).toBe("vault-scoped");
 	await expect(page).toHaveURL(
-		"/agents/11111111-1111-4111-8111-111111111111/vaults/scoped-vault?project=project-smoke&vault=vault-scoped",
+		(url) =>
+			url.pathname.endsWith("/vaults/scoped-vault") && url.searchParams.get("from") === vaultOrigin,
 	);
-	await expect(main.getByRole("link", { name: "Workspace" }).last()).toHaveAttribute(
+	await expect(main.getByRole("link", { name: "Manage in Vault Library" })).toHaveAttribute(
 		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke",
+		"/vaults/scoped-vault?vault=vault-scoped",
 	);
 	const requestedVaultProjectIds = vaultRequests.map((request) =>
 		new URL(request).searchParams.get("project_id"),
 	);
 	expect(requestedVaultProjectIds).toContain("project-smoke");
-	expect(requestedVaultProjectIds).not.toContain("project-context-first");
-	expect(requestedVaultProjectIds).toContain(null);
+	expect(requestedVaultProjectIds).toContain("project-context-first");
+	expect(requestedVaultProjectIds).not.toContain(null);
 	expect(requestedVaultProjectIds).not.toContain("project-unrelated");
 });
 
@@ -2398,147 +2349,100 @@ test("cached Project links retain their state and destination after a failed ref
 	await expect(page.getByPlaceholder("Search projects…")).toHaveValue("Team");
 });
 
-test("Vault catalog failures preserve scoped attachments and catalog return navigation", async ({
+test("Agent Vault inventory aggregates bound Projects and retains safe data on refresh errors", async ({
 	page,
-}) => {
-	const { projectAccessVaults } = await stubConnectedAgentResources(page);
-	projectAccessVaults.push({
-		...vaults.items[0],
-		id: "vault-viewer",
-		slug: "viewer-vault",
-		name: "Viewer Vault",
-		is_owner: false,
-		project_ids: ["project-context-first"],
-	});
-	const origin = "/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke/vaults";
-	const vaultRoute = "**/v1/vault?*";
+}, testInfo) => {
+	const { projectAccessVaults, vaultRequests } = await stubConnectedAgentResources(page);
+	const origin = "/agents/11111111-1111-4111-8111-111111111111/vaults";
+	let failVaults = false;
 	await page.route(
-		(url) => url.pathname === "/v1/vault" && url.searchParams.has("project_id"),
+		(url) => url.pathname === "/v1/vault",
 		async (route) => {
-			const projectId = new URL(route.request().url()).searchParams.get("project_id");
-			if (!projectId) throw new Error("Missing Project scope");
+			const url = new URL(route.request().url());
+			vaultRequests.push(url.href);
+			const projectId = url.searchParams.get("project_id");
+			expect(projectId).toBeTruthy();
+			if (failVaults) return fulfillJson(route, { detail: "Temporary failure" }, 503);
 			const items = projectAccessVaults
-				.filter((vault) => vault.project_ids.includes(projectId))
+				.filter((vault) => vault.project_ids.includes(projectId ?? ""))
 				.map((vault) => ({ ...vault, project_ids: [projectId] }));
-			await fulfillJson(route, { ...vaults, items, total: items.length });
+			return fulfillJson(route, { ...vaults, items, total: items.length });
 		},
 	);
-	let releaseAttachments = () => {};
-	const attachmentGate = new Promise<void>((resolve) => {
-		releaseAttachments = resolve;
-	});
-	await page.route(vaultRoute, async (route) => {
-		if (!new URL(route.request().url()).searchParams.has("project_id")) return route.fallback();
-		await attachmentGate;
-		return fulfillJson(route, { detail: "Links unavailable" }, 503);
-	});
-	await page.goto(origin);
-	const catalog = page.getByTestId("project-vault-catalog");
-	try {
-		await expect(catalog.getByTestId("project-vault-card")).toHaveCount(5);
-		await expect(catalog.getByText("Loading links…", { exact: true })).toHaveCount(5);
-		await expect(catalog.getByRole("region")).toHaveCount(0);
-	} finally {
-		releaseAttachments();
-	}
-	await expect(
-		catalog.getByText("Couldn't load Workspace Vault links", { exact: true }),
-	).toBeVisible();
-	await expect(catalog.getByRole("region")).toHaveCount(0);
-	await expect(catalog.getByText("Link status unavailable", { exact: true })).toHaveCount(5);
-	await page.unroute(vaultRoute);
-	await catalog.getByRole("button", { name: "Retry" }).click();
-	const linked = catalog.getByRole("region", { name: "Linked Workspace Vaults", exact: true });
-	const available = catalog.getByRole("region", { name: "Available Workspace Vaults" });
-	await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked2");
-	await expect(available.getByText("Available", { exact: true }).locator("..")).toHaveText(
-		"Available3",
+	let failBindings = true;
+	await page.route("**/v1/agents/*/project-bindings", (route) =>
+		failBindings ? fulfillJson(route, { detail: "Unavailable" }, 503) : route.fallback(),
 	);
-	const viewer = available.getByTestId("project-vault-card").filter({ hasText: "Viewer Vault" });
-	await expect(viewer).toContainText("Via linked Project");
-	await expect(viewer.getByRole("button")).toHaveCount(0);
-	const scoped = catalog.getByTestId("project-vault-card").filter({ hasText: "Scoped Vault" });
-	const detach = scoped.getByRole("button", { name: "Unlink Scoped Vault from Workspace" });
-	const link = scoped.getByRole("link", { name: "Open vault Scoped Vault" });
-	await expect(detach).toBeEnabled();
-	const href = await link.getAttribute("href");
-	const sharedVault = projectAccessVaults.find((vault) => vault.id === "vault-shared");
-	if (!sharedVault) throw new Error("Missing shared Vault fixture");
-	const sharedCard = catalog.getByTestId("project-vault-card").filter({ hasText: "Shared Vault" });
-	await expect(sharedCard).toContainText("2 keys");
-	sharedVault.item_count = 5;
-	let failAttachments = false;
-	await page.route(vaultRoute, (route) => {
-		if (!failAttachments && new URL(route.request().url()).searchParams.has("project_id"))
-			return route.fallback();
-		return fulfillJson(route, { detail: "Temporary refresh failure" }, 503);
-	});
+	await page.goto(origin);
+	const main = page.locator("main");
+	await expect(main.getByText("Couldn't load Agent Vault access")).toBeVisible();
+	await expect(main.getByRole("link", { name: /Open vault / })).toHaveCount(0);
+	expect(vaultRequests).toEqual([]);
+	failBindings = false;
+	await main.getByRole("button", { name: "Retry" }).click();
+	const inventory = page.getByTestId("vaults-surface");
+	await expect(inventory.getByRole("link", { name: /Open vault / })).toHaveCount(3);
+	await expect(inventory.getByRole("link", { name: "Open vault Shared Vault" })).toHaveCount(1);
+	await expect(
+		inventory.getByText("From Workspace, Team Knowledge", { exact: true }),
+	).toBeVisible();
+	await expect(inventory.getByText("Unrelated Vault", { exact: true })).toHaveCount(0);
+	await expect(
+		inventory.getByRole("button", { name: /^(Create vault|Add keys|Link|Unlink|Add |Remove )/ }),
+	).toHaveCount(0);
+	expect(vaultRequests.every((request) => new URL(request).searchParams.has("project_id"))).toBe(
+		true,
+	);
+	await page.setViewportSize({ width: 1440, height: 900 });
+	await expect(
+		page.getByTestId("app-sidebar").getByRole("link", { name: "Vaults", exact: true }),
+	).toHaveAttribute("data-active", "");
+	await expect(
+		page.getByTestId("app-sidebar").getByRole("link", { name: "Overview", exact: true }),
+	).not.toHaveAttribute("data-active", "");
+	await expect(
+		page
+			.getByRole("navigation", { name: "breadcrumb" })
+			.locator('[data-slot="breadcrumb-item"]:visible'),
+	).toHaveText(["Smoke Codex", "Vaults"]);
+	await page.screenshot({ path: testInfo.outputPath("agent-vaults-desktop.png"), fullPage: true });
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.screenshot({ path: testInfo.outputPath("agent-vaults-mobile.png"), fullPage: true });
+	expect(
+		await page
+			.locator("html")
+			.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+	).toBe(true);
+	failVaults = true;
 	await page.clock.setFixedTime(new Date(Date.now() + 60_000));
 	await page.evaluate(() => window.dispatchEvent(new Event("visibilitychange")));
-	await expect(catalog.getByText("Couldn't load Vault catalog", { exact: true })).toBeVisible();
-	await expect(sharedCard).toContainText("5 keys");
-	await expect(sharedCard).toContainText("used by Smoke Project, Team Knowledge");
-	await expect(detach).toBeEnabled();
-	await expect(
-		catalog.getByRole("button", { name: "Link Unrelated Vault to Workspace" }),
-	).toBeDisabled();
-	failAttachments = true;
-	await page.clock.setFixedTime(new Date(Date.now() + 120_000));
-	await page.evaluate(() => window.dispatchEvent(new Event("visibilitychange")));
-	await expect(
-		catalog.getByText("Couldn't load Workspace Vault links", { exact: true }),
-	).toBeVisible();
-	await expect(linked.getByText("Linked", { exact: true }).locator("..")).toHaveText("Linked2");
-	await expect(available.getByText("Available", { exact: true }).locator("..")).toHaveText(
-		"Available3",
-	);
-	await expect(viewer).toContainText("Via linked Project");
-	await expect(detach).toHaveText("Unlink");
-	await expect(link).toHaveAttribute("href", href ?? "");
-	await expect(detach).toBeDisabled();
-	await page.unroute(vaultRoute);
-	await catalog
-		.getByRole("alert")
-		.filter({ hasText: "Couldn't load Workspace Vault links" })
-		.getByRole("button", { name: "Retry" })
-		.click();
-	await expect(detach).toBeEnabled();
-	await expect(sharedCard).toContainText("5 keys");
-	sharedVault.item_count = 7;
-	await page.clock.setFixedTime(new Date(Date.now() + 180_000));
-	await catalog
-		.getByRole("alert")
-		.filter({ hasText: "Couldn't load Vault catalog" })
-		.getByRole("button", { name: "Retry" })
-		.click();
-	await expect(detach).toBeEnabled();
-	await expect(sharedCard).toContainText("7 keys");
-	await expect(sharedCard).toContainText("used by Smoke Project, Team Knowledge");
-	await catalog.getByLabel("Search Vaults").fill("Vault");
-	await expect(linked.getByTestId("project-vault-card")).toHaveCount(2);
-	await expect(available.getByTestId("project-vault-card")).toHaveCount(3);
-	await catalog.getByLabel("Search Vaults").fill("Unrelated");
-	await expect(linked).toHaveCount(0);
-	await expect(available.getByText("Available", { exact: true }).locator("..")).toHaveText(
-		"Available1",
-	);
-	await catalog.getByRole("link", { name: "Open vault Unrelated Vault" }).click();
+	await expect(inventory.getByText("Couldn’t refresh Vaults")).toBeVisible();
+	await expect(inventory.getByRole("link", { name: /Open vault / })).toHaveCount(3);
+	failVaults = false;
+	await inventory.getByRole("button", { name: "Retry" }).click();
+	await expect(inventory.getByRole("alert")).toHaveCount(0);
+	await inventory.getByPlaceholder("Search vaults…").fill("Team");
+	await inventory.getByRole("link", { name: "Open vault Team Vault" }).click();
 	await expect(page).toHaveURL(
 		(url) =>
-			url.pathname === "/vaults/unrelated-vault" &&
-			url.searchParams.get("from") === `${origin}?q=Unrelated`,
+			url.searchParams.get("vault") === "vault-team" &&
+			url.searchParams.get("project") === "project-context-first" &&
+			url.searchParams.get("from") === `${origin}?q=Team`,
 	);
-	await page.getByRole("button", { name: "Back to Agent Vaults" }).click();
-	await expect(catalog.getByLabel("Search Vaults")).toHaveValue("Unrelated");
-	await catalog.getByLabel("Search Vaults").fill("Team");
-	await catalog.getByRole("link", { name: "Open vault Team Vault" }).click();
-	await expect(page).toHaveURL(
-		(url) =>
-			url.pathname.endsWith("/vaults/team-vault") &&
-			url.searchParams.get("project") === "project-context-first",
+	await expect(
+		main.getByRole("button", { name: /^(Link|Unlink|Remove from|Share keys)/ }),
+	).toHaveCount(0);
+	await expect(
+		main.getByRole("link", { name: "Team Knowledge", exact: true }).last(),
+	).toHaveAttribute("href", "/projects/project-context-first?tab=vaults");
+	await main.getByRole("button", { name: "Back to Agent Vaults" }).click();
+	await expect(inventory.getByPlaceholder("Search vaults…")).toHaveValue("Team");
+	await page.goto("/agents/11111111-1111-4111-8111-111111111111");
+	await expect(main.locator('[data-overview-module="vaults"]')).toContainText("3 vaults");
+	await expect(main.locator('[data-overview-module="vaults"]').getByRole("link")).toHaveAttribute(
+		"href",
+		origin,
 	);
-	await page.getByRole("button", { name: "Back to Agent Vaults" }).click();
-	await expect(catalog.getByLabel("Search Vaults")).toHaveValue("Team");
 });
 
 test("Project card menu dialogs survive menu dismissal", async ({ page }) => {

--- a/apps/web/e2e/vault-detail-identity.pw.ts
+++ b/apps/web/e2e/vault-detail-identity.pw.ts
@@ -20,7 +20,7 @@ const vaults = [
 		slug: "collision",
 		name: "Owned Collision",
 		project_id: "project-owned",
-		project_ids: ["project-owned"],
+		project_ids: ["project-owned", "old-workspace"],
 		is_owner: true,
 		item_count: 1,
 		created_at: now,
@@ -67,7 +67,13 @@ test("same-slug Vault cards preserve UUID identity through detail and cache", as
 		}
 		if (url.pathname === "/v1/vault/collision" && route.request().method() === "DELETE") {
 			expect(url.searchParams.get("vault_id")).toBe(ownedId);
-			expect(url.searchParams.has("project_id")).toBe(false);
+			if (url.searchParams.has("project_id")) {
+				expect(url.searchParams.get("project_id")).toBe("old-workspace");
+				const vault = catalog.find((vault) => vault.id === ownedId);
+				if (!vault) throw new Error("Owned Vault missing");
+				vault.project_ids = vault.project_ids.filter((id) => id !== "old-workspace");
+				return fulfill(route, { status: "deleted" });
+			}
 			const index = catalog.findIndex((vault) => vault.id === ownedId);
 			if (index < 0) throw new Error("Owned Vault missing");
 			catalog.splice(index, 1);
@@ -91,6 +97,11 @@ test("same-slug Vault cards preserve UUID identity through detail and cache", as
 		}
 		if (url.pathname === "/v1/projects") {
 			return fulfill(route, [
+				...[
+					{ id: "old-workspace", name: "Old private workspace", kind: "environment" },
+					{ id: "new-workspace", name: "New private workspace", kind: "environment" },
+					{ id: "custom-project", name: "Release Project", kind: "workspace" },
+				].map((project) => ({ ...project, slug: project.id, is_owner: true, created_at: now })),
 				{
 					id: "project-shared",
 					name: "Shared",
@@ -127,6 +138,23 @@ test("same-slug Vault cards preserve UUID identity through detail and cache", as
 	await expect(page.getByRole("heading", { name: "Owned Collision" })).toBeVisible();
 	await expect(page.getByText("OWNED_ONLY", { exact: true })).toBeVisible();
 	await expect(page.getByText("SHARED_ONLY", { exact: true })).toHaveCount(0);
+
+	await page.getByRole("combobox", { name: "Project to add this Vault to" }).click();
+	await expect(page.getByRole("option", { name: "Release Project" })).toBeVisible();
+	await expect(page.getByRole("option", { name: /private workspace|Owned/ })).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await expect(page.getByText("Workspace", { exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Workspace", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Share keys", exact: true })).toHaveCount(0);
+	await page.getByRole("button", { name: "Remove from Workspace", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Remove vault", exact: true })
+		.click();
+	await expect(
+		page.getByRole("button", { name: "Remove from Workspace", exact: true }),
+	).toHaveCount(0);
+	await expect(page.getByText("OWNED_ONLY", { exact: true })).toBeVisible();
 
 	await page.getByRole("button", { name: "Add keys" }).click();
 	await page.getByPlaceholder(/OPENAI_API_KEY/).fill("ADDED_TO_OWNED=secret-value");

--- a/apps/web/src/components/app-breadcrumb-model.ts
+++ b/apps/web/src/components/app-breadcrumb-model.ts
@@ -89,7 +89,13 @@ function buildAgentBreadcrumbTrail(
 		return finishTrail(trail, overrideTitle ?? context.label);
 	}
 
-	if (route.section === "skills" || route.section === "vaults") {
+	if (route.section === "vaults") {
+		if (!route.vaultSlug) return finishTrail(trail, agentSectionLabel("vaults"));
+		trail.push({ key: "vaults", label: "Vaults", href: agentSectionHref(route.agentId, "vaults") });
+		return finishTrail(trail, overrideTitle);
+	}
+
+	if (route.section === "skills") {
 		const projectId = typeof search.project === "string" ? search.project.trim() : "";
 		if (projectId) {
 			const context = projectContext(route.agentId, projectId, segmentTitles);
@@ -107,8 +113,7 @@ function buildAgentBreadcrumbTrail(
 				href: agentSectionHref(route.agentId, "projects"),
 			});
 		}
-		const hasDetail =
-			route.section === "skills" ? Boolean(route.skillKey) : Boolean(route.vaultSlug);
+		const hasDetail = Boolean(route.skillKey);
 		return hasDetail
 			? finishTrail(trail, overrideTitle)
 			: finishTrail(trail, agentSectionLabel(route.section));

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -408,14 +408,14 @@ function AgentSectionList({
 	const activePrimaryProjectResource =
 		(primaryProjectRouteActive ? activeAgentRoute?.projectResource : null) ??
 		(scopedResourceTarget?.kind === "workspace" ? scopedResourceTarget.resource : null);
-	const isFlatProjectResourceRoute =
-		activeAgentRoute?.section === "skills" || activeAgentRoute?.section === "vaults";
+	const isFlatProjectResourceRoute = activeAgentRoute?.section === "skills";
 	// Invalid, legacy, and not-yet-resolved flat resource URLs all return through
 	// Projects. Keep that safe parent active until an exact Workspace or linked
 	// Project context has been proven instead of misleadingly highlighting Overview.
 	const activeContextProjectResource =
-		scopedResourceTarget?.kind === "projects" ||
-		(isFlatProjectResourceRoute && !activePrimaryProjectResource);
+		activeAgentRoute?.section !== "vaults" &&
+		(scopedResourceTarget?.kind === "projects" ||
+			(isFlatProjectResourceRoute && !activePrimaryProjectResource));
 	const normalizedActiveSection =
 		loading || groups.some((group) => group.items.some((item) => item.id === activeSection))
 			? activeSection
@@ -428,11 +428,17 @@ function AgentSectionList({
 					return {
 						id: `primary-project-${section}`,
 						label: item.label,
-						href: agentProjectResourceHref(agentId, primaryProject.id, section),
+						href:
+							section === "vaults"
+								? agentSectionHref(agentId, "vaults")
+								: agentProjectResourceHref(agentId, primaryProject.id, section),
 						icon: item.icon,
 						tint: item.tint,
-						tooltip: `${item.label} in Workspace`,
-						active: activePrimaryProjectResource === section,
+						tooltip: section === "vaults" ? "Available Vaults" : `${item.label} in Workspace`,
+						active:
+							section === "vaults"
+								? activeAgentRoute?.section === "vaults" || activePrimaryProjectResource === section
+								: activePrimaryProjectResource === section,
 					};
 				})
 		: [];
@@ -455,7 +461,8 @@ function AgentSectionList({
 										(normalizedActiveSection === "projects" && !activePrimaryProjectResource)
 									: normalizedActiveSection === item.id &&
 										!activePrimaryProjectResource &&
-										!activeContextProjectResource,
+										!activeContextProjectResource &&
+										activeAgentRoute?.section !== "vaults",
 							prefetch: item.id === "connectors" ? prefetchConnectorsCatalog : undefined,
 						};
 					}),

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
 import {
+	effectiveAgentProjectIds,
 	linkedAgentProjectCount,
 	resolveAgentWorkspaceProjectId,
 } from "@/components/dashboard/agent-project-scope";
@@ -175,7 +176,7 @@ export function ConnectedAgentDetail({
 		enabled: overviewEnabled && supportsSkills,
 	});
 	const vaultsModule = useOverviewVaultsModule({
-		projectIds: workspaceProjectId ? [workspaceProjectId] : [],
+		projectIds: workspaceProjectId ? effectiveAgentProjectIds(projectBindings ?? []) : [],
 		resolution: workspaceResolution,
 		enabled: overviewEnabled,
 	});
@@ -322,9 +323,7 @@ export function ConnectedAgentDetail({
 									memories: memoriesModule,
 									vaults: {
 										...vaultsModule,
-										link: workspaceProjectId
-											? agentProjectResourceLink(id, workspaceProjectId, "vaults")
-											: null,
+										link: agentSectionLink(id, "vaults"),
 									},
 									connectors: connectorsModule,
 								}}

--- a/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
@@ -41,7 +41,6 @@ const COMPLETION_ONLY = [
 	"hosted/v2/channels/link-channel-agent-action.tsx",
 	"hosted/v2/channels/whatsapp-repair-dialog.tsx",
 	"pages/dashboard/skills/page.tsx",
-	"pages/dashboard/vault/[slug]/page.tsx",
 ] as const;
 
 // Intentional exceptions: stateless wrappers/simple confirmations, navigation-owned shells,

--- a/apps/web/src/components/notification-center.logic.test.ts
+++ b/apps/web/src/components/notification-center.logic.test.ts
@@ -83,14 +83,12 @@ describe("notification center logic", () => {
 	});
 
 	test("keeps project invitation invariants as the first notification type", () => {
-		expect(getProjectInvitationAccessCopy()).toContain("read-only access");
-		expect(getProjectInvitationAccessCopy()).toContain("Adding the Project to an agent");
-		expect(getProjectInvitationAccessCopy()).toContain("separate step");
+		expect(getProjectInvitationAccessCopy()).toContain("Only the owner can edit");
+		expect(getProjectInvitationAccessCopy()).toContain("link them to your Agents");
 
 		const accepted = getAcceptedProjectInvitationToastCopy("Shared Workspace");
 		expect(accepted.title).toBe("Joined Shared Workspace");
-		expect(getAcceptedProjectInvitationToastCopy().title).toBe("Project Joined");
-		expect(accepted.description).toContain("Read-only access");
+		expect(getAcceptedProjectInvitationToastCopy().title).toBe("Project joined");
 		expect(accepted.description).toContain("Open the Project");
 		expect(accepted.description).toContain("link it to an Agent");
 	});

--- a/apps/web/src/components/notification-center.logic.ts
+++ b/apps/web/src/components/notification-center.logic.ts
@@ -88,7 +88,7 @@ export function getNotificationCenterDescription(): string {
 }
 
 export function getProjectInvitationAccessCopy(): string {
-	return "Project invitations give read-only access (view, not edit). Adding the Project to an agent is a separate step.";
+	return "View shared Projects and link them to your Agents. Only the owner can edit.";
 }
 
 export function getAcceptedProjectInvitationToastCopy(projectName?: string): {
@@ -96,8 +96,7 @@ export function getAcceptedProjectInvitationToastCopy(projectName?: string): {
 	description: string;
 } {
 	return {
-		title: projectName ? `Joined ${projectName}` : "Project Joined",
-		description:
-			"Read-only access granted. Open the Project to review shared resources, then link it to an Agent when needed.",
+		title: projectName ? `Joined ${projectName}` : "Project joined",
+		description: "Open the Project to view its resources or link it to an Agent.",
 	};
 }

--- a/apps/web/src/components/projects/create-project-dialog.tsx
+++ b/apps/web/src/components/projects/create-project-dialog.tsx
@@ -87,9 +87,7 @@ export function CreateProjectDialog({
 				<DialogHeader>
 					<DialogTitle>Create project</DialogTitle>
 					<DialogDescription>
-						{agentId
-							? "Create a shareable bundle and link it to this Agent immediately."
-							: "Create a shareable bundle for Skills and linked Vault access."}
+						{agentId ? "Create a Project for this Agent." : "Group Skills and Vaults in a Project."}
 					</DialogDescription>
 				</DialogHeader>
 				<form

--- a/apps/web/src/components/projects/projects-surface.tsx
+++ b/apps/web/src/components/projects/projects-surface.tsx
@@ -167,7 +167,7 @@ export function ProjectsSurface({
 				titleAdornment={headerAdornment}
 				description={
 					agentId
-						? "Your Projects and Projects shared with you. Link a Project to use its Skills and linked Vaults together."
+						? "Choose the Projects this Agent can use."
 						: getProjectResourceDefinition("projects").managementDescription
 				}
 				actions={
@@ -177,7 +177,7 @@ export function ProjectsSurface({
 							await refresh();
 							toast.success(agentId ? "Project created and linked" : "Project created", {
 								description: agentId
-									? "This Agent can use its Skills and linked Vaults immediately."
+									? "This Agent can use its Skills and Vaults immediately."
 									: "It is ready for Skills, Vaults, and Agent links.",
 								action: {
 									label: "Open project",

--- a/apps/web/src/components/sessions/share-controls.tsx
+++ b/apps/web/src/components/sessions/share-controls.tsx
@@ -48,7 +48,21 @@ export function SessionShareButton({ onClick }: { onClick: () => void }) {
 	);
 }
 
-export function SessionShareDialog({
+export function SessionShareDialog(props: {
+	sessionId: string;
+	target: SessionShareTarget;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	return (
+		<SessionShareDialogContent
+			key={`${props.sessionId}:${props.target.scope}:${"position" in props.target ? props.target.position : ""}`}
+			{...props}
+		/>
+	);
+}
+
+function SessionShareDialogContent({
 	sessionId,
 	target,
 	open,
@@ -120,15 +134,18 @@ export function SessionShareDialog({
 				: "Share session";
 	const description =
 		target.scope === "response"
-			? "Create a link containing only this Agent response."
+			? "Anyone with the link can view this Agent response."
 			: target.scope === "through"
-				? "Create a link containing the conversation through this message."
-				: "Create a snapshot of the current conversation. Future messages won’t be added.";
+				? "Anyone with the link can view the conversation through this message."
+				: "Anyone with the link can view this conversation. Future messages won’t be added.";
 	const shares = sharesQuery.data?.shares ?? [];
 	const matchingShares = shares.filter((share) => {
 		if (share.scope !== target.scope) return false;
 		return target.scope === "session" || share.end_position === target.position;
 	});
+	const latestShare =
+		matchingShares.find((share) => share.id === createdShareId) ?? matchingShares[0];
+	const previousShares = matchingShares.filter((share) => share.id !== latestShare?.id);
 	const otherShares =
 		target.scope === "session" ? shares.filter((share) => share.scope !== "session") : [];
 	const legacyLink =
@@ -181,7 +198,8 @@ export function SessionShareDialog({
 						<div className="flex min-h-16 items-center justify-center text-muted-foreground">
 							<Spinner className="size-4" />
 						</div>
-					) : loadError ? (
+					) : null}
+					{loadError ? (
 						<ApiErrorPanel
 							error={loadError}
 							title="Couldn't load share links"
@@ -190,61 +208,54 @@ export function SessionShareDialog({
 								if (target.scope === "session") void permissionsQuery.refetch();
 							}}
 						/>
-					) : matchingShares.length > 0 ? (
-						<div className="space-y-2">
-							{matchingShares.map((share) => (
+					) : null}
+					{latestShare ? (
+						<ShareLinkRow
+							key={latestShare.id}
+							url={latestShare.share_url}
+							label={shareLabel(latestShare)}
+							detail={shareDetail(latestShare)}
+							autoFocus={latestShare.id === createdShareId}
+							onRevoke={() => revokeShare(latestShare.id)}
+							onRevoked={refreshShares}
+						/>
+					) : null}
+
+					{previousShares.length + otherShares.length + (legacyLink ? 1 : 0) > 0 ? (
+						<details className="space-y-3">
+							<summary className="cursor-pointer text-sm text-muted-foreground">
+								Other active links (
+								{previousShares.length + otherShares.length + (legacyLink ? 1 : 0)})
+							</summary>
+							{[...previousShares, ...otherShares].map((share) => (
 								<ShareLinkRow
 									key={share.id}
 									url={share.share_url}
 									label={shareLabel(share)}
 									detail={shareDetail(share)}
-									autoFocus={share.id === createdShareId}
 									onRevoke={() => revokeShare(share.id)}
 									onRevoked={refreshShares}
 								/>
 							))}
-						</div>
-					) : (
-						<div className="rounded-lg border border-dashed px-3 py-4 text-sm text-muted-foreground">
-							No snapshot has been created for this view yet.
-						</div>
-					)}
-
-					{legacyLink ? (
-						<div className="border-t pt-3">
-							<p className="mb-2 text-xs font-medium text-muted-foreground">Older link</p>
-							<ShareLinkRow
-								url={legacyUrl}
-								label="Live Session link"
-								detail={`Reflects future uploads · created ${relativeTime(legacyLink.created_at)}`}
-								onRevoke={revokeLegacyLink}
-								onRevoked={refreshShares}
-							/>
-						</div>
-					) : null}
-
-					{otherShares.length > 0 ? (
-						<div className="border-t pt-3">
-							<p className="mb-2 text-xs font-medium text-muted-foreground">Other active links</p>
-							<div className="space-y-2">
-								{otherShares.map((share) => (
+							{legacyLink ? (
+								<div className="border-t pt-3">
+									<p className="mb-2 text-xs font-medium text-muted-foreground">Older link</p>
 									<ShareLinkRow
-										key={share.id}
-										url={share.share_url}
-										label={shareLabel(share)}
-										detail={shareDetail(share)}
-										onRevoke={() => revokeShare(share.id)}
+										url={legacyUrl}
+										label="Live Session link"
+										detail={`Reflects future uploads · created ${relativeTime(legacyLink.created_at)}`}
+										onRevoke={revokeLegacyLink}
 										onRevoked={refreshShares}
-										compact
 									/>
-								))}
-							</div>
-						</div>
+								</div>
+							) : null}
+						</details>
 					) : null}
 				</div>
 
 				<DialogFooter>
 					<Button
+						variant={latestShare ? "outline" : "default"}
 						onClick={() => createShare.mutate()}
 						disabled={createShare.isPending || isLoading || Boolean(loadError)}
 					>
@@ -274,7 +285,6 @@ function ShareLinkRow({
 	onRevoke,
 	onRevoked,
 	autoFocus = false,
-	compact = false,
 }: {
 	url: string;
 	label: string;
@@ -282,7 +292,6 @@ function ShareLinkRow({
 	onRevoke: () => Promise<void>;
 	onRevoked: () => void;
 	autoFocus?: boolean;
-	compact?: boolean;
 }) {
 	const { copied, copy } = useCopyToClipboard({ success: "Share link copied" });
 	const [confirmOpen, setConfirmOpen] = useState(false);
@@ -297,7 +306,7 @@ function ShareLinkRow({
 		onError: (error) => toast.error(errorMessage(error)),
 	});
 	return (
-		<div className={cn("rounded-lg border p-3", compact && "p-2.5")}>
+		<div className="rounded-lg border p-3">
 			<div className="mb-2 flex items-center justify-between gap-3">
 				<div className="min-w-0">
 					<p className="truncate text-sm font-medium">{label}</p>
@@ -335,7 +344,9 @@ function ShareLinkRow({
 
 			<AlertDialog
 				open={confirmOpen}
-				onOpenChange={setConfirmOpen}
+				onOpenChange={(nextOpen) => {
+					if (!revoke.isPending) setConfirmOpen(nextOpen);
+				}}
 				onOpenChangeComplete={(nextOpen) => {
 					if (!nextOpen && revokeSucceeded) {
 						setRevokeSucceeded(false);

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -86,7 +86,7 @@ export function ShareProjectDialog({
 					</DialogTitle>
 					<DialogDescription>
 						{isShareableProject
-							? "People can view this Project and let their Agents use its keys. Secret values stay hidden. Only you can edit."
+							? "People can view this Project and let their Agents use its keys. Secret values stay hidden in the dashboard. Only you can edit."
 							: "Sharing is available for Projects you create. An Agent's private Workspace cannot be shared."}
 					</DialogDescription>
 				</DialogHeader>

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -86,7 +86,7 @@ export function ShareProjectDialog({
 					</DialogTitle>
 					<DialogDescription>
 						{isShareableProject
-							? "People can view this Project. Their linked Agents can use its Vault values, but people cannot see those values. Only you can edit."
+							? "People can view this Project and let their Agents use its keys. Secret values stay hidden. Only you can edit."
 							: "Sharing is available for Projects you create. An Agent's private Workspace cannot be shared."}
 					</DialogDescription>
 				</DialogHeader>

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -2,18 +2,7 @@
 
 import { buildShareAgentHandoffPrompt } from "@clawdi/shared/sharing";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-	AlertCircle,
-	CheckCircle2,
-	Copy,
-	Link2,
-	MailPlus,
-	Plus,
-	Share2,
-	Trash2,
-	UserMinus,
-	Users,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, Copy, Link2, Share2, Trash2, UserMinus } from "lucide-react";
 import { type ReactElement, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { isCustomProject } from "@/components/projects/project-metadata";
@@ -40,7 +29,6 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { ApiError, unwrap, useApi } from "@/lib/api";
@@ -48,23 +36,6 @@ import { normalizeApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
-
-/**
- * Owner-side project-sharing surface.
- *
- * One stacked surface (no tabs): invite by email, current people, and the
- * share link — in reading order, with a single line explaining what a
- * viewer can do.
- *
- * Backend endpoints:
- *   GET    /api/projects/{project_id}/share-links
- *   POST   /api/projects/{project_id}/share-links
- *   DELETE /api/projects/{project_id}/share-links/{link_id}
- *   GET    /api/projects/{project_id}/invitations
- *   POST   /api/projects/{project_id}/invitations
- *   DELETE /api/projects/{project_id}/invitations/{invitation_id}
- *
- */
 
 type ShareLinkRow = components["schemas"]["ShareLinkResponse"];
 type ShareLinkCreated = components["schemas"]["ShareLinkCreated"];
@@ -108,50 +79,25 @@ export function ShareProjectDialog({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			{trigger ? <DialogTrigger render={trigger} /> : null}
-			{/* `sm:` prefix is load-bearing: the primitive's base classes include
-			    `sm:max-w-lg`, so an unprefixed `max-w-2xl` loses at sm+ and the
-			    content gets clipped at 512px wide. */}
-			<DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-2xl">
+			<DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg">
 				<DialogHeader>
-					<DialogTitle>
+					<DialogTitle className="pr-8 leading-snug break-words">
 						{isShareableProject ? `Share ${projectName}` : "Only Projects you create can be shared"}
 					</DialogTitle>
 					<DialogDescription>
 						{isShareableProject
-							? "Share this Project without sharing ownership. People join as Viewers with read access; agent use is a separate choice they make later."
+							? "People can view this Project. Their linked Agents can use its Vault values, but people cannot see those values. Only you can edit."
 							: "Sharing is available for Projects you create. An Agent's private Workspace cannot be shared."}
 					</DialogDescription>
 				</DialogHeader>
 				{isShareableProject ? (
-					<div className="space-y-5">
-						{/* One surface, no tabs (journey J4): invite people, see who's
-						    in, manage the link — top to bottom. */}
-						<section className="space-y-3">
-							<h3 className="flex items-center gap-1.5 text-sm font-semibold">
-								<MailPlus className="size-3.5 text-muted-foreground" />
-								Invite by email
-							</h3>
-							<InvitationsPanel projectId={projectId} />
-						</section>
-						<section className="space-y-3 border-t pt-4">
-							<h3 className="flex items-center gap-1.5 text-sm font-semibold">
-								<Users className="size-3.5 text-muted-foreground" />
-								People
-							</h3>
-							<MembersPanel projectId={projectId} />
-						</section>
-						<section className="space-y-3 border-t pt-4">
-							<h3 className="flex items-center gap-1.5 text-sm font-semibold">
-								<Link2 className="size-3.5 text-muted-foreground" />
-								Share link
-							</h3>
+					<div className="space-y-4">
+						<InvitationsPanel projectId={projectId} />
+						<MembersPanel projectId={projectId} />
+						<section className="space-y-3 border-t pt-4" aria-label="Invite links">
 							<ShareLinksPanel projectId={projectId} open={open} />
 						</section>
-						<p className="border-t pt-3 text-xs text-muted-foreground">
-							Everyone joins as a viewer: they read skills and key names here, and their agents can
-							use key values when the Project is linked. Key values stay protected, and only you can
-							edit anything.
-						</p>
+						<StopSharingPanel projectId={projectId} />
 					</div>
 				) : (
 					<Alert>
@@ -170,7 +116,6 @@ export function ShareProjectDialog({
 function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean }) {
 	const api = useApi();
 	const qc = useQueryClient();
-	const [label, setLabel] = useState("");
 	// The just-created link's full URL is shown once because the server
 	// stores only the prefix going forward.
 	const [freshLink, setFreshLink] = useState<ShareLinkCreated | null>(null);
@@ -197,16 +142,14 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			),
 	});
 
-	const create = useSensitiveAction(async (nextLabel: string): Promise<ShareLinkCreated> => {
+	const create = useSensitiveAction(async (): Promise<ShareLinkCreated> => {
 		try {
-			const trimmedLabel = nextLabel.trim();
 			const body = unwrap(
 				await api.POST("/v1/projects/{project_id}/share-links", {
 					params: { path: { project_id: projectId } },
-					body: { label: trimmedLabel.length > 0 ? trimmedLabel : null },
+					body: {},
 				}),
 			);
-			setLabel("");
 			setFreshLink(body);
 			qc.invalidateQueries({ queryKey: ["share-links", projectId] });
 			// Best-effort auto-copy. Browsers without the async
@@ -215,9 +158,7 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			if (typeof navigator !== "undefined" && navigator.clipboard) {
 				navigator.clipboard.writeText(body.url).catch(() => {});
 			}
-			toast.success("Share link created", {
-				description: "Copy it before closing this dialog. You can turn it off later.",
-			});
+			toast.success("Invite link created");
 			return body;
 		} catch (e) {
 			toast.error(
@@ -250,69 +191,42 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 		},
 	});
 
-	const visibleLinks = links.data ?? [];
+	const activeLinks = (links.data ?? []).filter(
+		(link) => link.revoked_at === null && !isExpiredLink(link),
+	);
+	const inactiveLinks = (links.data ?? []).filter(
+		(link) => link.revoked_at !== null || isExpiredLink(link),
+	);
 
 	return (
 		<div className="space-y-3">
-			<div className="space-y-1">
-				<p className="text-xs text-muted-foreground">
-					Create a link when you want to send access yourself, or when the person may not have a
-					Clawdi account yet.
-				</p>
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<h3 className="text-sm font-semibold">Invite link</h3>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={create.isPending}
+					onClick={() => {
+						void create.execute().catch(() => undefined);
+					}}
+				>
+					<Link2 className="mr-1.5 size-4" />
+					{create.isPending ? "Creating…" : "Create invite link"}
+				</Button>
 			</div>
-			<form
-				className="space-y-2 rounded-lg border p-3"
-				onSubmit={(e) => {
-					e.preventDefault();
-					void create.execute(label).catch(() => undefined);
-				}}
-			>
-				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-					<Input
-						name="share-link-label"
-						value={label}
-						onChange={(e) => setLabel(e.target.value)}
-						maxLength={200}
-						placeholder="Bob onboarding…"
-						aria-label="Share link label"
-						autoComplete="off"
-						className="min-w-0 flex-1"
-						spellCheck={false}
-					/>
-					<Button type="submit" size="sm" disabled={create.isPending}>
-						<Plus className="mr-1.5 size-3.5" />
-						{create.isPending ? "Creating…" : "Create link"}
-					</Button>
-				</div>
-				<p className="text-xs text-muted-foreground">
-					The full URL is shown once after creation. Labels stay visible so you can recognize links
-					before turning them off.
-				</p>
-			</form>
-
-			<div className="flex items-center justify-between gap-2">
-				<p className="text-xs text-muted-foreground">
-					Anyone with an active link can preview this Project and join as a read-only Viewer. Turn
-					off a link anytime to stop new accepts.
-				</p>
-				<Badge variant="secondary" className="text-xs">
-					{visibleLinks.filter((link) => link.revoked_at === null).length} Active
-				</Badge>
-			</div>
-
-			{freshLink ? <FreshLinkBanner link={freshLink} onDismiss={() => setFreshLink(null)} /> : null}
-
-			<Separator />
-
+			<p className="text-sm text-muted-foreground">
+				Anyone with the link can preview and join this Project.
+			</p>
+			{freshLink && !inactiveLinks.some((link) => link.id === freshLink.id) ? (
+				<FreshLinkBanner link={freshLink} onDismiss={() => setFreshLink(null)} />
+			) : null}
 			{links.isLoading ? (
-				<Skeleton className="h-16 w-full" />
+				<Skeleton className="h-10 w-full" />
 			) : shouldBlockQueryError(links.error, links.data) ? (
 				<EmptyHint variant="destructive" message={normalizeApiError(links.error)} />
-			) : visibleLinks.length === 0 ? (
-				<EmptyHint message="No share links yet. Create one when you need a lightweight invite." />
-			) : (
-				<ul className="space-y-2">
-					{visibleLinks.map((link) => (
+			) : activeLinks.length > 0 ? (
+				<ul className="space-y-1">
+					{activeLinks.map((link) => (
 						<LinkRow
 							key={link.id}
 							link={link}
@@ -325,7 +239,19 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 						/>
 					))}
 				</ul>
-			)}
+			) : null}
+			{inactiveLinks.length > 0 ? (
+				<details className="text-sm">
+					<summary className="cursor-pointer text-muted-foreground">
+						Inactive links ({inactiveLinks.length})
+					</summary>
+					<ul className="mt-2 space-y-1">
+						{inactiveLinks.map((link) => (
+							<LinkRow key={link.id} link={link} revoking={false} />
+						))}
+					</ul>
+				</details>
+			) : null}
 			<AlertDialog
 				open={revokeOpen}
 				onOpenChange={(nextOpen) => {
@@ -392,19 +318,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 			<CheckCircle2 />
 			<AlertTitle>Copy this link now</AlertTitle>
 			<AlertDescription>
-				<p className="text-xs text-muted-foreground">
-					Send this URL to the person you want to invite. They sign in or create an account, accept
-					as a read-only Viewer, then open the Project from their dashboard.
-				</p>
-				<p className="mt-1 text-xs text-muted-foreground">
-					This is the only time the full URL is visible here. After this, only the prefix{" "}
-					<span className="font-mono">{link.prefix}</span> remains available.
-				</p>
-				{link.label ? (
-					<p className="mt-1 text-xs text-muted-foreground">
-						Label: <span className="font-medium text-foreground">{link.label}</span>
-					</p>
-				) : null}
+				<p>Save it before closing this dialog.</p>
 				<div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
 					<Input
 						readOnly
@@ -429,28 +343,26 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						Done
 					</Button>
 				</div>
-				<div className="mt-2 rounded-md border bg-background/60 p-2">
-					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-						<div className="min-w-0">
-							<div className="text-xs font-medium">Agent Handoff Prompt</div>
-							<div className="truncate font-mono text-2xs text-muted-foreground">
-								Viewer access · add to an agent later · {link.prefix}
-							</div>
-						</div>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => copyText(agentPrompt, "Agent Prompt Copied")}
-							aria-label={`Copy agent handoff prompt for share link ${link.prefix}`}
-						>
-							<Copy className="mr-1.5 size-3.5" />
-							Copy Prompt
-						</Button>
-					</div>
-				</div>
+				<details className="mt-2 text-sm">
+					<summary className="cursor-pointer">Send to an Agent</summary>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="mt-2"
+						onClick={() => copyText(agentPrompt, "Agent Prompt Copied")}
+						aria-label={`Copy agent handoff prompt for share link ${link.prefix}`}
+					>
+						<Copy className="mr-1.5 size-3.5" />
+						Copy Prompt
+					</Button>
+				</details>
 			</AlertDescription>
 		</Alert>
 	);
+}
+
+function isExpiredLink(link: ShareLinkRow) {
+	return link.expires_at !== null && new Date(link.expires_at).getTime() <= Date.now();
 }
 
 function LinkRow({
@@ -459,26 +371,20 @@ function LinkRow({
 	revoking,
 }: {
 	link: ShareLinkRow;
-	onRevoke: () => void;
+	onRevoke?: () => void;
 	revoking: boolean;
 }) {
 	const revoked = link.revoked_at !== null;
+	const expired = isExpiredLink(link);
 	return (
-		<li className={`rounded-lg border p-3 ${revoked ? "bg-muted/30 text-muted-foreground" : ""}`}>
+		<li className={`py-2 ${revoked || expired ? "text-muted-foreground" : ""}`}>
 			<div className="flex items-center justify-between gap-2">
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2 text-sm">
-						<Badge variant="outline" className="font-mono">
-							{link.prefix}…
-						</Badge>
-						{link.label ? (
-							<span className="truncate font-medium">{link.label}</span>
-						) : (
-							<span className="text-xs italic text-muted-foreground">No Label</span>
-						)}
-						{revoked ? (
+						<span className="truncate font-medium">{link.label ?? "Invite link"}</span>
+						{revoked || expired ? (
 							<Badge variant="secondary" className="text-xs">
-								Off
+								{revoked ? "Off" : "Expired"}
 							</Badge>
 						) : null}
 					</div>
@@ -494,21 +400,9 @@ function LinkRow({
 						<span>
 							{link.redeem_count} accept{link.redeem_count === 1 ? "" : "s"}
 						</span>
-						{link.last_redeemed_at ? (
-							<>
-								<span aria-hidden>·</span>
-								<span>
-									Last used{" "}
-									{new Date(link.last_redeemed_at).toLocaleDateString(undefined, {
-										month: "short",
-										day: "numeric",
-									})}
-								</span>
-							</>
-						) : null}
 					</div>
 				</div>
-				{!revoked ? (
+				{!revoked && !expired ? (
 					<Button
 						variant="ghost"
 						size="icon"
@@ -561,8 +455,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
 			setEmail("");
 			toast.success("Invitation sent", {
-				description:
-					"They will see it under the top-right Notification Center bell after signing in with that email.",
+				description: "They can accept in Clawdi notifications after signing in.",
 			});
 		},
 		onError: (e) => {
@@ -593,28 +486,22 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 		},
 	});
 
-	const looksLikeEmail = /^\S+@\S+\.\S+$/.test(email);
+	const looksLikeEmail = /^\S+@\S+\.\S+$/.test(email.trim());
 
 	return (
 		<div className="space-y-3">
-			<div className="space-y-1">
-				<p className="text-xs text-muted-foreground">
-					Use email when the person already signs in with this address. If they may be new to
-					Clawdi, create a share link instead.
-				</p>
-			</div>
 			<form
 				onSubmit={(e) => {
 					e.preventDefault();
 					if (!looksLikeEmail) return;
-					invite.mutate(email);
+					invite.mutate(email.trim());
 				}}
-				className="flex flex-col gap-2 sm:flex-row"
+				className="flex gap-2"
 			>
 				<Input
 					type="email"
 					name="project-invite-email"
-					placeholder="email@example.com…"
+					placeholder="Enter email address"
 					value={email}
 					onChange={(e) => setEmail(e.target.value)}
 					autoComplete="email"
@@ -630,12 +517,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 					{invite.isPending ? "Sending…" : "Invite"}
 				</Button>
 			</form>
-			<p className="text-xs text-muted-foreground">
-				Invitees join as Viewers with read access to Skills and key names. Key values stay protected
-				and can be used by their linked Agents. After signing in, they accept from the top-right
-				Notification Center bell.
-			</p>
-			<Separator />
+
 			{invites.isLoading ? (
 				<Skeleton className="h-16 w-full" />
 			) : shouldBlockQueryError(invites.error, invites.data) ? (
@@ -647,27 +529,16 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 							: normalizeApiError(invites.error)
 					}
 				/>
-			) : (invites.data ?? []).length === 0 ? (
-				<EmptyHint message="No pending invites." />
-			) : (
+			) : (invites.data ?? []).length === 0 ? null : (
 				<ul className="space-y-2">
 					{invites.data?.map((inv) => (
-						<li
-							key={inv.id}
-							className="flex items-center justify-between gap-2 rounded-md border p-2 text-sm"
-						>
+						<li key={inv.id} className="flex items-center justify-between gap-2 py-1 text-sm">
 							<div className="min-w-0">
-								<div className="truncate font-medium">{inv.invitee_email}</div>
+								<div className="truncate font-medium" title={inv.invitee_email}>
+									{inv.invitee_email}
+								</div>
 								<div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
 									<Badge variant="outline">Pending</Badge>
-									<span aria-hidden>·</span>
-									<span>
-										Sent{" "}
-										{new Date(inv.created_at).toLocaleDateString(undefined, {
-											month: "short",
-											day: "numeric",
-										})}
-									</span>
 								</div>
 							</div>
 							<Button
@@ -738,7 +609,6 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 function MembersPanel({ projectId }: { projectId: string }) {
 	const api = useApi();
 	const qc = useQueryClient();
-	const [stopAllOpen, setStopAllOpen] = useState(false);
 	const [removeOpen, setRemoveOpen] = useState(false);
 	const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
 	const removeSucceededRef = useRef(false);
@@ -787,100 +657,27 @@ function MembersPanel({ projectId }: { projectId: string }) {
 			}),
 	});
 
-	const unshare = useMutation({
-		mutationFn: async () =>
-			unwrap(
-				await api.POST("/v1/projects/{project_id}/unshare", {
-					params: { path: { project_id: projectId } },
-				}),
-			),
-		onSuccess: (body) => {
-			setStopAllOpen(false);
-			refreshSharingState();
-			toast.success("Sharing stopped", {
-				description: `Turned off ${body.links_revoked} link(s) and removed ${body.members_removed} member(s).`,
-			});
-		},
-		onError: (e) =>
-			toast.error("Couldn't stop sharing", {
-				description: normalizeApiError(e),
-			}),
-	});
-
 	const rows = members.data ?? [];
 
 	return (
 		<div className="space-y-3">
-			<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-				<div className="space-y-1">
-					<p className="text-xs text-muted-foreground sm:max-w-sm">
-						People who accepted access. Viewers can read this Project until you remove them.
-					</p>
-				</div>
-				<AlertDialog
-					open={stopAllOpen}
-					onOpenChange={(nextOpen) => {
-						if (!unshare.isPending) setStopAllOpen(nextOpen);
-					}}
-				>
-					<AlertDialogTrigger
-						render={
-							<Button
-								variant="destructive"
-								size="sm"
-								disabled={unshare.isPending}
-								aria-label="Stop all sharing for this Project"
-							/>
-						}
-					>
-						{unshare.isPending ? "Stopping…" : "Stop all sharing"}
-					</AlertDialogTrigger>
-					<AlertDialogContent>
-						<AlertDialogHeader>
-							<AlertDialogTitle>Stop Sharing This Project?</AlertDialogTitle>
-							<AlertDialogDescription>
-								This turns off active links, cancels pending invitations, and removes accepted
-								Viewers. Project content remains yours.
-							</AlertDialogDescription>
-						</AlertDialogHeader>
-						<AlertDialogFooter>
-							<AlertDialogCancel disabled={unshare.isPending}>Keep Sharing</AlertDialogCancel>
-							<AlertDialogAction
-								onClick={() => unshare.mutate()}
-								disabled={unshare.isPending}
-								className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-							>
-								Stop all sharing
-							</AlertDialogAction>
-						</AlertDialogFooter>
-					</AlertDialogContent>
-				</AlertDialog>
-			</div>
-			<Separator />
+			<h3 className="text-sm font-semibold">People with access</h3>
 			{members.isLoading ? (
 				<Skeleton className="h-16 w-full" />
 			) : shouldBlockQueryError(members.error, members.data) ? (
 				<EmptyHint variant="destructive" message={normalizeApiError(members.error)} />
 			) : rows.length === 0 ? (
-				<EmptyHint message="No accepted Viewers yet. Invite someone or create a link." />
+				<p className="text-sm text-muted-foreground">Only you have access</p>
 			) : (
 				<ul className="space-y-2">
 					{rows.map((member) => {
 						const label = member.user_email ?? member.user_display ?? member.user_id;
 						return (
-							<li
-								key={member.id}
-								className="flex items-center justify-between gap-2 rounded-md border p-2 text-sm"
-							>
+							<li key={member.id} className="flex items-center justify-between gap-2 py-1 text-sm">
 								<div className="min-w-0">
 									<div className="truncate font-medium">{label}</div>
 									<div className="text-xs text-muted-foreground">
-										{formatMembershipToken(member.role)} · Joined via{" "}
-										{formatMembershipToken(member.joined_via)} ·{" "}
-										{new Date(member.joined_at).toLocaleDateString(undefined, {
-											month: "short",
-											day: "numeric",
-										})}
+										{formatMembershipToken(member.role)}
 									</div>
 								</div>
 								<Button
@@ -902,6 +699,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 					})}
 				</ul>
 			)}
+
 			<AlertDialog
 				open={removeOpen}
 				onOpenChange={(nextOpen) => {
@@ -950,6 +748,86 @@ function MembersPanel({ projectId }: { projectId: string }) {
 				</AlertDialogContent>
 			</AlertDialog>
 		</div>
+	);
+}
+
+function StopSharingPanel({ projectId }: { projectId: string }) {
+	const api = useApi();
+	const qc = useQueryClient();
+	const [stopAllOpen, setStopAllOpen] = useState(false);
+	const unshare = useMutation({
+		mutationFn: async () =>
+			unwrap(
+				await api.POST("/v1/projects/{project_id}/unshare", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
+		onSuccess: (body) => {
+			setStopAllOpen(false);
+			for (const queryKey of [
+				["project-members", projectId],
+				["share-links", projectId],
+				["invitations", projectId],
+				["skills"],
+				["get", "/v1/projects"],
+			])
+				void qc.invalidateQueries({ queryKey });
+			toast.success("Sharing stopped", {
+				description: `Turned off ${body.links_revoked} link(s) and removed ${body.members_removed} member(s).`,
+			});
+		},
+		onError: (e) =>
+			toast.error("Couldn't stop sharing", {
+				description: normalizeApiError(e),
+			}),
+	});
+
+	return (
+		<details className="text-sm">
+			<summary className="cursor-pointer text-muted-foreground">Manage sharing</summary>
+			<AlertDialog
+				open={stopAllOpen}
+				onOpenChange={(nextOpen) => {
+					if (!unshare.isPending) setStopAllOpen(nextOpen);
+				}}
+			>
+				<AlertDialogTrigger
+					render={
+						<Button
+							variant="ghost"
+							className="text-destructive"
+							size="sm"
+							disabled={unshare.isPending}
+							aria-label="Stop all sharing for this Project"
+						/>
+					}
+				>
+					{unshare.isPending ? "Stopping…" : "Stop all sharing"}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Stop Sharing This Project?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This turns off active links, cancels pending invitations, and removes accepted
+							Viewers. Project content remains yours.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={unshare.isPending}>Keep Sharing</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(event) => {
+								event.preventDefault();
+								if (!unshare.isPending) unshare.mutate();
+							}}
+							disabled={unshare.isPending}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Stop all sharing
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</details>
 	);
 }
 

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -91,7 +91,7 @@ export function ShareProjectDialog({
 					</DialogDescription>
 				</DialogHeader>
 				{isShareableProject ? (
-					<div className="space-y-4">
+					<div key={projectId} className="space-y-4">
 						<InvitationsPanel projectId={projectId} />
 						<MembersPanel projectId={projectId} />
 						<section className="space-y-3 border-t pt-4" aria-label="Invite links">

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -182,7 +182,7 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			revokeSucceededRef.current = true;
 			revokeExit.beginClose();
 			setRevokeOpen(false);
-			toast.success("Share link turned off");
+			toast.success("Invite link turned off");
 		},
 		onError: (e) => {
 			toast.error("Couldn't turn off link", {
@@ -273,10 +273,10 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Turn off this share link?</AlertDialogTitle>
+						<AlertDialogTitle>Turn off this invite link?</AlertDialogTitle>
 						<AlertDialogDescription>
-							New Viewers will no longer be able to join from this link. Existing Viewers retain
-							access until removed from People.
+							People will no longer be able to join from this link. Existing members retain access
+							until removed from People.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -290,7 +290,7 @@ function ShareLinksPanel({ projectId, open }: { projectId: string; open: boolean
 							disabled={!renderedRevokeTarget || revoke.isPending}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{revoke.isPending ? "Turning off…" : "Turn Off Link"}
+							{revoke.isPending ? "Turning off…" : "Turn off link"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
@@ -324,7 +324,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						readOnly
 						value={link.url}
 						name="fresh-share-link-url"
-						aria-label="New share link URL"
+						aria-label="New invite link URL"
 						autoComplete="off"
 						spellCheck={false}
 						className="min-w-0 font-mono text-xs"
@@ -332,9 +332,9 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 					<Button
 						variant="outline"
 						size="sm"
-						onClick={() => copyText(link.url, "Link Copied")}
+						onClick={() => copyText(link.url, "Link copied")}
 						className="sm:size-9 sm:px-0"
-						aria-label="Copy Share Link"
+						aria-label="Copy invite link"
 					>
 						<Copy className="size-3.5" />
 						<span className="sm:sr-only">Copy</span>
@@ -349,11 +349,11 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						variant="ghost"
 						size="sm"
 						className="mt-2"
-						onClick={() => copyText(agentPrompt, "Agent Prompt Copied")}
-						aria-label={`Copy agent handoff prompt for share link ${link.prefix}`}
+						onClick={() => copyText(agentPrompt, "Agent prompt copied")}
+						aria-label={`Copy agent handoff prompt for invite link ${link.prefix}`}
 					>
 						<Copy className="mr-1.5 size-3.5" />
-						Copy Prompt
+						Copy prompt
 					</Button>
 				</details>
 			</AlertDescription>
@@ -408,7 +408,7 @@ function LinkRow({
 						size="icon"
 						disabled={revoking}
 						title="Turn off link"
-						aria-label={`Turn off share link ${link.prefix}`}
+						aria-label={`Turn off invite link ${link.prefix}`}
 						onClick={onRevoke}
 					>
 						<Trash2 className="size-3.5 text-destructive" />
@@ -455,7 +455,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
 			setEmail("");
 			toast.success("Invitation sent", {
-				description: "They can accept in Clawdi notifications after signing in.",
+				description: "They can accept in Clawdi notifications.",
 			});
 		},
 		onError: (e) => {
@@ -477,7 +477,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 			cancelSucceededRef.current = true;
 			cancelExit.beginClose();
 			setCancelOpen(false);
-			toast.success("Invitation cancelled");
+			toast.success("Invitation canceled");
 		},
 		onError: (e) => {
 			toast.error("Couldn't cancel invitation", {
@@ -597,7 +597,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 							disabled={!renderedCancelTarget || cancel.isPending}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{cancel.isPending ? "Cancelling…" : "Cancel invitation"}
+							{cancel.isPending ? "Canceling…" : "Cancel invitation"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
@@ -742,7 +742,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 							disabled={!renderedRemoveTarget || remove.isPending}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{remove.isPending ? "Removing…" : "Remove Member"}
+							{remove.isPending ? "Removing…" : "Remove member"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
@@ -806,14 +806,14 @@ function StopSharingPanel({ projectId }: { projectId: string }) {
 				</AlertDialogTrigger>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Stop Sharing This Project?</AlertDialogTitle>
+						<AlertDialogTitle>Stop all sharing?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This turns off active links, cancels pending invitations, and removes accepted
-							Viewers. Project content remains yours.
+							All invite links and pending invitations will stop working. Members will lose access.
+							Your Project content stays unchanged.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={unshare.isPending}>Keep Sharing</AlertDialogCancel>
+						<AlertDialogCancel disabled={unshare.isPending}>Keep sharing</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={(event) => {
 								event.preventDefault();

--- a/apps/web/src/components/vault/agent-vaults-query.ts
+++ b/apps/web/src/components/vault/agent-vaults-query.ts
@@ -11,10 +11,11 @@ export function useAgentProjectVaults(
 	const api = useApi();
 	return useQuery({
 		queryKey: ["vaults", "agent-projects", ...projectIds],
-		queryFn: async () =>
+		queryFn: async ({ signal }) =>
 			fetchAgentProjectVaults(projectIds, async (projectId, page, pageSize) =>
 				unwrap(
 					await api.GET("/v1/vault", {
+						signal,
 						params: { query: { project_id: projectId, page, page_size: pageSize } },
 					}),
 				),

--- a/apps/web/src/components/vault/agent-vaults-surface.tsx
+++ b/apps/web/src/components/vault/agent-vaults-surface.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { resolveAgentProjectScope } from "@/components/dashboard/agent-project-scope";
+import { AgentResourceRouteGate } from "@/components/dashboard/agent-resource-route-gate";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { Skeleton } from "@/components/ui/skeleton";
+import { VaultsSurface } from "@/components/vault/vaults-surface";
+import { agentDetailQueryOptions } from "@/lib/agent-queries";
+import { agentSectionHref } from "@/lib/agent-routes";
+import { useOpenApi } from "@/lib/api";
+import { shouldBlockQueryError } from "@/lib/query-state";
+import { agentResourceScope } from "@/lib/resource-navigation";
+
+export function AgentVaultsSurface({ agentId }: { agentId: string }) {
+	return (
+		<AgentResourceRouteGate
+			agentId={agentId}
+			returnHref={agentSectionHref(agentId, "projects")}
+			returnLabel="Projects"
+		>
+			<AgentVaultInventory agentId={agentId} />
+		</AgentResourceRouteGate>
+	);
+}
+
+function AgentVaultInventory({ agentId }: { agentId: string }) {
+	const api = useOpenApi();
+	const queryClient = useQueryClient();
+	const agent = useQuery(agentDetailQueryOptions(api, queryClient, agentId));
+	const bindings = useAgentProjectBindings(agentId);
+	let projectIds: string[] = [];
+	let scopeError: unknown = null;
+	if (bindings.data) {
+		try {
+			projectIds = resolveAgentProjectScope(
+				bindings.data,
+				agent.data?.default_project_id,
+			).projectIds;
+		} catch (error) {
+			scopeError = error;
+		}
+	}
+	const blocked = scopeError || shouldBlockQueryError(bindings.error, bindings.data);
+	return (
+		<div className="space-y-4">
+			{bindings.error || scopeError ? (
+				<div className={`${CENTERED_PAGE_WIDTH_CLASS.page} px-4 lg:px-6`}>
+					<ApiErrorPanel
+						error={scopeError ?? bindings.error}
+						title="Couldn't load Agent Vault access"
+						onRetry={() => {
+							void bindings.refetch();
+							void agent.refetch();
+						}}
+					/>
+				</div>
+			) : null}
+			{blocked ? null : bindings.data === undefined ? (
+				<Skeleton className="mx-6 h-24 rounded-lg" />
+			) : (
+				<VaultsSurface
+					agentProjectIds={projectIds}
+					workspaceProjectId={
+						bindings.data.find((binding) => binding.binding_type === "primary")?.project_id
+					}
+					navigationScope={agentResourceScope(agentId)}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/vault/project-vault-catalog.tsx
+++ b/apps/web/src/components/vault/project-vault-catalog.tsx
@@ -5,7 +5,6 @@ import { parseAsString, useQueryState } from "nuqs";
 import { useRef } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import type { AgentProjectBinding } from "@/components/dashboard/agent-project-scope";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { ListToolbar } from "@/components/list-toolbar";
@@ -22,7 +21,6 @@ import { normalizeApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
-	agentResourceScope,
 	LIBRARY_RESOURCE_SCOPE,
 	type ResourceNavigationScope,
 	resourceCollectionTarget,
@@ -40,7 +38,6 @@ export function ProjectVaultCatalog({
 	error,
 	onRetry,
 	scope,
-	agentBindings,
 	onChanged,
 }: {
 	project: Project;
@@ -50,7 +47,6 @@ export function ProjectVaultCatalog({
 	error: unknown;
 	onRetry: () => void;
 	scope: ResourceNavigationScope;
-	agentBindings: readonly AgentProjectBinding[] | undefined;
 	onChanged: () => Promise<void>;
 }) {
 	const api = useApi();
@@ -58,7 +54,12 @@ export function ProjectVaultCatalog({
 	const projectNames = new Map(
 		(projects.data ?? []).map((row) => [row.id, displayProjectName(row)]),
 	);
-	projectNames.set(project.id, displayProjectName(project));
+	projectNames.set(
+		project.id,
+		scope.kind === "agent" && project.kind === "environment"
+			? "Workspace"
+			: displayProjectName(project),
+	);
 	const [search, setSearch] = useQueryState(
 		"q",
 		parseAsString.withDefault("").withOptions({ clearOnDefault: true, history: "replace" }),
@@ -72,7 +73,7 @@ export function ProjectVaultCatalog({
 	else returnSearch.delete("q");
 	const returnHref = `${location.pathname}${returnSearch.size ? `?${returnSearch}` : ""}`;
 	const locked = useRef(false);
-	const canAttach = project.is_owner !== false;
+	const canAttach = scope.kind !== "agent" && project.is_owner !== false;
 	const catalog = useVaultCatalog({ enabled: canAttach });
 	const context = project.kind === "environment" ? "Workspace" : "Project";
 	const attachedIds = new Set(attachedVaults?.map((vault) => vault.id));
@@ -99,7 +100,7 @@ export function ProjectVaultCatalog({
 		);
 	const groups = attachmentsKnown
 		? [
-				{ label: "Linked", rows: rows.filter((vault) => attachedIds.has(vault.id)) },
+				{ label: `In this ${context}`, rows: rows.filter((vault) => attachedIds.has(vault.id)) },
 				{ label: "Available", rows: rows.filter((vault) => !attachedIds.has(vault.id)) },
 			]
 		: [{ label: null, rows }];
@@ -131,10 +132,10 @@ export function ProjectVaultCatalog({
 		},
 		onSuccess: async (_, { attached }) => {
 			await onChanged();
-			toast.success(`Vault ${attached ? "unlinked from" : "linked to"} ${context}`);
+			toast.success(`Vault ${attached ? "removed from" : "added to"} ${context}`);
 		},
 		onError: (error) =>
-			toast.error("Couldn't update Vault link", { description: normalizeApiError(error) }),
+			toast.error("Couldn't update Project Vaults", { description: normalizeApiError(error) }),
 		onSettled: () => {
 			locked.current = false;
 		},
@@ -154,8 +155,8 @@ export function ProjectVaultCatalog({
 			/>
 			{canAttach ? (
 				<p className="text-sm text-muted-foreground">
-					Vaults linked to this {context} and the rest of your Library. Unlinking preserves keys and
-					other links.
+					Add Vaults from your Library to this {context}. Removing a Vault preserves its keys and
+					other Projects.
 				</p>
 			) : null}
 			{error ? (
@@ -178,7 +179,11 @@ export function ProjectVaultCatalog({
 						<section
 							key={group.label ?? "catalog"}
 							className="space-y-3"
-							aria-label={group.label ? `${group.label} ${context} Vaults` : undefined}
+							aria-label={
+								group.label
+									? `${group.label}${group.label === "Available" ? ` ${context}` : ""} Vaults`
+									: undefined
+							}
 						>
 							{group.label ? (
 								<SectionLabel count={group.rows.length}>{group.label}</SectionLabel>
@@ -186,14 +191,6 @@ export function ProjectVaultCatalog({
 							<div className={HERO_GRID_CLASS}>
 								{group.rows.map((vault) => {
 									const attached = attachmentsKnown && attachedIds.has(vault.id);
-									const inherited =
-										scope.kind === "agent" && !attached
-											? agentBindings?.find(
-													(binding) =>
-														binding.project_id !== project.id &&
-														vault.project_ids.includes(binding.project_id),
-												)
-											: undefined;
 									const pending =
 										updateAttachment.isPending && updateAttachment.variables.vault.id === vault.id;
 									const actionsDisabled =
@@ -206,11 +203,7 @@ export function ProjectVaultCatalog({
 										locked.current = true;
 										updateAttachment.mutate({ vault, attached });
 									};
-									const detailScope = attached
-										? scope
-										: inherited && scope.kind === "agent"
-											? agentResourceScope(scope.agentId, inherited.project_id)
-											: LIBRARY_RESOURCE_SCOPE;
+									const detailScope = attached ? scope : LIBRARY_RESOURCE_SCOPE;
 									return (
 										<div key={vault.id} data-testid="project-vault-card" className="min-w-0">
 											<VaultCard
@@ -220,8 +213,8 @@ export function ProjectVaultCatalog({
 													projects.error,
 													projects.data,
 												)}
-												visibleProjectIds={null}
-												projectId={attached ? project.id : inherited?.project_id}
+												visibleProjectIds={scope.kind === "agent" ? new Set([project.id]) : null}
+												projectId={attached ? project.id : undefined}
 												navigationScope={detailScope}
 												returnHref={
 													returnHref !== resourceCollectionTarget(detailScope, "vaults").href
@@ -230,23 +223,6 @@ export function ProjectVaultCatalog({
 												}
 												shared={vault.is_owner === false}
 												searchQuery={search.trim() || undefined}
-												status={
-													attachmentsKnown
-														? attached
-															? canAttach && vault.is_owner !== false
-																? undefined
-																: `Linked to ${context}`
-															: inherited
-																? inherited.binding_type === "primary"
-																	? "Via Workspace"
-																	: "Via linked Project"
-																: scope.kind === "agent" && !agentBindings
-																	? "Agent access unavailable"
-																	: undefined
-														: isLoading
-															? "Loading links…"
-															: "Link status unavailable"
-												}
 												actions={
 													canAttach && vault.is_owner !== false ? (
 														<Button
@@ -256,7 +232,7 @@ export function ProjectVaultCatalog({
 															aria-busy={pending}
 															aria-label={
 																attachmentsKnown
-																	? `${attached ? "Unlink" : "Link"} ${vault.name} ${attached ? "from" : "to"} ${context}`
+																	? `${attached ? "Remove" : "Add"} ${vault.name} ${attached ? "from" : "to"} ${context}`
 																	: `Link status unavailable for ${vault.name}`
 															}
 															onClick={toggleAttachment}
@@ -264,12 +240,12 @@ export function ProjectVaultCatalog({
 															{pending || isLoading ? <Spinner /> : null}
 															{pending
 																? updateAttachment.variables.attached
-																	? "Unlinking…"
-																	: "Linking…"
+																	? "Removing…"
+																	: "Adding…"
 																: attachmentsKnown
 																	? attached
-																		? "Unlink"
-																		: "Link"
+																		? "Remove"
+																		: "Add"
 																	: isLoading
 																		? "Loading…"
 																		: "Unavailable"}

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -213,7 +213,7 @@ export function VaultsSurface({
 					filterableProjects.length > 1 ? (
 						<>
 							<FilterChip active={projectFilter === "all"} onClick={() => setProjectFilter("all")}>
-								All projects
+								All Vaults
 								<span className="text-muted-foreground tabular-nums">{items.length}</span>
 							</FilterChip>
 							{filterableProjects.map((p) => (

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -50,11 +50,13 @@ import { identityFor } from "@/lib/identity";
 import { formatResourceCount, getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
+	agentResourceScope,
 	LIBRARY_RESOURCE_SCOPE,
 	type ResourceNavigationScope,
 	vaultDetailHrefForScope,
 	vaultDetailLink,
 } from "@/lib/resource-navigation";
+import { useCommittedLocation } from "@/lib/use-committed-location";
 import { cn } from "@/lib/utils";
 
 type VaultSummary = components["schemas"]["VaultResponse"];
@@ -67,13 +69,17 @@ const VAULTS_RESOURCE = getProjectResourceDefinition("vaults");
 export function VaultsSurface({
 	embedded = false,
 	agentProjectIds,
+	workspaceProjectId,
 	navigationScope = LIBRARY_RESOURCE_SCOPE,
 }: {
 	embedded?: boolean;
 	agentProjectIds?: readonly string[];
+	workspaceProjectId?: string;
 	navigationScope?: ResourceNavigationScope;
 }) {
 	const $api = useOpenApi();
+	const location = useCommittedLocation();
+	const isAgent = navigationScope.kind === "agent";
 	// URL-backed like the other lists: open a vault and come back with the
 	// filter text intact.
 	const [search, setSearch] = useQueryState(
@@ -110,8 +116,13 @@ export function VaultsSurface({
 	);
 	const projectNameById = useMemo(
 		() =>
-			new Map((projects.data ?? []).map((project) => [project.id, displayProjectName(project)])),
-		[projects.data],
+			new Map(
+				(projects.data ?? []).map((project) => [
+					project.id,
+					project.id === workspaceProjectId ? "Workspace" : displayProjectName(project),
+				]),
+			),
+		[projects.data, workspaceProjectId],
 	);
 	const projectNamesUnavailable = shouldBlockQueryError(projects.error, projects.data);
 
@@ -121,6 +132,12 @@ export function VaultsSurface({
 		() => (agentProjectIds ? new Set(agentProjectIds) : null),
 		[agentProjectIds],
 	);
+	const returnSearch = new URLSearchParams();
+	if (search) returnSearch.set("q", search);
+	if (projectFilter !== "all") returnSearch.set("project", projectFilter);
+	const returnHref = isAgent
+		? `${location.pathname}${returnSearch.size ? `?${returnSearch}` : ""}`
+		: undefined;
 	const hasActiveFilter = search.trim().length > 0 || projectFilter !== "all";
 	const filtered = useMemo(() => {
 		const q = search.trim();
@@ -143,13 +160,17 @@ export function VaultsSurface({
 	}, [items, visibleProjectIds]);
 	const filterableProjects = useMemo(() => {
 		return (projects.data ?? [])
-			.filter((p) => (vaultCountByProject.get(p.id) ?? 0) > 0 || p.id === projectFilter)
+			.filter(
+				(p) =>
+					(!visibleProjectIds || visibleProjectIds.has(p.id)) &&
+					((vaultCountByProject.get(p.id) ?? 0) > 0 || p.id === projectFilter),
+			)
 			.sort(
 				(a, b) =>
 					(vaultCountByProject.get(b.id) ?? 0) - (vaultCountByProject.get(a.id) ?? 0) ||
 					a.name.localeCompare(b.name),
 			);
-	}, [projectFilter, projects.data, vaultCountByProject]);
+	}, [projectFilter, projects.data, vaultCountByProject, visibleProjectIds]);
 	const sortVaults = (a: VaultSummary, b: VaultSummary) => compareVaultsForCatalog(a, b, search);
 	const mine = filtered.filter((v) => v.is_owner !== false).sort(sortVaults);
 	const shared = filtered.filter((v) => v.is_owner === false).sort(sortVaults);
@@ -165,17 +186,23 @@ export function VaultsSurface({
 			{embedded ? null : (
 				<PageHeader
 					title="Vaults"
-					description={VAULTS_RESOURCE.managementDescription}
+					description={
+						isAgent
+							? "Vaults available through this Agent’s Workspace and linked Projects. Configure Vaults in the source Project."
+							: VAULTS_RESOURCE.managementDescription
+					}
 					actions={
-						<>
-							<AddKeysDialog>
-								<Button size="sm" variant="outline">
-									<Plus className="size-3.5" />
-									Add keys
-								</Button>
-							</AddKeysDialog>
-							<NewVaultDialog navigationScope={navigationScope} />
-						</>
+						isAgent ? null : (
+							<>
+								<AddKeysDialog>
+									<Button size="sm" variant="outline">
+										<Plus className="size-3.5" />
+										Add keys
+									</Button>
+								</AddKeysDialog>
+								<NewVaultDialog navigationScope={navigationScope} />
+							</>
+						)
 					}
 				/>
 			)}
@@ -198,7 +225,7 @@ export function VaultsSurface({
 									<span aria-hidden className="select-none">
 										{identityFor(p.name).emoji}
 									</span>
-									{p.name}
+									{projectNameById.get(p.id)}
 									<span className="text-muted-foreground tabular-nums">
 										{vaultCountByProject.get(p.id) ?? 0}
 									</span>
@@ -209,6 +236,13 @@ export function VaultsSurface({
 				}
 			/>
 
+			{vaultsQuery.error && vaultsQuery.data !== undefined ? (
+				<ApiErrorPanel
+					error={vaultsQuery.error}
+					onRetry={() => void vaultsQuery.refetch()}
+					title="Couldn’t refresh Vaults"
+				/>
+			) : null}
 			{shouldBlockQueryError(vaultsQuery.error, vaultsQuery.data) ? (
 				<ApiErrorPanel
 					error={vaultsQuery.error}
@@ -229,7 +263,7 @@ export function VaultsSurface({
 					description={
 						hasActiveFilter
 							? "Try a different search or Project filter."
-							: embedded
+							: isAgent || embedded
 								? "This agent does not have any Vaults through its Projects yet."
 								: "Create a vault to group API keys for your agents."
 					}
@@ -254,6 +288,8 @@ export function VaultsSurface({
 								projectNamesUnavailable={projectNamesUnavailable}
 								visibleProjectIds={visibleProjectIds}
 								navigationScope={navigationScope}
+								actions={isAgent ? null : undefined}
+								returnHref={returnHref}
 								searchQuery={search.trim() || undefined}
 							/>
 						))}
@@ -274,6 +310,8 @@ export function VaultsSurface({
 										visibleProjectIds={visibleProjectIds}
 										navigationScope={navigationScope}
 										shared
+										actions={isAgent ? null : undefined}
+										returnHref={returnHref}
 										searchQuery={search.trim() || undefined}
 									/>
 								))}
@@ -314,8 +352,9 @@ export function VaultCard({
 	const api = useApi();
 	const itemProjectId =
 		projectId ??
-		vault.project_ids?.find((projectId) => visibleProjectIds?.has(projectId)) ??
-		vault.project_ids?.[0];
+		(navigationScope.kind === "agent"
+			? (navigationScope.projectId ?? vault.project_ids?.find((id) => visibleProjectIds?.has(id)))
+			: vault.project_ids?.[0]);
 	const canManageVault = vault.is_owner !== false;
 	// Key count ships on the list response (names only, never values) —
 	// no per-card items fetch. EXCEPT under deploy skew: a web build that
@@ -385,7 +424,8 @@ export function VaultCard({
 				usedBy.length > 0 ? (
 					<Tooltip>
 						<TooltipTrigger render={<span className="truncate" />}>
-							used by {usedBy.slice(0, 2).join(", ")}
+							{navigationScope.kind === "agent" ? "From " : "used by "}
+							{usedBy.slice(0, 2).join(", ")}
 							{usedBy.length > 2 ? ` +${usedBy.length - 2}` : ""}
 						</TooltipTrigger>
 						<TooltipContent>{usedBy.join(", ")}</TooltipContent>
@@ -411,7 +451,14 @@ export function VaultCard({
 					</AddKeysDialog>
 				) : undefined
 			}
-			link={vaultDetailLink(navigationScope, vault.slug, vault.id, returnHref)}
+			link={vaultDetailLink(
+				navigationScope.kind === "agent"
+					? agentResourceScope(navigationScope.agentId, navigationScope.projectId ?? itemProjectId)
+					: navigationScope,
+				vault.slug,
+				vault.id,
+				returnHref,
+			)}
 			ariaLabel={`Open vault ${vault.name}`}
 		/>
 	);
@@ -457,7 +504,7 @@ function NewVaultDialog({ navigationScope }: { navigationScope: ResourceNavigati
 			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
 			setOpen(false);
 			toast.success("Vault created", {
-				description: "Use Add keys on its card, then link it to a Project.",
+				description: "Use Add keys on its card, then add it to a Project.",
 				action: {
 					label: "Open vault",
 					onClick: () =>
@@ -486,7 +533,7 @@ function NewVaultDialog({ navigationScope }: { navigationScope: ResourceNavigati
 				<DialogHeader>
 					<DialogTitle>Create vault</DialogTitle>
 					<DialogDescription>
-						A bundle of API keys your Agents can use. Link it to Projects to control access.
+						A bundle of API keys your Agents can use. Add it to Projects to control access.
 					</DialogDescription>
 				</DialogHeader>
 				{vaultsQuery.error ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/components/dashboard/agent-overview-resource-bodies";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
 import {
+	effectiveAgentProjectIds,
 	linkedAgentProjectCount,
 	resolveAgentWorkspaceProjectId,
 } from "@/components/dashboard/agent-project-scope";
@@ -1388,7 +1389,7 @@ function OverviewTab({
 						].map((skill) => skill.skill_key),
 					);
 	const vaultsModule = useOverviewVaultsModule({
-		projectIds: workspaceProjectId ? [workspaceProjectId] : [],
+		projectIds: workspaceProjectId ? effectiveAgentProjectIds(projectBindings.data ?? []) : [],
 		resolution: workspaceResolution,
 	});
 	const memoriesModule = useOverviewMemoriesModule();
@@ -1412,9 +1413,7 @@ function OverviewTab({
 		memories: memoriesModule,
 		vaults: {
 			...vaultsModule,
-			link: workspaceProjectId
-				? agentProjectResourceLink(agentId, workspaceProjectId, "vaults")
-				: null,
+			link: agentSectionLink(agentId, "vaults"),
 		},
 		connectors: connectorsModule,
 	};

--- a/apps/web/src/lib/project-resource-model.ts
+++ b/apps/web/src/lib/project-resource-model.ts
@@ -84,7 +84,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		navLabel: "Vaults",
 		description: "Encrypted key collections linked to one or more Projects.",
 		managementDescription:
-			"Keep API keys in a Vault, then link it to the Projects where Agents should use those keys.",
+			"Keep API keys in a Vault, then add it to the Projects where Agents should use those keys.",
 		href: PROJECT_RESOURCE_LIST_PATHS.vaults,
 		emptyCta: "Create vault",
 		routeGroup: "library",

--- a/apps/web/src/lib/project-resource-model.ts
+++ b/apps/web/src/lib/project-resource-model.ts
@@ -41,8 +41,7 @@ export interface ProjectResourceDefinition {
 	countLabel?: string;
 }
 
-export const PROJECT_CANONICAL_DEFINITION =
-	"A Project owns Skills and links Vault access for a workflow or team.";
+export const PROJECT_CANONICAL_DEFINITION = "A Project groups Skills and Vaults for your Agents.";
 
 const PROJECT_RESOURCE_DEFINITIONS = [
 	{
@@ -52,7 +51,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		navLabel: "Projects",
 		description: PROJECT_CANONICAL_DEFINITION,
 		managementDescription:
-			"Create shareable Projects that bundle Skills with linked Vault access. Each Agent also has a private Workspace on that Agent's page.",
+			"Group Skills and Vaults into Projects, then choose which Agents use them.",
 		href: PROJECT_RESOURCE_LIST_PATHS.projects,
 		emptyCta: "Create project",
 		routeGroup: "projects",
@@ -82,7 +81,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		label: "Vaults",
 		singularLabel: "Vault",
 		navLabel: "Vaults",
-		description: "Encrypted key collections linked to one or more Projects.",
+		description: "Encrypted key collections used by Projects.",
 		managementDescription:
 			"Keep API keys in a Vault, then add it to the Projects where Agents should use those keys.",
 		href: PROJECT_RESOURCE_LIST_PATHS.vaults,

--- a/apps/web/src/lib/resource-navigation.test.ts
+++ b/apps/web/src/lib/resource-navigation.test.ts
@@ -20,7 +20,13 @@ import {
 
 describe("resource navigation scopes", () => {
 	it("preserves catalog search without allowing a return link to grant Agent access", () => {
-		const from = "/agents/agent-1/project-access/workspace-1/vaults?q=release%26keys";
+		const from = "/agents/agent-1/vaults?q=release%26keys&project=workspace-1";
+		expect(
+			resourceCatalogReturnTarget("/agents/agent-1/project-access/workspace-1/vaults?q=keys"),
+		).toEqual({
+			href: "/agents/agent-1/project-access/workspace-1/vaults?q=keys",
+			label: "Agent Vaults",
+		});
 		expect(resourceCatalogReturnTarget(from)).toEqual({ href: from, label: "Agent Vaults" });
 		expect(resourceCatalogReturnTarget("/projects/project-1?tab=vaults&q=release")).toEqual({
 			href: "/projects/project-1?tab=vaults&q=release",

--- a/apps/web/src/lib/resource-navigation.ts
+++ b/apps/web/src/lib/resource-navigation.ts
@@ -61,8 +61,8 @@ export function resourceCollectionTarget(
 					label: "Vaults",
 				}
 			: {
-					href: agentSectionHref(scope.agentId, "projects"),
-					label: "Projects",
+					href: agentSectionHref(scope.agentId, "vaults"),
+					label: "Vaults",
 				};
 	}
 	return {
@@ -150,6 +150,7 @@ export function resourceCatalogReturnTarget(from: unknown): ResourceNavigationTa
 	const url = new URL(from, "https://catalog.invalid");
 	const path = url.pathname;
 	const href = `${path}${url.search}`;
+	if (/^\/agents\/[^/]+\/vaults\/?$/.test(path)) return { href, label: "Agent Vaults" };
 	if (/^\/agents\/[^/]+\/project-access\/?$/.test(path)) return { href, label: "Agent Projects" };
 	if (/^\/agents\/[^/]+\/project-access\/[^/]+\/vaults\/?$/.test(path))
 		return { href, label: "Agent Vaults" };

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -674,13 +674,13 @@ export default function ProjectDetailPage({
 								? focus === "skills"
 									? "Skills available in this Agent's Workspace. Skills synced from the Agent are read-only."
 									: focus === "vaults"
-										? "Your Vault library and this Agent's Workspace Vault links."
+										? "Vaults available through this Agent’s Workspace."
 										: "This Agent's fixed Workspace for installed Skills and linked Vaults."
 								: focus === "skills"
 									? "Skills this Agent uses through this linked Project."
 									: focus === "vaults"
 										? isOwner
-											? "Your Vault library and this linked Project’s Vault links."
+											? "Vaults this Agent can use through this Project."
 											: "Vaults this Agent can use through this Project. Key values stay protected."
 										: "This Agent uses the Project's Skills and linked Vaults as one bundle."
 							: projectDetailDescription(project, isOwner)
@@ -700,7 +700,7 @@ export default function ProjectDetailPage({
 									Add skill
 								</Button>
 							</CreateSkillDialog>
-						) : focus === "vaults" && isOwner ? (
+						) : focus === "vaults" && isOwner && !isAgentScope ? (
 							<CreateProjectVaultDialog
 								projectId={project.id}
 								contextLabel={isWorkspace ? "Workspace" : "Project"}
@@ -907,7 +907,7 @@ export default function ProjectDetailPage({
 				description={
 					isAgentScope
 						? isWorkspace
-							? "Your Vault library and this Agent's Workspace Vault links."
+							? "Vaults available through this Agent’s Workspace."
 							: "Vaults this Agent can use through this Project."
 						: isOwner
 							? "Your Vault library and this Project’s Vault links."
@@ -922,7 +922,7 @@ export default function ProjectDetailPage({
 									resource="Vaults"
 								/>
 							) : null}
-							{isOwner ? (
+							{isOwner && !isAgentScope ? (
 								<CreateProjectVaultDialog
 									projectId={project.id}
 									contextLabel={isWorkspace ? "Workspace" : "Project"}
@@ -942,7 +942,6 @@ export default function ProjectDetailPage({
 					error={vaults.error}
 					onRetry={() => void vaults.refetch()}
 					scope={scope}
-					agentBindings={scopedBindings.data ? orderedScopedBindings : undefined}
 					onChanged={refresh}
 				/>
 			</HubSection>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -901,7 +901,7 @@ export default function ProjectDetailPage({
 				showHeading={!focus}
 				id="vaults"
 				title="Vaults"
-				count={vaultCount}
+				count={isAgentScope ? vaultCount : undefined}
 				description={
 					isAgentScope
 						? isWorkspace
@@ -912,9 +912,9 @@ export default function ProjectDetailPage({
 							: "Read-only vaults shared through this Project."
 				}
 				action={
-					!focus && (projectResourceTargets || isOwner) ? (
+					!focus && (isAgentScope || isOwner) ? (
 						<>
-							{!focus && projectResourceTargets ? (
+							{!focus && isAgentScope && projectResourceTargets ? (
 								<ProjectResourceViewAllLink
 									href={projectResourceTargets.vaults}
 									resource="Vaults"

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -675,14 +675,14 @@ export default function ProjectDetailPage({
 									? "Skills available in this Agent's Workspace. Skills synced from the Agent are read-only."
 									: focus === "vaults"
 										? "Vaults available through this Agent’s Workspace."
-										: "This Agent's fixed Workspace for installed Skills and linked Vaults."
+										: "This Agent's fixed Workspace for installed Skills and Vaults."
 								: focus === "skills"
 									? "Skills this Agent uses through this linked Project."
 									: focus === "vaults"
 										? isOwner
 											? "Vaults this Agent can use through this Project."
 											: "Vaults this Agent can use through this Project. Key values stay protected."
-										: "This Agent uses the Project's Skills and linked Vaults as one bundle."
+										: "This Agent uses the Project's Skills and Vaults as one bundle."
 							: projectDetailDescription(project, isOwner)
 					}
 					status={
@@ -734,9 +734,7 @@ export default function ProjectDetailPage({
 					<CheckCircle2 className="size-4" />
 					<AlertTitle>Project added</AlertTitle>
 					<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-						<span>
-							Linking lets an Agent use this Project&apos;s Skills and linked Vaults together.
-						</span>
+						<span>Linking lets an Agent use this Project&apos;s Skills and Vaults together.</span>
 						<Button type="button" size="sm" onClick={() => setUseWithAgentOpen(true)}>
 							<Bot className="mr-1.5 size-3.5" />
 							Manage agents
@@ -910,7 +908,7 @@ export default function ProjectDetailPage({
 							? "Vaults available through this Agent’s Workspace."
 							: "Vaults this Agent can use through this Project."
 						: isOwner
-							? "Your Vault library and this Project’s Vault links."
+							? "Vaults included in this Project."
 							: "Read-only vaults shared through this Project."
 				}
 				action={
@@ -999,7 +997,7 @@ export default function ProjectDetailPage({
 				<HubSection
 					id="people"
 					title="Your access"
-					description="You have viewer access. Linked Agents use this Project's Skills and linked Vaults together."
+					description="You have viewer access. Linked Agents use this Project's Skills and Vaults together."
 				>
 					<SharedAccessPanel
 						project={project}
@@ -1021,7 +1019,7 @@ export default function ProjectDetailPage({
 							? "Agent that owns this Workspace."
 							: project.kind === "personal"
 								? "Private library items are not linked to individual Agents."
-								: "Agents you own that use this Project's Skills and linked Vaults."
+								: "Agents you own that use this Project's Skills and Vaults."
 					}
 				>
 					{boundAgents.isLoading ? (
@@ -1041,7 +1039,7 @@ export default function ProjectDetailPage({
 									? "The home Agent for this Workspace is unavailable."
 									: project.kind === "personal"
 										? "Private library items have no Agent links."
-										: "None of your Agents are linked yet. Link this Project to let one use its Skills and linked Vaults."
+										: "None of your Agents are linked yet. Link this Project to let one use its Skills and Vaults."
 							}
 						/>
 					) : (
@@ -1219,8 +1217,8 @@ function projectDetailDescription(project: ProjectRow, isOwner: boolean) {
 	const access = isOwner ? "you own" : "shared with you";
 	if (project.kind === "workspace") {
 		return isOwner
-			? "Project you own. Add Skills and link Vaults, then link the whole bundle to Agents that need it."
-			: "Project shared with you. Linked Agents use its Skills and linked Vaults together.";
+			? "Add Skills and Vaults here, then choose which Agents use this Project."
+			: "Project shared with you. Linked Agents use its Skills and Vaults together.";
 	}
 	if (project.kind === "environment") {
 		return `Workspace ${access}. This private Workspace belongs to one Agent and cannot be shared.`;
@@ -1253,7 +1251,7 @@ function SharedAccessPanel({
 				</div>
 				<p className="text-xs text-muted-foreground">
 					You can read this Project and link it to an Agent. The Agent then uses the Project&apos;s
-					Skills and linked Vaults together.
+					Skills and Vaults together.
 				</p>
 			</div>
 			<div className="rounded-md border bg-background/60 p-3">
@@ -1281,7 +1279,7 @@ function SharedAccessPanel({
 						<AlertDialogTitle>Leave {displayProjectName(project)}?</AlertDialogTitle>
 						<AlertDialogDescription>
 							This removes your access and unlinks the Project from your Agents. Those Agents will
-							stop using its Skills and linked Vaults.
+							stop using its Skills and Vaults.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -3,16 +3,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import {
-	Check,
 	Copy as CopyIcon,
 	ExternalLink,
 	FolderInput,
 	ListChecks,
 	Plus,
-	Share2,
 	Trash2,
 } from "lucide-react";
-import { type ReactNode, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
@@ -30,21 +28,10 @@ import {
 	isCustomProject,
 	projectSupportingText,
 } from "@/components/projects/project-metadata";
-import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmAction } from "@/components/ui/confirm-action";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { SearchInput } from "@/components/ui/search-input";
 import {
 	Select,
@@ -68,7 +55,6 @@ import { decodeResourceRouteParam } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
 	libraryManagementTarget,
-	projectDetailLink,
 	type ResourceNavigationScope,
 	resourceCatalogReturnTarget,
 	resourceCollectionTarget,
@@ -92,7 +78,7 @@ function apiSection(section: string): string {
 
 /* Vault detail (journeys J5 + J6): a real page for one secret bundle —
  * keys (names only; values stay server-side), paste-to-import, project
- * attachments, and the guided "Share keys" chain. */
+ * attachments. */
 
 export default function VaultDetailPage({
 	slug: rawSlug,
@@ -328,7 +314,16 @@ export default function VaultDetailPage({
 
 	const attachProject = useMutation({
 		mutationFn: async (projectId: string) => {
-			if (!vault) throw new Error("Vault not loaded");
+			if (
+				!vault ||
+				isAgentScope ||
+				!isOwner ||
+				!projects.data?.some(
+					(project) =>
+						project.id === projectId && project.is_owner !== false && isCustomProject(project),
+				)
+			)
+				throw new Error("Project unavailable");
 			return unwrap(
 				await api.POST("/v1/vault", {
 					params: { query: { project_id: projectId } },
@@ -338,16 +333,16 @@ export default function VaultDetailPage({
 		},
 		onSuccess: () => {
 			refresh();
-			toast.success("Vault linked to Project", {
+			toast.success("Vault added to Project", {
 				description: "Key values stay protected, and linked Projects and Agents can use them.",
 			});
 		},
-		onError: (e) => toast.error("Couldn't link vault to Project", { description: errorMessage(e) }),
+		onError: (e) => toast.error("Couldn't add vault to Project", { description: errorMessage(e) }),
 	});
 
 	const detachProject = useMutation({
 		mutationFn: async (projectId: string) => {
-			if (!resolvedVaultId) throw new Error("Vault not loaded");
+			if (!resolvedVaultId || isAgentScope || !isOwner) throw new Error("Vault unavailable");
 			return unwrap(
 				await api.DELETE("/v1/vault/{slug}", {
 					params: {
@@ -360,16 +355,13 @@ export default function VaultDetailPage({
 		onSuccess: (_data, projectId) => {
 			refresh();
 			const attachmentLabel =
-				isAgentScope && projectId === requestedProjectId ? requestedAttachmentLabel : "Project";
-			toast.success(`Vault unlinked from ${attachmentLabel}`);
-			if (isAgentScope && projectId === requestedProjectId) {
-				void router.navigate({ href: backTarget.href });
-			}
+				projectById.get(projectId)?.kind === "environment" ? "Workspace" : "Project";
+			toast.success(`Vault removed from ${attachmentLabel}`);
 		},
 		onError: (e, projectId) => {
 			const attachmentLabel =
-				isAgentScope && projectId === requestedProjectId ? requestedAttachmentLabel : "Project";
-			toast.error(`Couldn't unlink vault from ${attachmentLabel}`, {
+				projectById.get(projectId)?.kind === "environment" ? "Workspace" : "Project";
+			toast.error(`Couldn't remove vault from ${attachmentLabel}`, {
 				description: errorMessage(e),
 			});
 		},
@@ -519,35 +511,28 @@ export default function VaultDetailPage({
 				}
 				actions={
 					canManageVault ? (
-						<>
-							<ShareKeysDialog
-								vault={vault}
-								projects={projects.data ?? []}
-								onAttach={(projectId) => attachProject.mutateAsync(projectId)}
-							/>
-							<ConfirmAction
-								title={`Delete ${vault.name}?`}
-								description={
-									<p>
-										Every key in this vault is removed for every Project using it. Agents lose
-										access immediately.
-									</p>
-								}
-								confirmLabel="Delete vault"
-								destructive
-								onConfirm={() => deleteVault.mutateAsync()}
+						<ConfirmAction
+							title={`Delete ${vault.name}?`}
+							description={
+								<p>
+									Every key in this vault is removed for every Project using it. Agents lose access
+									immediately.
+								</p>
+							}
+							confirmLabel="Delete vault"
+							destructive
+							onConfirm={() => deleteVault.mutateAsync()}
+						>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={deleteVault.isPending}
+								className="text-destructive"
 							>
-								<Button
-									variant="outline"
-									size="sm"
-									disabled={deleteVault.isPending}
-									className="text-destructive"
-								>
-									<Trash2 className="mr-1.5 size-3.5" />
-									Delete
-								</Button>
-							</ConfirmAction>
-						</>
+								<Trash2 className="mr-1.5 size-3.5" />
+								Delete
+							</Button>
+						</ConfirmAction>
 					) : null
 				}
 			/>
@@ -804,16 +789,16 @@ export default function VaultDetailPage({
 						</div>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							{isAgentScope
-								? `This Vault is linked to the ${requestedAttachmentLabel}. Its key values stay protected, and this Agent can use them.`
+								? `Available through this ${requestedAttachmentLabel}. Open the source below to configure its Vaults.`
 								: "Same Vault everywhere — key changes apply to every linked Project. Key values stay protected, and linked Projects and Agents can use them."}
 						</p>
 					</div>
-					{canManageVault && !blockingProjectsError ? (
+					{canManageVault && !isAgentScope && !blockingProjectsError ? (
 						<AttachProjectPicker
 							projects={(projects.data ?? []).filter(
 								(p) =>
 									p.is_owner !== false &&
-									(!isAgentScope || scopedProjectIdSet.has(p.id)) &&
+									isCustomProject(p) &&
 									!(vault.project_ids ?? []).includes(p.id),
 							)}
 							isPending={attachProject.isPending}
@@ -834,41 +819,56 @@ export default function VaultDetailPage({
 				) : attachedProjects.length === 0 ? (
 					<EmptyState
 						variant="inset"
-						title="Not linked to any Project yet"
-						description="Link this Vault to a Project before that Project and its Agents can use the key values."
+						title="Not in any Project yet"
+						description="Add this Vault to a Project so its Agents can use the key values."
 					/>
 				) : (
 					<div className="divide-y overflow-hidden rounded-lg border bg-card">
 						{attachedProjects.map((project) => {
-							const isWorkspaceAttachment =
-								isAgentScope &&
-								scopedBindings.data?.some(
-									(binding) =>
-										binding.project_id === project.id && binding.binding_type === "primary",
-								);
+							const isWorkspaceAttachment = project.kind === "environment";
 							const attachmentLabel = isWorkspaceAttachment ? "Workspace" : "Project";
 							return (
 								<div key={project.id} className="flex items-center gap-3 px-4 py-2.5">
 									<div className="min-w-0 flex-1">
-										<Link
-											{...projectDetailLink(scope, project.id)}
-											className="block truncate text-sm font-medium hover:underline"
-										>
-											{isWorkspaceAttachment ? "Workspace" : displayProjectName(project)}
-										</Link>
+										{isWorkspaceAttachment ? (
+											<>
+												<span className="block text-sm font-medium">Workspace</span>
+												{isAgentScope && isOwner ? (
+													<Link
+														to={managementTarget.href}
+														className="text-xs text-muted-foreground underline"
+													>
+														Manage in Vault Library
+													</Link>
+												) : null}
+											</>
+										) : isCustomProject(project) ? (
+											<Link
+												to="/projects/$id"
+												params={{ id: project.id }}
+												search={{ tab: "vaults" }}
+												className="block truncate text-sm font-medium hover:underline"
+											>
+												{displayProjectName(project)}
+											</Link>
+										) : (
+											<span className="block text-sm font-medium">
+												{displayProjectName(project)}
+											</span>
+										)}
 										<p className="truncate text-xs text-muted-foreground">
 											{projectSupportingText(project)}
 										</p>
 									</div>
-									{isOwner ? (
+									{isOwner && !isAgentScope ? (
 										<ConfirmAction
-											title={`Unlink from ${attachmentLabel}?`}
+											title={`Remove from ${attachmentLabel}?`}
 											description={
 												<p>
 													This {attachmentLabel} and its Agents will stop using these key values.
 												</p>
 											}
-											confirmLabel="Unlink vault"
+											confirmLabel="Remove vault"
 											destructive
 											onConfirm={() => detachProject.mutate(project.id)}
 										>
@@ -876,7 +876,7 @@ export default function VaultDetailPage({
 												variant="ghost"
 												size="icon-sm"
 												className="text-muted-foreground hover:text-destructive"
-												aria-label={`Unlink from ${attachmentLabel}`}
+												aria-label={`Remove from ${attachmentLabel}`}
 											>
 												<Trash2 className="size-3.5" />
 											</Button>
@@ -919,7 +919,7 @@ function AttachProjectPicker({
 				<SelectTrigger
 					size="sm"
 					className="w-full sm:w-44"
-					aria-label="Project to link this Vault to"
+					aria-label="Project to add this Vault to"
 				>
 					<SelectValue placeholder="Choose a Project…" />
 				</SelectTrigger>
@@ -942,166 +942,8 @@ function AttachProjectPicker({
 				}}
 			>
 				{isPending ? <Spinner /> : <Plus className="size-3.5" />}
-				Link vault
+				Add to Project
 			</Button>
 		</div>
-	);
-}
-
-/**
- * The guided share chain (journey J5): keys are shared by putting the vault
- * in a workspace Project and sharing that Project. This sheet walks the two
- * hops in one place instead of leaving users to discover them.
- */
-function ShareKeysDialog({
-	vault,
-	projects,
-	onAttach,
-}: {
-	vault: VaultSummary;
-	projects: ProjectRow[];
-	onAttach: (projectId: string) => Promise<unknown>;
-}) {
-	const [open, setOpen] = useState(false);
-	const shareable = projects.filter((p) => p.is_owner !== false && isCustomProject(p));
-	const alreadyIn = shareable.filter((p) => (vault.project_ids ?? []).includes(p.id));
-	// If the vault already lives in a shareable project, that's almost
-	// certainly the one to share — preselect it so the common case is one
-	// click (journey simulation finding J6).
-	const [projectId, setProjectId] = useState(alreadyIn[0]?.id ?? "");
-	const [attached, setAttached] = useState<ProjectRow | null>(null);
-	const [isAttaching, setIsAttaching] = useState(false);
-
-	const candidates = shareable;
-	const candidateItems = candidates.map((project) => ({
-		value: project.id,
-		label: `${displayProjectName(project)}${
-			(vault.project_ids ?? []).includes(project.id) ? " (already linked)" : ""
-		}`,
-	}));
-
-	const reset = () => {
-		setProjectId("");
-		setAttached(null);
-		setIsAttaching(false);
-	};
-
-	let body: ReactNode;
-	if (attached) {
-		body = (
-			<div className="space-y-4">
-				<Alert>
-					<Check className="size-4" />
-					<AlertTitle>Vault linked to {displayProjectName(attached)}</AlertTitle>
-					<AlertDescription>
-						Now invite your colleague to that Project. They&apos;ll see key names here, and their
-						Agents can use the values. Key values stay protected, and only you can edit them.
-					</AlertDescription>
-				</Alert>
-				<ShareProjectDialog
-					projectId={attached.id}
-					projectName={displayProjectName(attached)}
-					projectKind={attached.kind}
-				>
-					<Button className="w-full">
-						<Share2 className="mr-1.5 size-3.5" />
-						Invite people to {displayProjectName(attached)}
-					</Button>
-				</ShareProjectDialog>
-			</div>
-		);
-	} else if (shareable.length === 0) {
-		body = (
-			<Alert>
-				<AlertTitle>Create a Project first</AlertTitle>
-				<AlertDescription>
-					Keys are shared through a Project. Create one on the Projects page, then come back here.
-				</AlertDescription>
-			</Alert>
-		);
-	} else {
-		body = (
-			<div className="space-y-4">
-				<p className="text-sm text-muted-foreground">
-					To share keys, link this Vault to a Project, then invite people to that Project.
-					Members&apos; agents can use the keys; nobody but you can read or edit the values.
-				</p>
-				<div className="space-y-1.5">
-					<Label htmlFor="share-keys-project">Project</Label>
-					<Select
-						items={candidateItems}
-						value={projectId}
-						onValueChange={(value) => {
-							if (value !== null) setProjectId(value);
-						}}
-					>
-						<SelectTrigger id="share-keys-project" className="w-full">
-							<SelectValue placeholder="Choose a Project…" />
-						</SelectTrigger>
-						<SelectContent>
-							{candidates.map((p) => (
-								<SelectItem key={p.id} value={p.id}>
-									{displayProjectName(p)}
-									{(vault.project_ids ?? []).includes(p.id) ? " (already linked)" : ""}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-				<Button
-					className="w-full"
-					disabled={!projectId || isAttaching}
-					onClick={async () => {
-						const project = candidates.find((p) => p.id === projectId);
-						if (!project) return;
-						if ((vault.project_ids ?? []).includes(project.id)) {
-							setAttached(project);
-							return;
-						}
-						setIsAttaching(true);
-						try {
-							await onAttach(project.id);
-							setAttached(project);
-						} finally {
-							setIsAttaching(false);
-						}
-					}}
-				>
-					{isAttaching ? <Spinner /> : <Plus className="size-3.5" />}
-					{projectId && (vault.project_ids ?? []).includes(projectId) ? "Continue" : "Link vault"}
-				</Button>
-				{alreadyIn.length > 0 ? (
-					<p className="text-xs text-muted-foreground">
-						Linked to: {alreadyIn.map((p) => displayProjectName(p)).join(", ")}
-					</p>
-				) : null}
-			</div>
-		);
-	}
-
-	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-			}}
-			onOpenChangeComplete={(next) => {
-				if (!next) reset();
-			}}
-		>
-			<DialogTrigger render={<Button size="sm" />}>
-				<Share2 className="mr-1.5 size-3.5" />
-				Share keys
-			</DialogTrigger>
-			<DialogContent className="sm:max-w-md">
-				<DialogHeader>
-					<DialogTitle>Share keys</DialogTitle>
-					<DialogDescription>
-						Give a teammate&apos;s agents access to {vault.name}.
-					</DialogDescription>
-				</DialogHeader>
-				{body}
-			</DialogContent>
-		</Dialog>
 	);
 }

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -1,20 +1,10 @@
 "use client";
 
 import { Link, useRouter } from "@tanstack/react-router";
-import {
-	AlertCircle,
-	CheckCircle2,
-	FileText,
-	KeyRound,
-	Lock,
-	LogIn,
-	ShieldCheck,
-	Sparkles,
-} from "lucide-react";
+import { AlertCircle, CheckCircle2, KeyRound, LogIn, ShieldCheck, Sparkles } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -161,23 +151,12 @@ export default function SharePage({ token }: { token: string }) {
 					</p>
 				</CardHeader>
 				<CardContent className="space-y-6">
-					<div className="grid grid-cols-2 gap-3">
-						<ContentTile
-							icon={<FileText className="size-5" />}
-							label="Skills"
-							count={data.skill_count}
-							hint="Readable on any device"
-						/>
-						<ContentTile
-							icon={<Lock className="size-5" />}
-							label="Vaults"
-							count={data.vault_count}
-							hint="Key names only; values stay private"
-							muted={data.vault_count === 0}
-						/>
-					</div>
+					<p className="text-sm text-muted-foreground">
+						{data.skill_count} {data.skill_count === 1 ? "Skill" : "Skills"} · {data.vault_count}{" "}
+						{data.vault_count === 1 ? "Vault" : "Vaults"}
+					</p>
 
-					<ViewerAccessCard hasVaults={data.vault_count > 0} />
+					<ViewerAccessSummary hasVaults={data.vault_count > 0} />
 
 					<Separator />
 
@@ -185,10 +164,7 @@ export default function SharePage({ token }: { token: string }) {
 						<Alert>
 							<CheckCircle2 />
 							<AlertTitle>You're In</AlertTitle>
-							<AlertDescription>
-								Added to your Projects with Viewer access. Adding it to an agent is a separate step.
-								Redirecting…
-							</AlertDescription>
+							<AlertDescription>Invitation accepted. Opening Project…</AlertDescription>
 						</Alert>
 					) : isOwner ? (
 						<Alert>
@@ -205,14 +181,8 @@ export default function SharePage({ token }: { token: string }) {
 								size="lg"
 							>
 								<CheckCircle2 className="mr-2 size-4" />
-								{upgrade.isPending ? "Joining…" : "Accept Project Access"}
+								{upgrade.isPending ? "Joining…" : "Accept invitation"}
 							</Button>
-							<p className="text-xs text-muted-foreground">
-								You'll join as a <Badge variant="secondary">Viewer</Badge> with read access to
-								skills
-								{data.vault_count > 0 ? " and Vault values from the Clawdi CLI" : ""}. The dashboard
-								does not reveal key values.
-							</p>
 							{upgrade.error instanceof ShareError && upgrade.error.code === "already_member" ? (
 								<Alert>
 									<CheckCircle2 />
@@ -239,7 +209,7 @@ export default function SharePage({ token }: { token: string }) {
 								size="lg"
 							>
 								<LogIn className="mr-2 size-4" />
-								Continue in Browser
+								Sign in to accept
 							</Button>
 							<p className="text-xs text-muted-foreground">
 								Sign in or create a free account. After signing in, click Accept here to join the
@@ -260,71 +230,18 @@ export default function SharePage({ token }: { token: string }) {
 					)}
 				</CardContent>
 			</Card>
-			<p className="text-center text-xs text-muted-foreground">
-				Shared Projects never grant write access. The owner can turn off this link anytime.
-			</p>
 		</Shell>
 	);
 }
 
-function ViewerAccessCard({ hasVaults }: { hasVaults: boolean }) {
-	const vaultCopy = hasVaults
-		? "Use Vault values from the Clawdi CLI"
-		: "Use Vault values from the Clawdi CLI if added later";
+function ViewerAccessSummary({ hasVaults }: { hasVaults: boolean }) {
 	return (
-		<div className="grid gap-3 rounded-lg border bg-muted/30 p-4 text-sm sm:grid-cols-2">
-			<div className="space-y-2">
-				<p className="font-medium">Viewer Can</p>
-				<ul className="space-y-1.5 text-muted-foreground">
-					<li className="flex items-center gap-2">
-						<CheckCircle2 aria-hidden="true" className="size-4 shrink-0 text-foreground" />
-						<span>View skills</span>
-					</li>
-					<li className="flex items-center gap-2">
-						<CheckCircle2 aria-hidden="true" className="size-4 shrink-0 text-foreground" />
-						<span>{vaultCopy}</span>
-					</li>
-				</ul>
-			</div>
-			<div className="space-y-2">
-				<p className="font-medium">Viewer Cannot</p>
-				<ul className="space-y-1.5 text-muted-foreground">
-					<li className="flex items-center gap-2">
-						<AlertCircle aria-hidden="true" className="size-4 shrink-0 text-foreground" />
-						<span>Reveal key values in the dashboard</span>
-					</li>
-					<li className="flex items-center gap-2">
-						<AlertCircle aria-hidden="true" className="size-4 shrink-0 text-foreground" />
-						<span>Edit anything</span>
-					</li>
-				</ul>
-			</div>
-		</div>
-	);
-}
-
-function ContentTile({
-	icon,
-	label,
-	count,
-	hint,
-	muted,
-}: {
-	icon: React.ReactNode;
-	label: string;
-	count: number;
-	hint: string;
-	muted?: boolean;
-}) {
-	return (
-		<div className={`rounded-lg border p-4 ${muted ? "bg-muted/30 text-muted-foreground" : ""}`}>
-			<div className="flex items-center gap-2 text-sm">
-				{icon}
-				<span className="font-medium">{label}</span>
-			</div>
-			<div className="mt-2 text-2xl font-semibold">{count}</div>
-			<div className="text-xs text-muted-foreground">{hint}</div>
-		</div>
+		<p className="text-sm text-muted-foreground">
+			You can view this Project and link it to your Agents. Only the owner can edit.
+			{hasVaults
+				? " Your Agents and the Clawdi CLI can use its keys; secret values stay hidden in the dashboard."
+				: ""}
+		</p>
 	);
 }
 

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -142,7 +142,7 @@ export default function SharePage({ token }: { token: string }) {
 				<CardHeader>
 					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
 						<Sparkles className="size-4" />
-						You've been invited to a Shared Project
+						Project invitation
 					</div>
 					<CardTitle className="mt-2 text-2xl">{data.project_name}</CardTitle>
 					<p className="text-sm text-muted-foreground">
@@ -163,14 +163,14 @@ export default function SharePage({ token }: { token: string }) {
 					{upgradeSucceeded ? (
 						<Alert>
 							<CheckCircle2 />
-							<AlertTitle>You're In</AlertTitle>
-							<AlertDescription>Invitation accepted. Opening Project…</AlertDescription>
+							<AlertTitle>Invitation accepted</AlertTitle>
+							<AlertDescription>Opening Project…</AlertDescription>
 						</Alert>
 					) : isOwner ? (
 						<Alert>
 							<ShieldCheck />
-							<AlertTitle>This is your project</AlertTitle>
-							<AlertDescription>You don't need to accept it — it's already yours.</AlertDescription>
+							<AlertTitle>This is your Project</AlertTitle>
+							<AlertDescription>You already have access.</AlertDescription>
 						</Alert>
 					) : isSignedIn ? (
 						<div className="space-y-3">
@@ -187,8 +187,7 @@ export default function SharePage({ token }: { token: string }) {
 								<Alert>
 									<CheckCircle2 />
 									<AlertDescription>
-										You're already a member. Open the Project from your dashboard, then add it to an
-										agent when needed.
+										You already have access. Open this Project from your dashboard.
 									</AlertDescription>
 								</Alert>
 							) : upgrade.error ? (
@@ -212,18 +211,13 @@ export default function SharePage({ token }: { token: string }) {
 								Sign in to accept
 							</Button>
 							<p className="text-xs text-muted-foreground">
-								Sign in or create a free account. After signing in, click Accept here to join the
-								Project.
+								Sign in or create an account to accept this invitation.
 							</p>
 							<details className="group rounded-lg border bg-muted/30 p-4">
 								<summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium marker:hidden">
 									<KeyRound className="size-4 shrink-0" />
-									<span>Advanced CLI Option</span>
+									<span>Accept with CLI</span>
 								</summary>
-								<p className="mt-1 text-xs text-muted-foreground">
-									Use this if you're already familiar with command line tools. The browser flow
-									above is the normal path.
-								</p>
 								<CopyableCommand command={`clawdi inbox accept ${buildLandingUrl(token)}`} />
 							</details>
 						</div>
@@ -285,7 +279,7 @@ function ErrorView({ error }: { error: unknown }) {
 				<Alert variant="destructive">
 					<AlertCircle />
 					<AlertTitle>Something went wrong</AlertTitle>
-					<AlertDescription>Share link unavailable. Ask the owner for a new link.</AlertDescription>
+					<AlertDescription>Couldn't load this invitation. Please try again.</AlertDescription>
 				</Alert>
 			</Shell>
 		);
@@ -304,30 +298,30 @@ function ErrorView({ error }: { error: unknown }) {
 function titleForError(code: ShareErrorCode): string {
 	switch (code) {
 		case "not_found":
-			return "Share Link Not Found";
+			return "Invite link not found";
 		case "revoked":
-			return "Share Link Turned Off";
+			return "Invite link unavailable";
 		case "already_member":
-			return "Already a Member";
+			return "Already joined";
 		case "already_owner":
-			return "That's Your Project";
+			return "This is your Project";
 		default:
-			return "Couldn't load this share";
+			return "Couldn't load invitation";
 	}
 }
 
 function describeError(code: ShareErrorCode): string {
 	switch (code) {
 		case "not_found":
-			return "This link doesn't exist. Ask the owner to send you a fresh one.";
+			return "Ask the owner for a new invite link.";
 		case "revoked":
-			return "The owner turned off this link. Ask them to send you a new one.";
+			return "This invite link is no longer active. Ask the owner for a new one.";
 		case "already_member":
-			return "You already accepted this share. Open it from your dashboard.";
+			return "You already have access. Open this Project from your dashboard.";
 		case "already_owner":
 			return "You own this Project. There is nothing to accept.";
 		default:
-			return "Please try again. If the problem persists, ping the owner.";
+			return "Try again. If the problem continues, contact the owner.";
 	}
 }
 

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/$section.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/$section.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { AgentProjectResourceCanonicalizer } from "@/components/dashboard/agent-project-resource-canonicalizer";
+import { AgentVaultsSurface } from "@/components/vault/agent-vaults-surface";
 import {
 	agentSectionLabel,
 	agentSectionLink,
@@ -47,7 +48,8 @@ function AgentSectionRoute() {
 	const { id } = Route.useParams();
 	const { section } = Route.useRouteContext();
 	const search = Route.useSearch();
-	if (section === "skills" || section === "vaults") {
+	if (section === "vaults") return <AgentVaultsSurface agentId={id} />;
+	if (section === "skills") {
 		return (
 			<AgentProjectResourceCanonicalizer agentId={id} resource={section} routeSearch={search} />
 		);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -339,6 +339,14 @@ Vaults are account-owned secret bundles. Projects attach to vaults through
 `vault_project_attachments`; keys remain on the vault. `vault_items` stores
 sectioned fields encrypted with AES-256-GCM using `VAULT_ENCRYPTION_KEY`.
 
+Dashboard Project pages own Vault inclusion through Add and Remove actions.
+The Agent Vaults page shows effective access across its Workspace and linked
+Projects, including the source of each Vault; it does not manage a second set
+of Agent-to-Vault links. Existing Workspace associations are preserved and can
+be removed deliberately from the Vault library. New dashboard additions target
+user-created Projects. Project sharing is the single sharing entry for Vault
+access; it does not change Vault ownership or expose plaintext values.
+
 The dashboard can list and mutate metadata but never receives plaintext values.
 Plaintext resolution is restricted to API-key auth through `/v1/vault/resolve`
 and `/v1/vault/resolve/bulk`. Agent-scoped resolution reads the Agent Workspace


### PR DESCRIPTION
Project sharing previously exposed invitation instructions, membership management, link creation/history, and bulk revocation together. The dialog now prioritizes inviting people and reviewing access, with one concise permission summary, compact pending/member rows, simple invite-link creation, and collapsed inactive-link and bulk-management controls. Newly created URLs remain available if refresh or clipboard access fails, and expired links are classified as inactive.

Agent Vaults now shows a deduplicated inventory from validated Workspace and linked-Project access, with source labels and matching overview counts. It no longer presents a second Agent-to-Vault linking flow. Project pages configure Vault inclusion with Add/Remove; Agent-scoped relation views are read-only. Existing Workspace associations remain visible and can be removed deliberately from the Vault library, while new UI additions target user Projects. Source navigation opens the correct Project configuration or Vault library. The redundant Share keys wizard and duplicate Project Vault navigation are removed; Project sharing remains the sharing entry.

Project invitation previews now use a single resource summary and permission explanation, with a clear accept action. Session sharing prioritizes the newest matching snapshot, discloses other active links, and states that anyone with the link can view it. Cached and newly created URLs remain usable after refresh failure; switching sharing targets resets dialog-local state. Notification invitations and public copy/export controls retain their existing focused flows.

No API/schema or data migration: existing members, links, Vault contents, and runtime permission enforcement are preserved. Private Workspace state is not silently migrated or deleted.

Validation in isolated Docker: 1166 web unit tests, typecheck, OSS build, and six production SSR checks passed. Twenty-eight OSS browser cases and the Hosted overview case passed, including targeted reruns after updating old UI assertions. Focused sharing coverage verifies expiry, create/copy failure recovery, cancellation/revocation, disclosure, and dialog lifecycle. Desktop/mobile sharing, Agent inventory, and Project configuration screenshots were reviewed. Biome and diff checks passed.

Additional Docker verification: all 1166 web unit tests, typecheck, Biome, OSS build and six production SSR checks passed. Eight focused browser scenarios cover Project sharing, responsive invitation acceptance, Session snapshot refresh failures and legacy-link revocation. Updated invitation screenshots were reviewed at desktop and mobile widths. The host hook references another workspace; its Biome check was performed in Docker instead.
