### PR TITLE
feat(cli): complete shared context and remote Skill workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ database migration, CI, and implementation details.
 
 ### Added
 
+- Share a whole Session, a conversation up to a chosen message, or one response
+  from the CLI. Review and turn off active links, or export without sharing.
+- `clawdi memory update` edits one Memory while preserving its category and source.
+- `clawdi agent skills` inspects, installs, and removes supported Cloud Agent
+  Skills from public GitHub or Library, with installation status and failures.
+
 - Agent Skills can be installed from Library or public GitHub repositories,
   with source details, updates, and removal from the Agent page.
 - Session search now matches visible user and assistant message text in addition to summaries, folders, and IDs. CLI and Web results show the best matching message excerpt; private reasoning, tool payloads, system messages, and hidden events remain excluded.
@@ -50,6 +56,10 @@ database migration, CI, and implementation details.
 - The product tour now shows messaging Channels and explains the separate bot, Agent link, and paired-chat boundaries.
 
 ### Fixed
+
+- Deploy with native saved AI Providers without supplying a model. Existing
+  scripts that pass `--model` still work and receive a warning; choose models
+  inside the Agent.
 
 - CLI 0.14.53 ships only the Python egress addon source in npm and native packages,
   rejecting generated Python caches and bytecode before publication.

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -21,6 +21,8 @@ from app.schemas.memory import (
     MemoryCreatedResponse,
     MemoryDeleteResponse,
     MemoryResponse,
+    MemoryUpdate,
+    MemoryUpdatedResponse,
 )
 from app.services.embedding import EmbeddingUpstreamError, resolve_embedder
 from app.services.memory_provider import get_memory_provider, memory_to_dict
@@ -253,6 +255,30 @@ async def create_memory(
             source_environment_id=source_environment_id,
         )
     )
+
+
+@router.patch("/{memory_id}")
+async def update_memory(
+    memory_id: UUID,
+    body: MemoryUpdate,
+    auth: AuthContext = Depends(require_scope("memories:write")),
+    db: AsyncSession = Depends(get_session),
+) -> MemoryUpdatedResponse:
+    """Replace exact-item content while preserving category, tags and provenance."""
+    finding = find_likely_secret(body.content)
+    if finding is not None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "memory_secret_rejected",
+                "message": secret_memory_warning(finding),
+                "secret_type": finding.label,
+            },
+        )
+    provider = await get_memory_provider(str(auth.user_id), db)
+    if not await provider.update(str(auth.user_id), str(memory_id), body.content):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Memory not found")
+    return MemoryUpdatedResponse(status="updated", memory_id=str(memory_id))
 
 
 @router.delete("/{memory_id}")

--- a/backend/app/routes/session_shares.py
+++ b/backend/app/routes/session_shares.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
 from sqlalchemy import func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import AuthContext, require_web_auth
+from app.core.auth import AuthContext, require_user_auth_unbound
 from app.core.config import settings
 from app.core.database import get_session
 from app.models.session import AgentEnvironment, Session
@@ -84,7 +85,8 @@ def _share_response(share: SessionShare) -> SessionShareResponse:
 async def list_all_session_shares(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=100),
-    auth: AuthContext = Depends(require_web_auth),
+    session_id: UUID | None = Query(default=None),
+    auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> Paginated[SessionShareListItemResponse]:
     """List every active Session link owned by the signed-in user."""
@@ -124,6 +126,9 @@ async def list_all_session_shares(
             ),
         )
     )
+    if session_id is not None:
+        snapshot_rows = snapshot_rows.where(Session.id == session_id)
+        live_rows = live_rows.where(Session.id == session_id)
     active_links = union_all(snapshot_rows, live_rows).subquery()
     total = int((await db.execute(select(func.count()).select_from(active_links))).scalar_one())
     rows = (
@@ -163,7 +168,7 @@ async def list_all_session_shares(
 @router.get("/sessions/{session_id}/shares")
 async def list_session_shares(
     session_id: UUID,
-    auth: AuthContext = Depends(require_web_auth),
+    auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> SessionSharesResponse:
     await _owned_session(db, auth, session_id)
@@ -186,7 +191,7 @@ async def list_session_shares(
 async def create_share(
     body: SessionShareCreate,
     session_id: UUID,
-    auth: AuthContext = Depends(require_web_auth),
+    auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> SessionShareResponse:
     session, agent_type = await _owned_session(db, auth, session_id)
@@ -221,9 +226,30 @@ async def create_share(
 @router.delete("/session-shares/{share_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_share(
     share_id: UUID,
-    auth: AuthContext = Depends(require_web_auth),
+    kind: Literal["snapshot", "live"] = Query(default="snapshot"),
+    auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> None:
+    """Revoke one owned snapshot or legacy live link by its exact inventory ID."""
+    if kind == "live":
+        permission = (
+            await db.execute(
+                select(SessionPermission)
+                .join(Session, Session.id == SessionPermission.session_id)
+                .where(
+                    SessionPermission.id == share_id,
+                    SessionPermission.kind == PERMISSION_KIND_LINK,
+                    Session.user_id == auth.user_id,
+                )
+                .with_for_update(of=SessionPermission)
+            )
+        ).scalar_one_or_none()
+        if permission is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Session share not found")
+        if permission.revoked_at is None:
+            permission.revoked_at = datetime.now(UTC)
+            await db.commit()
+        return
     share = (
         await db.execute(
             select(SessionShare)

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -97,7 +97,6 @@ from app.schemas.session import (
     SessionDetailResponse,
     SessionExtractResponse,
     SessionListItemResponse,
-    SessionMessageResponse,
     SessionMessagesPage,
     SessionPermissionCreate,
     SessionPermissionResponse,
@@ -105,6 +104,7 @@ from app.schemas.session import (
     SessionSearchAnchorResponse,
     SessionSearchMatchResponse,
     SessionSearchNavigationResponse,
+    SessionTimelineMessageResponse,
     SessionTimelinePage,
     SessionUploadResponse,
 )
@@ -3244,8 +3244,8 @@ async def get_session_content(
     # message bodies must not be reachable without sessions:read.
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
-) -> list[SessionMessageResponse]:
-    """Read session messages from FileStore, typed as SessionMessageResponse[]."""
+) -> list[SessionTimelineMessageResponse]:
+    """Read visible messages with canonical source positions for sharing."""
     bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
@@ -3261,7 +3261,7 @@ async def get_session_content(
     if not session_has_uploaded_content(session):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content not uploaded")
     try:
-        raw = await load_session_messages(session, file_store, db)
+        projection = await load_session_content_projection(session, file_store, db)
     except SessionContentMissing:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content file not found") from None
     except SessionContentUnavailable:
@@ -3274,7 +3274,10 @@ async def get_session_content(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
 
-    return [SessionMessageResponse.model_validate(m) for m in raw]
+    return [
+        SessionTimelineMessageResponse.model_validate({**message, "position": position})
+        for message, position in zip(projection.messages, projection.source_positions, strict=True)
+    ]
 
 
 @router.get("/sessions/{session_id}/messages")

--- a/backend/app/schemas/memory.py
+++ b/backend/app/schemas/memory.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MemoryCreate(BaseModel):
@@ -39,3 +39,12 @@ class MemoryDeleteResponse(BaseModel):
 class EmbedBackfillResponse(BaseModel):
     processed: int
     failed: int
+
+
+class MemoryUpdate(BaseModel):
+    content: str = Field(min_length=1, max_length=100_000, pattern=r"\S")
+
+
+class MemoryUpdatedResponse(BaseModel):
+    status: Literal["updated"]
+    memory_id: str

--- a/backend/tests/test_cli_oauth_auth.py
+++ b/backend/tests/test_cli_oauth_auth.py
@@ -840,3 +840,174 @@ async def test_oauth_revoke_hides_upstream_failure_details(
     assert response.status_code == 503
     assert response.json() == {"detail": "OAuth CLI revocation is temporarily unavailable"}
     assert refresh_token not in response.text
+
+
+@pytest.mark.asyncio
+async def test_session_share_cli_auth_ownership_and_exact_legacy_revocation(
+    raw_auth_client, db_session, seed_user, clerk_oauth_signing_key
+):
+    from app.models.session import Session
+    from tests.test_session_shares import _seed_session
+
+    browser = _session_token(
+        clerk_oauth_signing_key, seed_user.clerk_id, {"iss": _ISSUER, "aud": _AUDIENCE}
+    )
+    token = _oauth_access_token(clerk_oauth_signing_key, seed_user.clerk_id)
+    raw_auth_client.headers["Authorization"] = f"Bearer {token}"
+    session_id, _, _ = await _seed_session(raw_auth_client)
+    created = await raw_auth_client.post(
+        f"/v1/sessions/{session_id}/shares", json={"scope": "response", "position": 1}
+    )
+    assert created.status_code == 201, created.text
+    share_id = created.json()["id"]
+    session = await db_session.get(Session, uuid.UUID(session_id))
+    assert session is not None
+    for scopes, bound in ((["sessions:read"], False), (None, True), (None, False)):
+        key = f"clawdi_{uuid.uuid4().hex}"
+        db_session.add(
+            ApiKey(
+                user_id=seed_user.id,
+                key_hash=hashlib.sha256(key.encode()).hexdigest(),
+                key_prefix=key[:16],
+                label="Share boundary",
+                scopes=scopes,
+                environment_id=session.environment_id if bound else None,
+            )
+        )
+        await db_session.commit()
+        headers = {"Authorization": f"Bearer {key}"}
+        expected = 403 if scopes or bound else 200
+        listing = await raw_auth_client.get("/v1/session-shares", headers=headers)
+        assert listing.status_code == expected, listing.text
+        if expected == 403:
+            for method, path, kwargs in (
+                ("POST", f"/v1/sessions/{session_id}/shares", {"json": {}}),
+                ("DELETE", f"/v1/session-shares/{share_id}", {}),
+                ("DELETE", f"/v1/session-shares/{share_id}?kind=live", {}),
+            ):
+                denied = await raw_auth_client.request(method, path, headers=headers, **kwargs)
+                assert denied.status_code == 403, denied.text
+    foreign = User(clerk_id=f"foreign_{uuid.uuid4().hex}", email="foreign-share@test.invalid")
+    db_session.add(foreign)
+    await db_session.commit()
+    foreign_headers = {
+        "Authorization": f"Bearer {_oauth_access_token(clerk_oauth_signing_key, foreign.clerk_id)}"
+    }
+    assert (await raw_auth_client.get("/v1/session-shares", headers=foreign_headers)).json()[
+        "items"
+    ] == []
+    assert (
+        await raw_auth_client.delete(f"/v1/session-shares/{share_id}", headers=foreign_headers)
+    ).status_code == 404
+    assert (
+        await raw_auth_client.post(
+            f"/v1/sessions/{session_id}/shares", json={}, headers=foreign_headers
+        )
+    ).status_code == 404
+
+    live = await raw_auth_client.post(
+        f"/v1/sessions/{session_id}/permissions",
+        json={"kind": "link"},
+        headers={"Authorization": f"Bearer {browser}"},
+    )
+    assert live.status_code == 200, live.text
+    live_id = live.json()["id"]
+    assert (await raw_auth_client.delete(f"/v1/session-shares/{live_id}")).status_code == 404
+    assert (
+        await raw_auth_client.delete(
+            f"/v1/session-shares/{live_id}?kind=live", headers=foreign_headers
+        )
+    ).status_code == 404
+    assert (
+        await raw_auth_client.delete(f"/v1/session-shares/{live_id}?kind=live")
+    ).status_code == 204
+    new_live = await raw_auth_client.post(
+        f"/v1/sessions/{session_id}/permissions",
+        json={"kind": "link"},
+        headers={"Authorization": f"Bearer {browser}"},
+    )
+    assert new_live.status_code == 200
+    assert new_live.json()["id"] != live_id
+    assert (
+        await raw_auth_client.delete(f"/v1/session-shares/{live_id}?kind=live")
+    ).status_code == 204
+    remaining = (
+        await raw_auth_client.get("/v1/session-shares", params={"session_id": session_id})
+    ).json()
+    assert {item["id"] for item in remaining["items"]} == {share_id, new_live.json()["id"]}
+
+
+@pytest.mark.asyncio
+async def test_memory_update_cli_preserves_metadata_and_enforces_scope_owner_and_secrets(
+    raw_auth_client, db_session, seed_user, clerk_oauth_signing_key
+):
+    from app.models.memory import Memory
+
+    memory = Memory(
+        user_id=seed_user.id,
+        content="Old preference",
+        category="preference",
+        source="manual",
+        tags=["editor"],
+        access_count=7,
+    )
+    db_session.add(memory)
+    await db_session.commit()
+    await db_session.refresh(memory)
+    original_created_at = memory.created_at
+    path = f"/v1/memories/{memory.id}"
+    raw_auth_client.headers["Authorization"] = (
+        f"Bearer {_oauth_access_token(clerk_oauth_signing_key, seed_user.clerk_id)}"
+    )
+    result = await raw_auth_client.patch(path, json={"content": "Use tabs"})
+    assert result.status_code == 200, result.text
+    assert result.json() == {"status": "updated", "memory_id": str(memory.id)}
+    await db_session.refresh(memory)
+    assert (
+        memory.content,
+        memory.category,
+        memory.source,
+        memory.tags,
+        memory.access_count,
+        memory.created_at,
+    ) == (
+        "Use tabs",
+        "preference",
+        "manual",
+        ["editor"],
+        7,
+        original_created_at,
+    )
+    for scopes, expected in ((["memories:read"], 403), (["memories:write"], 200)):
+        key = f"clawdi_{uuid.uuid4().hex}"
+        db_session.add(
+            ApiKey(
+                user_id=seed_user.id,
+                key_hash=hashlib.sha256(key.encode()).hexdigest(),
+                key_prefix=key[:16],
+                label="Memory scope",
+                scopes=scopes,
+            )
+        )
+        await db_session.commit()
+        result = await raw_auth_client.patch(
+            path, json={"content": "Keep tabs"}, headers={"Authorization": f"Bearer {key}"}
+        )
+        assert result.status_code == expected, result.text
+    foreign = User(clerk_id=f"foreign_{uuid.uuid4().hex}", email="foreign-memory@test.invalid")
+    db_session.add(foreign)
+    await db_session.commit()
+    foreign_token = _oauth_access_token(clerk_oauth_signing_key, foreign.clerk_id)
+    denied = await raw_auth_client.patch(
+        path,
+        json={"content": "Overwrite"},
+        headers={"Authorization": f"Bearer {foreign_token}"},
+    )
+    assert denied.status_code == 404
+    secret = "ghp_" + "a" * 36
+    rejected = await raw_auth_client.patch(path, json={"content": secret})
+    assert rejected.status_code == 400
+    assert secret not in rejected.text
+    assert (await raw_auth_client.patch(path, json={"content": "   "})).status_code == 422
+    await db_session.refresh(memory)
+    assert memory.content == "Keep tabs"

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -666,18 +666,29 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     projected = await client.get(f"/v1/sessions/{session.id}/content")
     assert projected.status_code == 200, projected.text
     assert projected.json() == [
-        {"role": "user", "content": "inspect this", "model": None, "timestamp": None},
+        {
+            "role": "user",
+            "content": "inspect this",
+            "model": None,
+            "timestamp": None,
+            "kind": "message",
+            "position": 1,
+        },
         {
             "role": "assistant",
             "content": "visible answer",
             "model": "claude-sonnet",
             "timestamp": None,
+            "kind": "message",
+            "position": 4,
         },
         {
             "role": "assistant",
             "content": "appended left\x00right answer",
             "model": None,
             "timestamp": None,
+            "kind": "message",
+            "position": 6,
         },
     ]
     assert "private context" not in projected.text

--- a/backend/tests/test_session_shares.py
+++ b/backend/tests/test_session_shares.py
@@ -101,7 +101,9 @@ def _event_chunk(events: list[dict[str, Any]]) -> tuple[bytes, str]:
     return data, hashlib.sha256(data).hexdigest()
 
 
-async def _seed_event_session(client: httpx.AsyncClient) -> tuple[str, str, str, str]:
+async def _seed_event_session(
+    client: httpx.AsyncClient, events: list[dict[str, Any]] | None = None
+) -> tuple[str, str, str, str]:
     registered = await client.post(
         "/v1/agents",
         json={
@@ -132,7 +134,7 @@ async def _seed_event_session(client: httpx.AsyncClient) -> tuple[str, str, str,
     )
     assert batch.status_code == 200, batch.text
 
-    events = [
+    events = events or [
         _event(0, "user", "user", "Original question"),
         _event(1, "assistant", "assistant", "Original answer"),
     ]
@@ -376,3 +378,46 @@ async def test_session_share_reports_storage_outages(
     response = await anon_client.get(f"/v1/public/session-shares/{created.json()['id']}/messages")
     assert response.status_code == 503
     assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_owner_content_positions_survive_hidden_and_tool_gaps(client, anon_client):
+    hidden = _event(1, "hidden", "assistant", "Private hidden reasoning")
+    hidden["semantics"] = {
+        "lifecycle": "active",
+        "display": "hidden",
+        "compressed_summary": False,
+        "display_kind": "ignored_text",
+    }
+    tool = _event(2, "tool", "assistant", "unused")
+    tool.pop("role")
+    tool.pop("parts")
+    tool.update(type="tool_call", call_id="call-1", name="read", arguments_json="{}")
+    tool["event_id"] = hashlib.sha256(
+        canonical_event_json({"source": tool["source"], "type": "tool_call"})
+    ).hexdigest()
+    events = [
+        _event(0, "user", "user", "Question"),
+        hidden,
+        tool,
+        _event(3, "answer", "assistant", "Visible answer"),
+    ]
+    session_id, _, _, _ = await _seed_event_session(client, events)
+    content = await client.get(f"/v1/sessions/{session_id}/content")
+    assert content.status_code == 200, content.text
+    assert [item["position"] for item in content.json()] == [0, 3]
+    assert "Private hidden" not in content.text
+    for scope in ("through", "response"):
+        share = await client.post(
+            f"/v1/sessions/{session_id}/shares",
+            json={"scope": scope, "position": content.json()[-1]["position"]},
+        )
+        assert share.status_code == 201, share.text
+        public = await anon_client.get(f"/v1/public/session-shares/{share.json()['id']}/messages")
+        assert [item["content"] for item in public.json()["items"]] == (
+            ["Question", "Visible answer"] if scope == "through" else ["Visible answer"]
+        )
+    invalid = await client.post(
+        f"/v1/sessions/{session_id}/shares", json={"scope": "response", "position": 1}
+    )
+    assert invalid.status_code == 409

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -204,7 +204,11 @@ Deploy Wizard:
 clawdi deploy
 clawdi deploy --runtime hermes --provider managed --model <id> \
   --compute basic --request-id <uuid> --yes --json
-clawdi deploy --provider <saved-provider-id> --model <id> \
+# Native saved provider (credentials only):
+clawdi deploy --provider <native-provider-id> \
+  --compute basic --request-id <uuid> --yes --json
+# Custom saved provider:
+clawdi deploy --provider <custom-provider-id> --model <id> \
   --compute basic --request-id <uuid> --yes --json
 clawdi deploy --compute performance --term 12 --payment wallet \
   --request-id <uuid> --yes --json
@@ -220,8 +224,81 @@ deterministic automation and reuse the same request ID after an ambiguous
 create or checkout response.
 `--provider` also accepts an exact Cloud saved-provider id. The CLI reads only
 secret-free provider metadata and sends a provider binding/bootstrap; it never
-accepts or prints the saved credential. Pass `--model` unless that provider has
-one unambiguous default model.
+accepts or prints the saved credential. Native saved providers do not prompt
+for or require a model: choose models inside
+the Agent. Legacy `--model` is accepted with a stderr warning and omitted from
+the binding, preserving existing model choices. Custom saved providers require
+`--model` unless they have one unambiguous default. Provider IDs come from Cloud
+AI Providers, not the local `ai-provider list` catalog.
+
+## Cloud context and remote Skills
+
+These commands use the configured Cloud API and require login. `session list`
+continues to read local history; `session search`, `read`, and `export` use Cloud
+session UUIDs. Export writes owner Markdown to stdout and never creates a link.
+`--json` exports owner metadata and messages instead.
+
+```bash
+clawdi session search "workspace setup" --json
+clawdi session read <cloud-session-id> --json
+clawdi session export <cloud-session-id> > session.md
+clawdi session share <cloud-session-id> --yes --json
+clawdi session share <cloud-session-id> --through <position> --yes --json
+clawdi session share <cloud-session-id> --response <position> --yes --json
+clawdi session shares <cloud-session-id> --json
+clawdi session unshare <share-id> --yes
+clawdi session unshare <legacy-link-id> --legacy --yes
+clawdi memory update <full-memory-id> "Prefer tabs" --json
+```
+
+Sharing publishes an immutable whole-session snapshot by default. Scoped shares
+use the canonical `position` returned by `session read --json`; these positions
+may have gaps from hidden/tool events, so never enumerate the filtered messages.
+`--response` requires an assistant message. Publication and revocation prompt
+unless `--yes` is supplied; automation requires it. `shares` includes both active
+snapshot and legacy live links, with `--page` and `--limit` pagination. Revoke
+uses the exact inventory link ID; `--legacy` selects a legacy link explicitly
+and retrying it cannot revoke a newly created replacement. Sharing requires
+OAuth CLI or a fully unbound account key; scoped and Agent-bound keys are denied.
+Memory update requires `memories:write`, retains metadata through the configured
+provider service, and rejects likely secrets on both client and server.
+
+```bash
+clawdi agent skills list <agent-id> --json
+clawdi agent skills read <agent-id> <skill-key>
+clawdi agent skills install <agent-id> --github owner/repo --path skills/review
+clawdi agent skills install <agent-id> --library <skill-id>
+clawdi agent skills rm <agent-id> <skill-key>
+```
+
+Remote targets are stable Cloud Agent UUIDs. Local `skill --agent <type>` keeps
+its existing meaning. Library operations use Cloud references and preserve the
+source Skill. Linked Project and bundled Skills are read-only here. GitHub
+operations use Hosted's native source validation and capability gate, with the
+canonical OAuth CLI login. Unsupported runtimes/capabilities fail explicitly;
+no local installation is substituted. `list` includes desired state, observed
+convergence and failed removals; failed status sets exit code 1. `read` prints
+instructions on a terminal and structured detail with `--json` or a pipe.
+
+Accepted requests are not proof of runtime application. GitHub writes carry a
+fresh resource version and a generated or caller-supplied `--request-id`. After
+an ambiguous response, inspect inventory. Exact replay must reuse **both** the
+original `--request-id` and `--resource-version` printed in the result/error;
+the Hosted fingerprint includes that version. Version conflicts require
+reviewing current state before submitting a new request.
+
+Against local Cloud/Hosted APIs with suitable fixtures, verify that
+`session read --json` exposes canonical positions, owner exports create no
+links, revoked links disappear from `shares`, and `agent skills list` reports
+actual convergence. Run the focused hermetic regressions:
+
+```bash
+bash scripts/test.sh cli tests/commands/deploy.test.ts tests/commands/session.test.ts tests/commands/agent-skills.test.ts
+bash scripts/test.sh backend tests/test_cli_oauth_auth.py tests/test_session_shares.py
+```
+
+Done: both commands exit 0. The backend tests cover real OAuth/API-key gates,
+exact legacy revocation, hidden/tool position gaps and Memory metadata/ownership.
 
 ## Typecheck / test / build
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,9 +5,9 @@ local AI agents, syncs sessions and skills, manages memory and vault workflows,
 installs the MCP server, and controls the background sync daemon.
 
 For product usage, start with the
-[Connected Agent quickstart](https://docs.clawdi.ai/getting-started/quickstart). For the full command reference, read the
-[top-level README](../../README.md#cli-reference). For contributor workflows, read
-[`docs/cli-development.md`](../../docs/cli-development.md). For a full local
+[Connected Agent quickstart](https://docs.clawdi.ai/getting-started/quickstart).
+For Cloud context and remote Skill commands, testing, and contributor workflows,
+read [`docs/cli-development.md`](../../docs/cli-development.md). For a full local
 backend + dashboard + CLI stack, use the canonical runbook in
 [`AGENTS.md`](../../AGENTS.md#local-end-to-end).
 

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -36,6 +36,9 @@ save routine task completion, code facts, speculation, or plaintext secrets; use
 remember only the exact `clawdi://` reference. List before updating or deleting unless the user
 already supplied the exact memory ID; never infer which stored item to mutate.
 
+CLI fallback for exact updates: `clawdi memory update <full-memory-id> "new content" --json`.
+It preserves metadata; find the exact ID before changing it.
+
 ## Sessions
 
 - Use `session_list` to browse recent sessions or filter by time, Agent, or Project.
@@ -47,6 +50,19 @@ contents. For a request to open a specific unnamed past conversation, use `sessi
 to find the UUID and then read the selected match.
 
 Do NOT call WebFetch on `cloud.clawdi.ai/s/...` URLs — `session_get` is the right tool and avoids the WebFetch permission prompt.
+
+CLI fallback: `clawdi session search "query" --json`, then `clawdi session read <cloud-session-id> --json`.
+`session list` is local; `session export <cloud-session-id>` exports owner Markdown without
+publishing. Publish only with user authorization: `session share <cloud-session-id> --yes`.
+For `--through` or `--response`, use the returned canonical message `position`, never a
+filtered array index. `session shares --json` lists active links; revoke the exact link
+ID with `session unshare <share-id> --yes` (add `--legacy` for `kind=live`).
+
+Remote Skill operations use `clawdi agent skills list/read/install/rm <agent-id>`; local
+`skill --agent <type>` remains separate. Use `install --github owner/repo --path skills/name`
+or `install --library <skill-id>`. Accepted intent is not applied state: check `list` for
+convergence and failures. GitHub exact replay needs both original `--request-id` and
+`--resource-version` from the result/error.
 
 ## Projects
 

--- a/packages/cli/src/commands/agent-skills.ts
+++ b/packages/cli/src/commands/agent-skills.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "node:crypto";
+import { ApiClient, ApiError, unwrap } from "../lib/api-client";
+import { isLoggedIn } from "../lib/config";
+import { HostedDeployClient } from "../lib/hosted-deploy-client";
+import { sanitizeMetadata, stripTerminalEscapes } from "../lib/sanitize";
+
+function requireAgentId(agentId: string): void {
+	if (!isLoggedIn()) throw new Error("Not logged in. Run `clawdi auth login` first.");
+	if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(agentId)) {
+		throw new Error("Use the full remote Cloud Agent UUID, not a local --agent type.");
+	}
+}
+
+async function inventory(agentId: string) {
+	requireAgentId(agentId);
+	try {
+		return unwrap(
+			await new ApiClient().GET("/v1/agents/{agent_id}/skills", {
+				params: { path: { agent_id: agentId } },
+			}),
+		);
+	} catch (error) {
+		if (error instanceof ApiError && error.body.includes("hosted_skill_runtime_required")) {
+			throw new Error(
+				"Remote Skills require a Hosted Hermes or OpenClaw Agent. Use `skill --agent <type>` for local Skills.",
+			);
+		}
+		throw error;
+	}
+}
+
+async function hostedWorkspace(agentId: string) {
+	const client = new HostedDeployClient();
+	const deployment = await client.getAgentDeployment(agentId);
+	const deploymentId = deployment.resource.id;
+	const workspace = await client.getWorkspaceSkills(deploymentId);
+	return { client, deploymentId, workspace };
+}
+
+function print(value: unknown): void {
+	console.log(JSON.stringify(value, null, 2));
+}
+
+export async function agentSkillsList(agentId: string, opts: { json?: boolean } = {}) {
+	const desired = await inventory(agentId);
+	const { workspace } = await hostedWorkspace(agentId);
+	const failed =
+		desired.skills.some((item) => item.convergence === "failed") ||
+		Boolean(desired.removal_failures?.length) ||
+		workspace.items?.some((item) => item.status === "failed");
+	if (failed) process.exitCode = 1;
+	if (opts.json || !process.stdout.isTTY) {
+		print({ ...desired, workspace });
+		return;
+	}
+	for (const skill of desired.skills) {
+		console.log(
+			`${sanitizeMetadata(skill.skill_key)}  ${skill.source}  ${skill.convergence}${skill.read_only ? "  read-only" : ""}`,
+		);
+		if (skill.observation_error_code)
+			console.log(`  ${sanitizeMetadata(skill.observation_error_code)}`);
+	}
+	for (const item of workspace.items ?? []) {
+		console.log(`${sanitizeMetadata(item.skill_key)}  GitHub request: ${item.status}`);
+		if (item.failure_message) console.log(`  ${sanitizeMetadata(item.failure_message)}`);
+	}
+	for (const failure of desired.removal_failures ?? []) {
+		console.log(
+			`${sanitizeMetadata(failure.skill_key)}  removal failed: ${sanitizeMetadata(failure.observation_error_code)}`,
+		);
+	}
+	if (!workspace.capability.available)
+		console.log(`GitHub Skills unavailable: ${workspace.capability.reason}`);
+	console.log(
+		"Only installed convergence confirms runtime application; requested/managed state does not.",
+	);
+}
+
+export async function agentSkillsRead(
+	agentId: string,
+	skillKey: string,
+	opts: { json?: boolean } = {},
+) {
+	const desired = await inventory(agentId);
+	const skill = desired.skills.find((item) => item.skill_key === skillKey);
+	if (skill?.authority === "cloud" && skill.project_id && skill.source_skill_key) {
+		const detail = unwrap(
+			await new ApiClient().GET("/v1/projects/{project_id}/skills/{skill_key}", {
+				params: { path: { project_id: skill.project_id, skill_key: skill.source_skill_key } },
+			}),
+		);
+		if (opts.json || !process.stdout.isTTY) print({ ...skill, detail });
+		else console.log(stripTerminalEscapes(detail.content ?? "Skill content is unavailable."));
+		return;
+	}
+	if (skill?.source === "bundled") {
+		throw new Error("Bundled Skill content is not exposed by the remote Skill API.");
+	}
+	const { client, deploymentId } = await hostedWorkspace(agentId);
+	const detail = await client.getWorkspaceSkill(deploymentId, skillKey);
+	if (opts.json || !process.stdout.isTTY) print({ ...skill, detail });
+	else console.log(stripTerminalEscapes(detail.content));
+}
+
+interface InstallOptions {
+	json?: boolean;
+	github?: string;
+	path?: string;
+	library?: string;
+	requestId?: string;
+	resourceVersion?: string;
+}
+
+export async function agentSkillsInstall(agentId: string, opts: InstallOptions) {
+	requireAgentId(agentId);
+	if (Boolean(opts.github) === Boolean(opts.library)) {
+		throw new Error(
+			"Choose exactly one source: --github <public-repository> or --library <skill-id>.",
+		);
+	}
+	if (opts.library) {
+		if (opts.path || opts.requestId || opts.resourceVersion)
+			throw new Error("--path, --request-id and --resource-version apply only to GitHub installs.");
+		const result = unwrap(
+			await new ApiClient().PUT("/v1/agents/{agent_id}/skill-references/{skill_id}", {
+				params: { path: { agent_id: agentId, skill_id: opts.library } },
+			}),
+		);
+		if (opts.json || !process.stdout.isTTY) print({ status: "accepted", ...result });
+		else
+			console.log(
+				`Library Skill ${result.desired_state} request accepted. Run \`agent skills list ${agentId}\` to check application.`,
+			);
+		return;
+	}
+	await mutateGithubSkill(
+		agentId,
+		{ repo: opts.github ?? "", path: opts.path },
+		undefined,
+		opts.requestId,
+		opts.resourceVersion,
+		opts.json,
+	);
+}
+
+export async function agentSkillsRemove(
+	agentId: string,
+	skillKey: string,
+	opts: { requestId?: string; resourceVersion?: string; json?: boolean } = {},
+) {
+	const desired = await inventory(agentId);
+	const skill = desired.skills.find((item) => item.skill_key === skillKey);
+	if (skill?.read_only)
+		throw new Error(
+			"This Skill is managed by its linked Project or runtime and cannot be removed here.",
+		);
+	if (skill?.authority === "cloud" && skill.skill_id) {
+		if (opts.requestId || opts.resourceVersion)
+			throw new Error("--request-id and --resource-version apply only to GitHub removals.");
+		const result = unwrap(
+			await new ApiClient().DELETE("/v1/agents/{agent_id}/skill-references/{skill_id}", {
+				params: { path: { agent_id: agentId, skill_id: skill.skill_id } },
+			}),
+		);
+		if (opts.json || !process.stdout.isTTY) print({ status: "accepted", ...result });
+		else
+			console.log(
+				`Library Skill ${result.desired_state} request accepted. Run \`agent skills list ${agentId}\` to check application.`,
+			);
+		return;
+	}
+	// Hosted may still have a requested GitHub entry before Cloud projects it.
+	await mutateGithubSkill(
+		agentId,
+		undefined,
+		skillKey,
+		opts.requestId,
+		opts.resourceVersion,
+		opts.json,
+	);
+}
+
+async function mutateGithubSkill(
+	agentId: string,
+	source: { repo: string; path?: string } | undefined,
+	skillKey: string | undefined,
+	requestedId?: string,
+	requestedVersion?: string,
+	json?: boolean,
+) {
+	const requestId = requestedId ?? randomUUID();
+	if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(requestId)) {
+		throw new Error("--request-id must be a UUID; reuse it only for the same request.");
+	}
+	if (
+		requestedVersion !== undefined &&
+		(!requestedId ||
+			!/^[\x21-\x7e]{1,128}$/.test(requestedVersion) ||
+			/["\\]/.test(requestedVersion))
+	) {
+		throw new Error(
+			"--resource-version must be an unquoted strong resource version accompanied by --request-id.",
+		);
+	}
+	const { client, deploymentId, workspace } = await hostedWorkspace(agentId);
+	const resourceVersion = requestedVersion ?? workspace.deployment_resource_version;
+	if (!workspace.capability.available) {
+		throw new Error(
+			`Remote GitHub Skills are unavailable: ${workspace.capability.reason}. Upgrade the Agent and wait for capability observation.`,
+		);
+	}
+	if (
+		!source &&
+		!requestedVersion &&
+		!workspace.items?.some((item) => item.skill_key === skillKey)
+	) {
+		throw new Error(
+			"GitHub Skill not found in the Hosted desired inventory; no change was requested.",
+		);
+	}
+	try {
+		const result = source
+			? await client.installWorkspaceSkill(deploymentId, source, resourceVersion, requestId)
+			: await client.removeWorkspaceSkill(deploymentId, skillKey ?? "", resourceVersion, requestId);
+		if (json || !process.stdout.isTTY) {
+			print({
+				acceptance: "accepted",
+				request_id: requestId,
+				request_resource_version: resourceVersion,
+				...result,
+			});
+		} else {
+			console.log(
+				`${sanitizeMetadata(result.skill_key)}: ${result.desired_state} request ${result.status}.`,
+			);
+			if (result.failure_message) console.log(sanitizeMetadata(result.failure_message));
+			console.log(`Request ID: ${requestId}; resource version: ${resourceVersion}`);
+			console.log(`Run \`agent skills list ${agentId}\` to check runtime application.`);
+		}
+		if (result.status === "failed") process.exitCode = 1;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Remote Skill request failed.";
+		throw new Error(
+			`${message} Request ID: ${requestId}; resource version: ${resourceVersion}. Replay only with the same --request-id and --resource-version. Inspect \`agent skills list ${agentId}\` before retrying; acceptance does not prove application.`,
+		);
+	}
+}

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -728,7 +728,7 @@ export async function runDeployFlow(
 	if (aiMode === "saved" && !selectedSavedProvider) {
 		throw new DeployInputError(
 			"provider_missing",
-			`Saved AI provider ${providerId ?? ""} was not found. Pass its exact provider id or run \`clawdi ai-provider list\`.`,
+			`Saved AI provider ${providerId ?? ""} was not found. Pass its exact provider id from Cloud AI Providers.`,
 		);
 	}
 	const selectedProviderIssue = selectedSavedProvider
@@ -744,7 +744,15 @@ export async function runDeployFlow(
 		);
 	}
 
-	let model = parsed.model ?? (aiMode === "managed" ? defaultManagedModel(managedModels) : "");
+	const nativeProvider = selectedSavedProvider?.configuration_mode === "native";
+	if (nativeProvider && parsed.model) {
+		console.error(
+			"Warning: --model is ignored for native saved providers; choose models inside the Agent. Existing model choices are preserved.",
+		);
+	}
+	let model = nativeProvider
+		? ""
+		: (parsed.model ?? (aiMode === "managed" ? defaultManagedModel(managedModels) : ""));
 	if (aiMode === "managed") {
 		if (managedModels.length === 0) {
 			throw new Error(
@@ -762,7 +770,7 @@ export async function runDeployFlow(
 				defaultManagedModel(managedModels),
 			);
 		}
-	} else if (selectedSavedProvider) {
+	} else if (selectedSavedProvider && selectedSavedProvider.configuration_mode !== "native") {
 		const catalog = selectedSavedProvider.models ?? [];
 		const automaticModel = savedProviderDefaultModel(selectedSavedProvider);
 		if (interactive && !parsed.model) {
@@ -1064,7 +1072,7 @@ export async function runDeployFlow(
 			aiMode === "managed"
 				? `Clawdi AI · ${model}`
 				: aiMode === "saved"
-					? `${selectedSavedProvider ? savedProviderLabel(selectedSavedProvider) : providerId} · ${model}`
+					? `${selectedSavedProvider ? savedProviderLabel(selectedSavedProvider) : providerId}${model ? ` · ${model}` : " · choose models inside Agent"}`
 					: "Configure inside agent"
 		}`,
 		`Compute: ${planLabel(computePlanSlug)}${includedBasic ? " · included" : ` · ${paidSelection?.billingTermMonths} month term`}`,
@@ -1234,7 +1242,7 @@ export async function runDeployFlow(
 		runtime,
 		compute_plan_slug: computePlanSlug,
 		ai_provider: aiMode === "saved" ? (selectedSavedProvider?.provider_id ?? "") : aiMode,
-		primary_model: aiMode === "unmanaged" ? null : model,
+		primary_model: aiMode === "unmanaged" || !model ? null : model,
 		payment: includedBasic
 			? { kind: "included_basic" }
 			: payment === "wallet"

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -128,3 +128,23 @@ export async function memoryRm(id: string) {
 	unwrap(await api.DELETE("/v1/memories/{memory_id}", { params: { path: { memory_id: id } } }));
 	console.log(chalk.green("✓ Deleted memory"));
 }
+
+export async function memoryUpdate(id: string, content: string, opts: { json?: boolean } = {}) {
+	requireAuth();
+	if (!content.trim() || content.length > 100_000) {
+		throw new Error("Memory content must contain text and be at most 100000 characters.");
+	}
+	const finding = findLikelySecret(content);
+	if (finding) throw new Error(formatSecretMemoryWarning(finding));
+	const result = unwrap(
+		await new ApiClient().PATCH("/v1/memories/{memory_id}", {
+			params: { path: { memory_id: id } },
+			body: { content },
+		}),
+	);
+	console.log(
+		opts.json || !process.stdout.isTTY
+			? JSON.stringify(result)
+			: `Updated memory ${sanitizeMetadata(result.memory_id)}; metadata preserved.`,
+	);
+}

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import * as p from "@clack/prompts";
 import chalk from "chalk";
 import type { RawSession } from "../adapters/base";
 import { type AgentType, adapterRegistry } from "../adapters/registry";
@@ -12,6 +13,7 @@ import {
 	listRegisteredAgentTypes,
 	resolveTargetAgentTypes,
 } from "../lib/select-adapter";
+import { isInteractive } from "../lib/tty";
 
 interface SessionListOpts {
 	agent?: string;
@@ -340,4 +342,122 @@ export async function sessionExtract(sessionId: string, opts: SessionExtractOpts
 		}
 		throw e;
 	}
+}
+
+export async function sessionExport(sessionId: string, opts: { json?: boolean } = {}) {
+	if (opts.json) return sessionRead(sessionId, { json: true });
+	if (!requireCloudSessionAuth()) return;
+	const markdown = unwrap(
+		await new ApiClient().GET("/v1/sessions/{session_id}/export.md", {
+			params: { path: { session_id: sessionId } },
+			parseAs: "text",
+		}),
+	);
+	process.stdout.write(process.stdout.isTTY ? stripTerminalEscapes(markdown) : markdown);
+}
+
+export async function sessionShareCreate(
+	sessionId: string,
+	opts: { through?: string; response?: string; json?: boolean; yes?: boolean } = {},
+) {
+	if (!requireCloudSessionAuth()) return;
+	if (opts.through !== undefined && opts.response !== undefined) {
+		throw new Error("Use only one of --through or --response.");
+	}
+	const scope =
+		opts.through !== undefined ? "through" : opts.response !== undefined ? "response" : "session";
+	const rawPosition = opts.through ?? opts.response;
+	const position = rawPosition === undefined ? undefined : Number(rawPosition);
+	if (
+		rawPosition !== undefined &&
+		(!/^\d+$/.test(rawPosition) || !Number.isSafeInteger(position))
+	) {
+		throw new Error("Message position must be a non-negative integer from `session read --json`.");
+	}
+	if (
+		!(await confirmSessionLink(
+			`Publish a public ${scope} snapshot of session ${sanitizeMetadata(sessionId)}? Anyone with the link can read it.`,
+			opts.yes,
+		))
+	)
+		return;
+	const share = unwrap(
+		await new ApiClient().POST("/v1/sessions/{session_id}/shares", {
+			params: { path: { session_id: sessionId } },
+			body: { scope, position },
+		}),
+	);
+	console.log(
+		opts.json || !process.stdout.isTTY ? JSON.stringify(share, null, 2) : share.share_url,
+	);
+}
+
+export async function sessionShareList(
+	sessionId: string | undefined,
+	opts: { page?: string; limit?: string; json?: boolean } = {},
+) {
+	if (!requireCloudSessionAuth()) return;
+	const page = opts.page === undefined ? 1 : Number(opts.page);
+	const limit = opts.limit === undefined ? 25 : Number(opts.limit);
+	if (
+		!Number.isSafeInteger(page) ||
+		page < 1 ||
+		!Number.isSafeInteger(limit) ||
+		limit < 1 ||
+		limit > 100
+	) {
+		throw new Error("--page must be a positive integer; --limit must be between 1 and 100.");
+	}
+	const result = unwrap(
+		await new ApiClient().GET("/v1/session-shares", {
+			params: { query: { page, page_size: limit, session_id: sessionId } },
+		}),
+	);
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+	for (const link of result.items) {
+		console.log(`${link.id}  ${link.kind}  ${link.scope}  ${sanitizeMetadata(link.session_title)}`);
+		console.log(`  ${stripTerminalEscapes(link.share_url)}`);
+	}
+	console.log(
+		chalk.gray(`Page ${result.page}: ${result.items.length} of ${result.total} active links`),
+	);
+}
+
+export async function sessionShareRevoke(
+	shareId: string,
+	opts: { yes?: boolean; legacy?: boolean; json?: boolean } = {},
+) {
+	if (!requireCloudSessionAuth()) return;
+	if (
+		!(await confirmSessionLink(
+			`Revoke ${opts.legacy ? "legacy live" : "snapshot"} link ${sanitizeMetadata(shareId)}?`,
+			opts.yes,
+		))
+	)
+		return;
+	unwrap(
+		await new ApiClient().DELETE("/v1/session-shares/{share_id}", {
+			params: { path: { share_id: shareId }, query: { kind: opts.legacy ? "live" : "snapshot" } },
+		}),
+	);
+	console.log(
+		opts.json || !process.stdout.isTTY
+			? JSON.stringify({ id: shareId, status: "revoked" })
+			: `Revoked ${opts.legacy ? "legacy live" : "snapshot"} link ${sanitizeMetadata(shareId)}.`,
+	);
+}
+
+async function confirmSessionLink(message: string, yes?: boolean): Promise<boolean> {
+	if (yes) return true;
+	if (!isInteractive())
+		throw new Error("Pass --yes to confirm this session link change in non-interactive mode.");
+	const confirmed = await p.confirm({ message, initialValue: false });
+	if (p.isCancel(confirmed) || !confirmed) {
+		process.exitCode = 1;
+		return false;
+	}
+	return true;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -115,6 +115,9 @@ program
 Examples:
   $ clawdi deploy
   $ clawdi deploy --runtime hermes --provider managed --model <id> --compute basic --request-id <uuid> --yes --json
+  # Native saved provider: choose models inside the Agent
+  $ clawdi deploy --provider <saved-provider-id> --compute basic --request-id <uuid> --yes --json
+  # Custom saved provider: select its model
   $ clawdi deploy --provider <saved-provider-id> --model <id> --compute basic --request-id <uuid> --yes --json
   $ clawdi deploy --compute performance --term 12 --payment wallet --request-id <uuid> --yes --json
   $ clawdi deploy --compute performance --payment card --request-id <uuid> --yes --json
@@ -1140,6 +1143,47 @@ sessionCmd
 	});
 
 sessionCmd
+	.command("export <session-id>")
+	.description("Export an uploaded Cloud session as Markdown to stdout")
+	.option("--json", "Export owner metadata and messages as JSON instead")
+	.action(async (id, opts) => {
+		const { sessionExport } = await import("./commands/session.js");
+		await sessionExport(id, opts);
+	});
+
+sessionCmd
+	.command("share <session-id>")
+	.description("Publish an immutable public snapshot (user-level auth)")
+	.option("-y, --yes", "Confirm public publication without prompting")
+	.option("--through <position>", "Include messages through this zero-based position")
+	.option("--response <position>", "Share only the assistant response at this zero-based position")
+	.option("--json", "Output link metadata as JSON")
+	.action(async (id, opts) => {
+		const { sessionShareCreate } = await import("./commands/session.js");
+		await sessionShareCreate(id, opts);
+	});
+sessionCmd
+	.command("shares [session-id]")
+	.description("List active snapshot and legacy links")
+	.option("--page <n>", "Page number", "1")
+	.option("--limit <n>", "Page size (1-100)", "25")
+	.option("--json", "Output as JSON")
+	.action(async (id, opts) => {
+		const { sessionShareList } = await import("./commands/session.js");
+		await sessionShareList(id, opts);
+	});
+sessionCmd
+	.command("unshare <share-id>")
+	.option("--legacy", "Revoke a legacy live link (kind=live in session shares)")
+	.option("-y, --yes", "Confirm revocation without prompting")
+	.description("Revoke the exact snapshot or legacy link ID from session shares")
+	.option("--json", "Output as JSON")
+	.action(async (id, opts) => {
+		const { sessionShareRevoke } = await import("./commands/session.js");
+		await sessionShareRevoke(id, opts);
+	});
+
+sessionCmd
 	.command("extract <session-id>")
 	.description("Extract memories from a session via the cloud's configured LLM")
 	.option("--json", "Output result as JSON")
@@ -1200,6 +1244,15 @@ memoryCmd
 	.action(async (content, opts) => {
 		const { memoryAdd } = await import("./commands/memory.js");
 		await memoryAdd(content, opts);
+	});
+
+memoryCmd
+	.command("update <id> <content>")
+	.description("Replace exact memory content, preserving metadata; use the full ID")
+	.option("--json", "Output as JSON")
+	.action(async (id, content, opts) => {
+		const { memoryUpdate } = await import("./commands/memory.js");
+		await memoryUpdate(id, content, opts);
 	});
 
 memoryCmd
@@ -1573,6 +1626,55 @@ projectCmd
 	});
 
 const agentCmd = program.command("agent").description("Manage agents");
+
+const agentSkillsCmd = agentCmd
+	.command("skills")
+	.description("Manage remote Cloud Agent Skills (not local --agent types)");
+agentSkillsCmd
+	.command("list <agent-id>")
+	.description("List remote desired Skills, capabilities and observed convergence")
+	.option("--json", "Output as JSON")
+	.action(async (id, opts) => {
+		const { agentSkillsList } = await import("./commands/agent-skills.js");
+		await agentSkillsList(id, opts);
+	});
+agentSkillsCmd
+	.command("read <agent-id> <skill-key>")
+	.description("Read remote Skill detail using its exact inventory key")
+	.option("--json", "Output as JSON")
+	.action(async (id, key, opts) => {
+		const { agentSkillsRead } = await import("./commands/agent-skills.js");
+		await agentSkillsRead(id, key, opts);
+	});
+agentSkillsCmd
+	.command("install <agent-id>")
+	.description("Request a public GitHub Skill or Library reference; inspect list for application")
+	.option("--github <repo>", "Public GitHub owner/repo or URL")
+	.option("--path <directory>", "Skill directory within the GitHub repository")
+	.option("--library <skill-id>", "Cloud Library Skill UUID")
+	.option("--request-id <uuid>", "GitHub mutation idempotency key (generated if omitted)")
+	.option(
+		"--resource-version <version>",
+		"Original resource version for exact replay with --request-id",
+	)
+	.option("--json", "Output as JSON")
+	.action(async (id, opts) => {
+		const { agentSkillsInstall } = await import("./commands/agent-skills.js");
+		await agentSkillsInstall(id, opts);
+	});
+agentSkillsCmd
+	.command("rm <agent-id> <skill-key>")
+	.description("Request removal by exact remote inventory key; linked/bundled Skills are read-only")
+	.option("--request-id <uuid>", "GitHub mutation idempotency key (generated if omitted)")
+	.option(
+		"--resource-version <version>",
+		"Original resource version for exact replay with --request-id",
+	)
+	.option("--json", "Output as JSON")
+	.action(async (id, key, opts) => {
+		const { agentSkillsRemove } = await import("./commands/agent-skills.js");
+		await agentSkillsRemove(id, key, opts);
+	});
 
 agentCmd
 	.command("detect")

--- a/packages/cli/src/lib/api-schemas.ts
+++ b/packages/cli/src/lib/api-schemas.ts
@@ -10,7 +10,7 @@ export type Memory = Schemas["MemoryResponse"];
 export type SkillSummary = Schemas["SkillSummaryResponse"];
 export type SessionListItem = Schemas["SessionListItemResponse"];
 export type SessionDetail = Schemas["SessionDetailResponse"];
-export type SessionMessage = Schemas["SessionMessageResponse"];
+export type SessionMessage = Schemas["SessionTimelineMessageResponse"];
 
 // ── Write responses ───────────────────────────────────────────────────────
 // `/v1/vault/resolve` has richer single-reference/debug shapes in OpenAPI.

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
 	type components,
+	type DeployComponents,
 	type DeployPaths,
 	extractApiDetail,
 	type HostedDeployCheckoutRequest,
@@ -16,6 +17,7 @@ import {
 	type HostedSavedAiProvider,
 	type HostedWalletBinding,
 	type paths,
+	unwrapDeploymentList,
 } from "@clawdi/shared/api";
 import createClient, { type Client, type Middleware } from "openapi-fetch";
 import {
@@ -63,7 +65,7 @@ async function fetchWithTimeout(request: Request): Promise<Response> {
 		throw new HostedDeployApiError(
 			0,
 			timedOut
-				? "Hosted deploy API request timed out. The request may still have been accepted; retry with the same --request-id."
+				? "Hosted API request timed out. A mutation may have been accepted; inspect its status before retrying."
 				: "Could not reach the Hosted deploy API. Check your connection and deployApiUrl.",
 		);
 	} finally {
@@ -163,6 +165,72 @@ export class HostedDeployClient {
 	 */
 	supportsPaidCheckout(): boolean {
 		return this.paidCheckoutSupported;
+	}
+
+	async getAgentDeployment(agentId: string) {
+		const deployments = unwrapDeploymentList(
+			unwrapHosted(await this.client.GET("/v2/deployments", {})),
+		);
+		const matches = deployments.filter(
+			(item) => item.agent_id === agentId && item.resource.spec.desired_lifecycle !== "deleted",
+		);
+		if (matches.length !== 1) {
+			throw new Error(
+				"This Agent does not have one active Hosted deployment supporting remote Skills.",
+			);
+		}
+		const deployment = matches[0];
+		if (!deployment) throw new Error("Hosted deployment is unavailable.");
+		return deployment;
+	}
+
+	async getWorkspaceSkills(deploymentId: string) {
+		return unwrapHosted(
+			await this.client.GET("/v2/deployments/{deployment_id}/workspace-skills", {
+				params: { path: { deployment_id: deploymentId } },
+			}),
+		);
+	}
+
+	async getWorkspaceSkill(deploymentId: string, skillKey: string) {
+		return unwrapHosted(
+			await this.client.GET("/v2/deployments/{deployment_id}/workspace-skills/{skill_key}", {
+				params: { path: { deployment_id: deploymentId, skill_key: skillKey } },
+			}),
+		);
+	}
+
+	async installWorkspaceSkill(
+		deploymentId: string,
+		body: DeployComponents["schemas"]["V2WorkspaceSkillInstallRequest"],
+		resourceVersion: string,
+		requestId: string,
+	) {
+		return unwrapHosted(
+			await this.client.POST("/v2/deployments/{deployment_id}/workspace-skills", {
+				params: {
+					path: { deployment_id: deploymentId },
+					header: { "If-Match": `"${resourceVersion}"`, "Idempotency-Key": requestId },
+				},
+				body,
+			}),
+		);
+	}
+
+	async removeWorkspaceSkill(
+		deploymentId: string,
+		skillKey: string,
+		resourceVersion: string,
+		requestId: string,
+	) {
+		return unwrapHosted(
+			await this.client.DELETE("/v2/deployments/{deployment_id}/workspace-skills/{skill_key}", {
+				params: {
+					path: { deployment_id: deploymentId, skill_key: skillKey },
+					header: { "If-Match": `"${resourceVersion}"`, "Idempotency-Key": requestId },
+				},
+			}),
+		);
 	}
 
 	async getPlans(): Promise<HostedDeployPlan[]> {

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -225,7 +225,10 @@ describe("managed Skill reservations", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "service-state");
 		const existing = join(root, "one", "skills", "clawdi");
 		const absent = join(root, "two", "skills", "clawdi");
-		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), existing, { recursive: true });
+		// Released CLI 0.14.28 content: legacy adoption must not depend on the current bundle.
+		cpSync(resolve(import.meta.dir, "../../tests/fixtures/legacy-local-clawdi"), existing, {
+			recursive: true,
+		});
 
 		expect(
 			migrateLegacyLocalSetupSkill({

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -412,7 +412,7 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 
 	it("adopts a pre-ledger bundled clawdi target without uploading it", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
-		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), legacy, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), legacy, { recursive: true });
 		const adapter = new ClaudeCodeAdapter();
 		expect((await adapter.skills.collect()).map((skill) => skill.skillKey)).not.toContain("clawdi");
 		expect(await adapter.skills.listKeys()).not.toContain("clawdi");

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -412,7 +412,9 @@ describe("ClaudeCodeAdapter.collectSkills", () => {
 
 	it("adopts a pre-ledger bundled clawdi target without uploading it", async () => {
 		const legacy = join(tmpHome, ".claude", "skills", "clawdi");
-		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), legacy, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), legacy, {
+			recursive: true,
+		});
 		const adapter = new ClaudeCodeAdapter();
 		expect((await adapter.skills.collect()).map((skill) => skill.skillKey)).not.toContain("clawdi");
 		expect(await adapter.skills.listKeys()).not.toContain("clawdi");

--- a/packages/cli/tests/commands/agent-skills.test.ts
+++ b/packages/cli/tests/commands/agent-skills.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	agentSkillsInstall,
+	agentSkillsList,
+	agentSkillsRead,
+	agentSkillsRemove,
+} from "../../src/commands/agent-skills";
+import { setAuth } from "../../src/lib/config";
+import { jsonResponse, mockFetch } from "./helpers";
+
+const agentId = "123e4567-e89b-42d3-a456-426614174000";
+const requestId = "123e4567-e89b-42d3-a456-426614174001";
+const priorEnv: Record<string, string | undefined> = {};
+let taskHome: string;
+let originalLog: typeof console.log;
+let priorExitCode: typeof process.exitCode;
+let output: string[];
+
+beforeEach(() => {
+	for (const key of ["CLAWDI_HOME", "CLAWDI_API_URL", "CLAWDI_DEPLOY_API_URL"])
+		priorEnv[key] = process.env[key];
+	taskHome = mkdtempSync(join(tmpdir(), "clawdi-remote-skills-"));
+	process.env.CLAWDI_HOME = taskHome;
+	process.env.CLAWDI_API_URL = "https://cloud.example.test";
+	process.env.CLAWDI_DEPLOY_API_URL = "https://hosted.example.test";
+	const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+	setAuth({
+		authType: "clerk_oauth",
+		apiKey: `${encode({ typ: "at+jwt" })}.${encode({ sub: "user" })}.signature`,
+		refreshToken: "test-refresh",
+		accessTokenExpiresAt: new Date(Date.now() + 3600000).toISOString(),
+		issuer: "https://clerk.example.test",
+		clientId: "test-client",
+		audience: "clawdi-api",
+		tokenEndpoint: "https://clerk.example.test/oauth/token",
+		scopes: ["openid"],
+		subject: "user",
+		userId: "user",
+		endpointBinding: {
+			version: 1,
+			cloudApiOrigin: "https://cloud.example.test",
+			hostedApiOrigin: "https://hosted.example.test",
+		},
+	});
+	originalLog = console.log;
+	priorExitCode = process.exitCode ?? 0;
+	output = [];
+	console.log = (...values: unknown[]) => output.push(values.join(" "));
+});
+
+afterEach(() => {
+	console.log = originalLog;
+	process.exitCode = priorExitCode;
+	for (const [key, value] of Object.entries(priorEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	rmSync(taskHome, { recursive: true, force: true });
+});
+
+function hostedHandlers(available = true) {
+	return [
+		{
+			method: "GET",
+			path: /^\/v2\/deployments$/,
+			response: () =>
+				jsonResponse([
+					{
+						agent_id: agentId,
+						resource: { id: "hdep-owned", spec: { desired_lifecycle: "running" } },
+					},
+					{
+						agent_id: "other",
+						clawdi_cloud_environments: { hermes: agentId },
+						resource: { id: "hdep-wrong", spec: { desired_lifecycle: "running" } },
+					},
+				]),
+		},
+		{
+			method: "GET",
+			path: /^\/v2\/deployments\/hdep-owned\/workspace-skills$/,
+			response: () =>
+				jsonResponse({
+					deployment_resource_version: "rv_current",
+					capability: { available, reason: available ? "available" : "upgrade_not_observed" },
+					items: [{ skill_key: "review", status: "requested" }],
+				}),
+		},
+	];
+}
+
+test("GitHub requests use stable Agent identity, original replay version and surface failure", async () => {
+	const { captured, restore } = mockFetch([
+		...hostedHandlers(),
+		{
+			method: "POST",
+			path: "/v2/deployments/hdep-owned/workspace-skills",
+			response: () =>
+				jsonResponse({
+					skill_key: "review",
+					desired_state: "present",
+					status: "failed",
+					failure_message: "Native validation failed",
+				}),
+		},
+	]);
+	try {
+		await agentSkillsInstall(agentId, {
+			github: "owner/repo",
+			path: "skills/review",
+			requestId,
+			resourceVersion: "rv_original",
+			json: true,
+		});
+		const mutation = captured.find((item) => item.method === "POST");
+		expect(mutation?.headers["if-match"]).toBe('"rv_original"');
+		expect(mutation?.headers["idempotency-key"]).toBe(requestId);
+		expect(mutation?.body).toEqual({ repo: "owner/repo", path: "skills/review" });
+		expect(process.exitCode).toBe(1);
+		expect(JSON.parse(output[0] ?? "")).toMatchObject({
+			status: "failed",
+			request_id: requestId,
+			request_resource_version: "rv_original",
+		});
+	} finally {
+		restore();
+	}
+});
+
+test("unavailable GitHub capability and conflicting source flags cannot mutate", async () => {
+	const { captured, restore } = mockFetch(hostedHandlers(false));
+	try {
+		await expect(
+			agentSkillsInstall(agentId, { github: "owner/repo", library: "library-id" }),
+		).rejects.toThrow("exactly one");
+		expect(captured).toHaveLength(0);
+		await expect(agentSkillsInstall(agentId, { github: "owner/repo" })).rejects.toThrow(
+			"upgrade_not_observed",
+		);
+		expect(captured.every((item) => item.method === "GET")).toBe(true);
+	} finally {
+		restore();
+	}
+});
+
+test("Library install/read/remove follows Cloud authority and protects linked Skills", async () => {
+	const { captured, restore } = mockFetch([
+		{
+			method: "PUT",
+			path: `/v1/agents/${agentId}/skill-references/library-id`,
+			response: () =>
+				jsonResponse({ agent_id: agentId, skill_id: "library-id", desired_state: "present" }, 202),
+		},
+		{
+			method: "GET",
+			path: `/v1/agents/${agentId}/skills`,
+			response: () =>
+				jsonResponse({
+					agent_id: agentId,
+					skills: [
+						{
+							skill_key: "library-review",
+							authority: "cloud",
+							source: "library",
+							skill_id: "library-id",
+							project_id: "project-id",
+							source_skill_key: "review",
+							read_only: false,
+						},
+						{ skill_key: "linked", authority: "cloud", source: "project", read_only: true },
+					],
+				}),
+		},
+		{
+			method: "GET",
+			path: "/v1/projects/project-id/skills/review",
+			response: () => jsonResponse({ content: "# Review\nUse instructions" }),
+		},
+		{
+			method: "DELETE",
+			path: `/v1/agents/${agentId}/skill-references/library-id`,
+			response: () => jsonResponse({ desired_state: "absent" }, 202),
+		},
+	]);
+	try {
+		await agentSkillsInstall(agentId, { library: "library-id", json: true });
+		await agentSkillsRead(agentId, "library-review", { json: true });
+		await agentSkillsRemove(agentId, "library-review", { json: true });
+		await expect(agentSkillsRemove(agentId, "linked")).rejects.toThrow("cannot be removed");
+		expect(captured.filter((item) => item.method === "DELETE")).toHaveLength(1);
+		expect(
+			captured.every((item) => new URL(item.url).origin === "https://cloud.example.test"),
+		).toBe(true);
+		expect(JSON.parse(output[0] ?? "").status).toBe("accepted");
+		expect(JSON.parse(output[1] ?? "").detail.content).toContain("Use instructions");
+	} finally {
+		restore();
+	}
+});
+
+test("list exposes failed removals and sets failure exit status without claiming installation", async () => {
+	const { restore } = mockFetch([
+		...hostedHandlers(),
+		{
+			method: "GET",
+			path: `/v1/agents/${agentId}/skills`,
+			response: () =>
+				jsonResponse({
+					agent_id: agentId,
+					skills: [],
+					removal_failures: [{ skill_key: "removed", observation_error_code: "reconcile_failed" }],
+				}),
+		},
+	]);
+	try {
+		await agentSkillsList(agentId, { json: true });
+		expect(process.exitCode).toBe(1);
+		expect(JSON.parse(output[0] ?? "").removal_failures).toEqual([
+			{ skill_key: "removed", observation_error_code: "reconcile_failed" },
+		]);
+	} finally {
+		restore();
+	}
+});

--- a/packages/cli/tests/commands/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy.test.ts
@@ -649,6 +649,48 @@ describe("deploy orchestration", () => {
 		expect(JSON.stringify(codexClient.created?.body)).not.toContain("access_token");
 	});
 
+	test("native saved providers deliver credentials without model selection in either mode", async () => {
+		for (const interactive of [false, true]) {
+			const client = new FakeDeployGateway();
+			client.savedProviders = [
+				{
+					...savedProvider("native", { models: [] }),
+					base_url: "https://api.openai.com/v1",
+					configuration_mode: "native",
+					native_provider: "openai",
+				},
+			];
+			const options = {
+				provider: "native",
+				runtime: "hermes",
+				compute: "basic",
+				name: "Native",
+				language: "en",
+				timezone: "UTC",
+				requestId: "123e4567-e89b-42d3-a456-426614174099",
+				yes: true,
+			};
+			const result = await runDeployFlow(parseDeployCommandOptions(options), {
+				client,
+				interactive,
+				prompts: noUnexpectedPrompts,
+				sleep: async () => undefined,
+			});
+			expect(client.created?.body).toMatchObject({
+				primary_model: null,
+				provider_ids: ["native"],
+				ai_provider_auth_kind: "api_key",
+			});
+			expect(result.primary_model).toBeNull();
+			const legacy = await runDeployFlow(
+				parseDeployCommandOptions({ ...options, model: "legacy-model" }),
+				{ client, interactive: false, sleep: async () => undefined },
+			);
+			expect(legacy.primary_model).toBeNull();
+			expect(client.created?.body.primary_model).toBeNull();
+		}
+	});
+
 	test("fails closed for missing, unusable, and ambiguous saved-provider models", async () => {
 		const client = new FakeDeployGateway();
 		client.savedProviders = [

--- a/packages/cli/tests/commands/memory.test.ts
+++ b/packages/cli/tests/commands/memory.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { memoryAdd } from "../../src/commands/memory";
+import { memoryAdd, memoryUpdate } from "../../src/commands/memory";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -75,4 +75,27 @@ describe("memoryAdd", () => {
 			source: "manual",
 		});
 	});
+});
+
+it("updates exact content only and rejects secrets before the request", async () => {
+	const id = "00000000-0000-0000-0000-000000000abc";
+	const { captured, restore } = mockFetch([
+		{
+			method: "PATCH",
+			path: `/v1/memories/${id}`,
+			response: () => jsonResponse({ status: "updated", memory_id: id }),
+		},
+	]);
+	const originalLog = console.log;
+	console.log = () => {};
+	try {
+		await expect(memoryUpdate(id, `ghp_${"a".repeat(36)}`)).rejects.toThrow("Store secrets");
+		expect(captured).toHaveLength(0);
+		await memoryUpdate(id, "Use tabs", { json: true });
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.body).toEqual({ content: "Use tabs" });
+	} finally {
+		console.log = originalLog;
+		restore();
+	}
 });

--- a/packages/cli/tests/commands/session.test.ts
+++ b/packages/cli/tests/commands/session.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sessionRead, sessionSearch } from "../../src/commands/session";
+import {
+	sessionExport,
+	sessionRead,
+	sessionSearch,
+	sessionShareCreate,
+	sessionShareList,
+	sessionShareRevoke,
+} from "../../src/commands/session";
 import { jsonResponse, mockFetch, seedAuthAndEnv } from "./helpers";
 
 let tmpHome: string;
@@ -111,7 +118,7 @@ describe("cloud session commands", () => {
 			{
 				method: "GET",
 				path: `/v1/sessions/${sessionId}/content`,
-				response: () => jsonResponse([{ role: "user", content: "hello" }]),
+				response: () => jsonResponse([{ role: "user", content: "hello", position: 3 }]),
 			},
 			{
 				method: "GET",
@@ -142,7 +149,7 @@ describe("cloud session commands", () => {
 		);
 		expect(JSON.parse(output[0])).toMatchObject({
 			session: { id: sessionId },
-			messages: [{ role: "user", content: "hello" }],
+			messages: [{ role: "user", content: "hello", position: 3 }],
 		});
 	});
 
@@ -179,4 +186,62 @@ describe("cloud session commands", () => {
 			messages: [],
 		});
 	});
+});
+
+it("publishes only with confirmation and keeps canonical positions and legacy IDs", async () => {
+	const { captured, restore } = mockFetch([
+		{
+			method: "POST",
+			path: "/v1/sessions/cloud-id/shares",
+			response: () => jsonResponse({ id: "snapshot-id", scope: "response", position: 3 }, 201),
+		},
+		{
+			method: "GET",
+			path: "/v1/session-shares",
+			response: () => jsonResponse({ items: [], total: 0, page: 1, page_size: 25 }),
+		},
+		{
+			method: "DELETE",
+			path: "/v1/session-shares/legacy-id",
+			response: () => new Response(null, { status: 204 }),
+		},
+	]);
+	const originalLog = console.log;
+	console.log = () => {};
+	try {
+		await expect(sessionShareCreate("cloud-id", { response: "3" })).rejects.toThrow("--yes");
+		await expect(
+			sessionShareCreate("cloud-id", { through: "1", response: "3", yes: true }),
+		).rejects.toThrow("only one");
+		expect(captured).toHaveLength(0);
+		await sessionShareCreate("cloud-id", { response: "3", yes: true, json: true });
+		await sessionShareList("cloud-id", { json: true });
+		await sessionShareRevoke("legacy-id", { legacy: true, yes: true, json: true });
+		expect(captured[0]?.body).toEqual({ scope: "response", position: 3 });
+		expect(new URL(captured[1]?.url ?? "").searchParams.get("session_id")).toBe("cloud-id");
+		expect(new URL(captured[2]?.url ?? "").searchParams.get("kind")).toBe("live");
+	} finally {
+		console.log = originalLog;
+		restore();
+	}
+});
+
+it("exports owner Markdown without publishing a link", async () => {
+	const { captured, restore } = mockFetch([
+		{
+			method: "GET",
+			path: "/v1/sessions/cloud-id/export.md",
+			response: () =>
+				new Response("# Private session\n", { headers: { "Content-Type": "text/markdown" } }),
+		},
+	]);
+	const write = spyOn(process.stdout, "write").mockImplementation(() => true);
+	try {
+		await sessionExport("cloud-id");
+		expect(write).toHaveBeenCalledWith("# Private session\n");
+		expect(captured.map((item) => item.method)).toEqual(["GET"]);
+	} finally {
+		write.mockRestore();
+		restore();
+	}
 });

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -247,7 +247,7 @@ describe("setup daemon install", () => {
 
 	it("adopts a pre-ledger clawdi target under the previous exclusion contract", async () => {
 		const target = join(home, ".codex", "skills", "clawdi");
-		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), target, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, { recursive: true });
 		installEnvironmentMock("env-codex");
 
 		await setup({ agent: "codex", yes: true, daemon: false });

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -247,7 +247,9 @@ describe("setup daemon install", () => {
 
 	it("adopts a pre-ledger clawdi target under the previous exclusion contract", async () => {
 		const target = join(home, ".codex", "skills", "clawdi");
-		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, {
+			recursive: true,
+		});
 		installEnvironmentMock("env-codex");
 
 		await setup({ agent: "codex", yes: true, daemon: false });

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -208,7 +208,7 @@ describe("teardown — flag behavior", () => {
 		const { skillPath } = setup("claude_code", { managed: false });
 		const target = dirname(skillPath);
 		rmSync(target, { recursive: true, force: true });
-		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), target, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, { recursive: true });
 
 		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
 

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -208,7 +208,9 @@ describe("teardown — flag behavior", () => {
 		const { skillPath } = setup("claude_code", { managed: false });
 		const target = dirname(skillPath);
 		rmSync(target, { recursive: true, force: true });
-		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, { recursive: true });
+		cpSync(resolve(import.meta.dir, "../fixtures/legacy-local-clawdi"), target, {
+			recursive: true,
+		});
 
 		await teardown({ agent: "claude_code", yes: true, keepMcp: true });
 

--- a/packages/cli/tests/fixtures/legacy-local-clawdi/SKILL.md
+++ b/packages/cli/tests/fixtures/legacy-local-clawdi/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: clawdi
+description: "Cross-agent long-term memory + session history for the current user: their preferences, coding habits, named projects / repos / tools, past bugs and architecture decisions, AND their past agent conversations across Claude Code / Codex / OpenClaw / Hermes. Surface this skill BEFORE answering any question about the user themselves, their work, or their history — even when phrased abstractly (e.g. 'what do I usually use for X', 'find the session where I worked on auth'). Also provides connected-service tools (Gmail, GitHub, Notion, Drive, Calendar, etc.) and reads Clawdi share URLs (https://cloud.clawdi.ai/s/...) the user pastes."
+---
+
+# Clawdi Cloud
+
+You have access to Clawdi Cloud tools via the `clawdi` MCP server. Use them aggressively — memory + session retrieval is the highest-leverage capability you have here.
+
+## Memory
+
+Three tools for cross-agent memory:
+
+- `memory_search` — Search long-term memory by natural-language query (any language).
+- `memory_add` — Save a durable memory for cross-agent recall. Do not store plaintext tokens, API keys, or bearer credentials; store those in Vault and save only the `clawdi://` reference. Categories: `fact` (technical facts, API details, config values), `preference` (user preferences, coding style, workflow choices), `pattern` (recurring patterns, pitfalls, team conventions), `decision` (architecture decisions and their reasoning), `context` (project context, deadlines, ongoing work).
+- `memory_extract` — Batch-extract durable memories from the CURRENT conversation. Call this when the user says "extract memories", "save what we discussed", "remember this conversation", or equivalent. The tool returns instructions that walk you through a list-then-confirm flow using `memory_search` and `memory_add` — follow them exactly, including **waiting for the user's approval before writing anything**. Never skip the confirmation step, never save more than 5 memories in one invocation, and do not narrate your internal workflow to the user.
+
+### When to search — bias toward calling
+
+**Default assumption: the user has stored context you don't have. Call `memory_search` BEFORE answering any question about them, their project, their preferences, or their history. A call that returns empty costs ~100ms; a missed hit makes you look amnesic and forces them to re-teach you every session.**
+
+The single most common failure mode is NOT calling memory_search on abstract self-referential questions. If the user's message has any of these shapes, you MUST call it — no judgment, no exceptions:
+
+1. **Preference / habit questions**, even without a specific entity named.
+   Examples: "what do I usually use for X", "how do I normally do Y", "what's my preferred tool for Z", "what's my coding style". Pass a short paraphrase as the query.
+2. **Callbacks to prior context.** "as I mentioned", "like last time", "you know the one", "we discussed before", "what was that X we set up".
+3. **Named entities specific to this user.** Their project / repo / service / team / tool name. A person by name.
+4. **Past bugs, decisions, investigations, design choices.**
+5. **Start of a new session where they reference anything about themselves or their work.**
+
+Do NOT search for:
+- Purely textbook programming questions with no user-specific signal ("how does `useEffect` work", "what is the time complexity of quicksort").
+- Questions the current code already answers directly.
+
+**When unsure, search.** Empty results cost you nothing. Missing the user's context costs you their trust.
+
+### When to save
+
+- After fixing a non-obvious bug (save root cause + fix)
+- After making an architecture decision (save reasoning)
+- After discovering a useful pattern or workaround
+- When the user explicitly says "remember this" / "save this"
+- After learning a user preference you'd otherwise have to re-ask ("I prefer rg", "I always use pnpm")
+
+Write memories as standalone sentences with full context — include names, not pronouns. A future session will read this without knowing today's conversation.
+
+Do NOT save trivial facts that are obvious from the code itself, or generic programming knowledge.
+
+Do NOT save plaintext tokens, API keys, bearer credentials, or private keys in memory. Use Vault for secret values and save only a `clawdi://` reference when future agents need to know where a secret lives.
+
+## Sessions
+
+Two tools for reading and finding past agent conversations stored in Clawdi Cloud:
+
+- `session_read` — Fetch a single session by reference and return its full conversation as Markdown. Accepts a Clawdi share URL (`https://cloud.clawdi.ai/s/{uuid}`) OR a session UUID for one of the user's own sessions. Handles owned and shared sessions transparently — you don't need to know which one.
+- `session_search` — Find sessions in the user's history by keyword. Trigram-ranked substring search with typo tolerance. Returns matching sessions with summary, project, timestamps, and **session UUIDs you can pass back to `session_read`**.
+
+### When to read — call `session_read` whenever the user references a specific session
+
+MUST call when the user's message includes:
+- A Clawdi share URL (e.g. `https://cloud.clawdi.ai/s/11111111-2222-3333-4444-555555555555`) — pass the full URL
+- A direct reference like "open the session where I did X" or "the one from yesterday about auth" — first call `session_search` to find the UUID, then `session_read` to load it
+
+Do NOT call WebFetch on `cloud.clawdi.ai/s/...` URLs — `session_read` is the right tool and avoids the WebFetch permission prompt.
+
+### When to search — bias toward calling, similar to `memory_search`
+
+MUST call `session_search` when:
+- The user asks about prior work: "what did I do about the focus bug", "find the session where I migrated auth", "show me last week's debugging session"
+- They reference a past investigation by topic but don't name a specific session
+- They want to continue / reuse approach from a prior conversation
+
+### Difference from `memory_search`
+
+- `memory_search` finds **stored facts / preferences / decisions** the user (or a previous agent run) explicitly extracted. Short rows; high signal.
+- `session_search` finds **full conversations** in the corpus. Long rows; useful when the user wants the original context, not just the takeaway.
+
+When the user's request is **conceptual** ("how do I usually do X"), prefer `memory_search`. When they want to **revisit a specific past conversation** ("the session where..."), use `session_search`. When unsure, try `memory_search` first (cheaper, faster), fall back to `session_search` if empty.
+
+## Projects
+
+Three read-only tools expose the caller's visible Project context:
+
+- `project_current` — Read the current or runtime-bound Project.
+- `project_list` — List visible Projects.
+- `project_get` — Read one visible Project by UUID.
+
+Hosted runtimes see only their bound Project. Treat a not-found response as an
+access boundary as well as a possible unknown UUID; do not try to bypass it
+through another tool.
+
+## Vault Metadata
+
+Two read-only MCP tools expose safe Vault metadata without secret values:
+
+- `vault_list` — List Vault attachments and key counts for visible Projects.
+- `vault_get` — List key names, provenance, and exact `clawdi://` references for one attached Vault.
+
+Use `vault_resolve` only when the current task requires one referenced plaintext value. Pass
+the exact Project-scoped reference. Treat the result as sensitive: never echo it, save it to
+Memory, or include it in logs.
+
+The metadata tools never resolve or return plaintext. Never imply that a returned key name
+is a secret value. Preserve their exact references for `vault_resolve` or when passing them
+to an authorized runtime:
+
+- `clawdi://project/<project-id>/vault/<vault>/field/<field>`
+- `clawdi://project/<project-id>/vault/<vault>/section/<section>/field/<field>`
+
+Use the live schemas from the `clawdi` MCP server as authoritative; the local
+stdio command only transports the protocol.
+
+## Wallet Funding
+
+Use `clawdi wallet status --json` to inspect the authenticated Wallet balance, verified
+binding, and x402 readiness. Binding and Base USDC top-up are available only through the
+browser wallet surface; Clawdi does not store the payment private key. Ask the user to fund
+there. Command-line spending requires a future owner-only or hardware signer authority and is not
+available.
+
+## Connectors
+
+Use the Composio Tool Router meta-tools returned by `tools/list` on the `clawdi` MCP server.
+Treat their live names and schemas as authoritative; never assume a fixed meta-tool set.
+
+1. Start each external-app workflow with `COMPOSIO_SEARCH_TOOLS`. Follow its exposed
+   `queries` and `session` schema, reuse the returned session ID throughout that workflow,
+   and use only the exact toolkit and tool slugs it returns. If a required schema is absent
+   or incomplete, call `COMPOSIO_GET_TOOL_SCHEMAS`; never invent fields or inputs.
+2. Before a side effect, require a complete target identity and all schema-required inputs.
+   Explicit intent authorizes the exact requested action and target, but never authorizes
+   guessing a missing recipient, account, resource, or other target. Ask only for what is
+   missing, and do not request redundant confirmation once the exact action is authorized.
+3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
+   exposed schema and interpret only the fields it returns. Continue on `active`. On
+   `initiated`, present its non-empty `redirect_url` as a clickable authentication link with
+   a concise explanation that authorization is pending; the link URL must be exactly that
+   value. If `initiated` has no non-empty `redirect_url`, report that authorization cannot
+   continue and stop. On `failed`, report the returned error and stop. Never construct a
+   substitute link, ask for OAuth credentials, API keys, or tokens, or suggest an
+   out-of-band fallback.
+4. Use a wait or status operation only when `tools/list` exposes one. Follow its actual schema
+   and status values without inventing polling arguments. Continue only when it reports an
+   active connection; keep waiting only for a non-terminal status its schema defines, and
+   report any terminal failure. If none is exposed, stop until the user reports completing
+   authorization, then re-run search to verify the active connection before continuing.
+5. Execute exact returned slugs through `COMPOSIO_MULTI_EXECUTE_TOOL` with schema-compliant
+   arguments. Batch only independent calls. Keep ordinary results inline. Set
+   `sync_response_to_workbench` only when a result may be large or needs later remote
+   processing; use `COMPOSIO_REMOTE_WORKBENCH` / `COMPOSIO_REMOTE_BASH_TOOL` only for large
+   responses saved remotely or remote artifacts.
+6. Preserve dependencies and returned semantics. Follow signed-file metadata, pagination
+   fields, and termination signals exactly as exposed. Select an account only when the schema
+   supports it, and use additional or future meta-tools only according to their live schemas.
+
+## Vault Management
+
+Vault mutation is intentionally not an Agent MCP capability. Do not use raw HTTP, daemon
+control RPC, or execute foreground Vault CLI commands on the user's behalf. When the user
+asks to write, import, attach, detach, or delete Vault data, explain that a human operator
+must perform it and provide the safest exact foreground command. Prefer `clawdi vault set
+KEY --prompt` for one value and `clawdi vault import ...` for migrations; never place a
+plaintext secret in command arguments or your response.
+
+## AI Provider Management
+
+Provider configuration is also a human operator workflow, not an Agent MCP capability. Do
+not execute provider CLI commands or handle provider credentials on the user's behalf. When
+asked, provide an exact `clawdi ai-provider` command for the operator to run and explain its
+effect; suggest `validate` or a non-live `test` before any explicitly requested live probe.
+
+- Treat the local Provider Catalog as multi-record metadata. Do not activate it into local agent config; Core Hosted activation is supplied by the runtime manifest/controller, whose configured runtime binds exactly one provider and whose unmanaged runtime binds none.
+- Keep Codex OAuth ownership singular across Hosted runtimes. Hermes/OpenClaw native refresh, revoke, and ownership state belongs to Hosted convergence, not a local CLI materialization command.
+- Default export/import is metadata-only; `--include-secrets` requires passphrase-encrypted secret export.
+- BYOK model requests go directly from the agent runtime to the configured provider. Clawdi stores metadata and secret references but is not a model proxy.

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1019,7 +1019,10 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Revoke Share */
+        /**
+         * Revoke Share
+         * @description Revoke one owned snapshot or legacy live link by its exact inventory ID.
+         */
         delete: operations["revoke_share_v1_session_shares__share_id__delete"];
         options?: never;
         head?: never;
@@ -1490,7 +1493,7 @@ export interface paths {
         };
         /**
          * Get Session Content
-         * @description Read session messages from FileStore, typed as SessionMessageResponse[].
+         * @description Read visible messages with canonical source positions for sharing.
          */
         get: operations["get_session_content_v1_sessions__session_id__content_get"];
         put?: never;
@@ -2358,7 +2361,11 @@ export interface paths {
         delete: operations["delete_memory_v1_memories__memory_id__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update Memory
+         * @description Replace exact-item content while preserving category, tags and provenance.
+         */
+        patch: operations["update_memory_v1_memories__memory_id__patch"];
         trace?: never;
     };
     "/v1/memories/embed-backfill": {
@@ -6988,6 +6995,21 @@ export interface components {
             source_environment_id?: string | null;
             /** Source Machine Name */
             source_machine_name?: string | null;
+        };
+        /** MemoryUpdate */
+        MemoryUpdate: {
+            /** Content */
+            content: string;
+        };
+        /** MemoryUpdatedResponse */
+        MemoryUpdatedResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "updated";
+            /** Memory Id */
+            memory_id: string;
         };
         /**
          * OAuthConfigResponse
@@ -11679,6 +11701,7 @@ export interface operations {
             query?: {
                 page?: number;
                 page_size?: number;
+                session_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -11774,7 +11797,9 @@ export interface operations {
     };
     revoke_share_v1_session_shares__share_id__delete: {
         parameters: {
-            query?: never;
+            query?: {
+                kind?: "snapshot" | "live";
+            };
             header?: never;
             path: {
                 share_id: string;
@@ -12900,7 +12925,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SessionMessageResponse"][];
+                    "application/json": components["schemas"]["SessionTimelineMessageResponse"][];
                 };
             };
             /** @description Validation Error */
@@ -14390,6 +14415,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MemoryDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_memory_v1_memories__memory_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                memory_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MemoryUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MemoryUpdatedResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
CLI users could search Sessions but could not share or manage links, update one Memory, or manage a Cloud Agent's installed Skills. Native saved provider deployment also required a model that its binding did not use. Complete these workflows through the existing Cloud and Hosted authorities.

- Add Session snapshot creation for whole/through/response scopes, paged link listing, exact snapshot/legacy revocation, and owner export without publication. Sharing requires confirmation and user-level authentication; scoped and Agent-bound keys remain denied.
- Return canonical source positions with owner Session content so hidden/tool events cannot shift the selected share target.
- Add exact Memory updates through the configured provider, preserving metadata and enforcing owner, scope, content, and secret checks. Regenerate the additive API contracts.
- Add remote `agent skills list/read/install/rm` using stable Cloud Agent IDs, Library references and Hosted GitHub operations. Preserve local `skill --agent <type>`, native capability/ownership checks, and request-version replay. Accepted requests are distinguished from observed installation; failures set a nonzero exit status.
- Skip model selection for native saved providers. Legacy scripts supplying `--model` still work, with a stderr warning and no model change. Managed/custom catalog behavior remains intact.

## Validation

All execution used disposable Docker environments:

- CLI typecheck and 55 tests: deploy, session, agent-skills, memory, and Hosted auth.
- Core PostgreSQL: 65 tests across CLI OAuth/auth boundaries, Session sharing and Agent Skill references.
- Generated API consistency and Python changed-file type governance passed.
- Biome and Ruff checks passed; two-dot diff check passed. The host commit hook could not find lefthook; equivalent formatting checks ran in Docker.
- Public guide CI and 8 isolated Chromium guide routes passed in Clawdi-AI/clawdi-docs#28.

Review covered scoped/bound-key denial, foreign ownership, exact legacy revocation after replacement, hidden/tool position gaps, unchanged Memory metadata, native-provider legacy flags, and remote Skill failure/replay reporting. No live account or tenant testing was performed.

## Release coordination

Pair with Clawdi-AI/clawdi-hosted#2138 for the four Skill OAuth routes and Clawdi-AI/clawdi-docs#28. Release Core server contracts and Hosted authorization before the new CLI, then publish the new-command guides. This PR contains no CLI version bump, package publication, deployment, or tenant operation.


CI follow-up: pin the legacy migration test to the exact published CLI 0.14.28 Skill fixture instead of the editable current bundle. The production legacy digest allowlist is unchanged. All legacy adoption consumers (reservation, adapter collection, setup and teardown) now share that one historical fixture. The official isolated CLI runner passes typecheck and 77 tests across those four paths; the bundled-Skill contract checks also passed. Full CI was restarted on the updated head.


Release verification: merged as 3e8b7d3f2d563e4671e4044e6756e7a1d86ff67f. Clawdi Image Release https://github.com/Clawdi-AI/clawdi/actions/runs/34216305141 completed successfully. Public Cloud API health returns 200, and its live OpenAPI exposes Memory PATCH and Session link inventory. CLI publication is tracked by #1421 and docs by Clawdi-AI/clawdi-docs#28.
