### PR TITLE
release(cli): publish 0.14.57 workflow completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,6 @@ database migration, CI, and implementation details.
 
 ### Added
 
-- Share a whole Session, a conversation up to a chosen message, or one response
-  from the CLI. Review and turn off active links, or export without sharing.
-- `clawdi memory update` edits one Memory while preserving its category and source.
-- `clawdi agent skills` inspects, installs, and removes supported Cloud Agent
-  Skills from public GitHub or Library, with installation status and failures.
-
 - Agent Skills can be installed from Library or public GitHub repositories,
   with source details, updates, and removal from the Agent page.
 - Session search now matches visible user and assistant message text in addition to summaries, folders, and IDs. CLI and Web results show the best matching message excerpt; private reasoning, tool payloads, system messages, and hidden events remain excluded.
@@ -56,10 +50,6 @@ database migration, CI, and implementation details.
 - The product tour now shows messaging Channels and explains the separate bot, Agent link, and paired-chat boundaries.
 
 ### Fixed
-
-- Deploy with native saved AI Providers without supplying a model. Existing
-  scripts that pass `--model` still work and receive a warning; choose models
-  inside the Agent.
 
 - CLI 0.14.53 ships only the Python egress addon source in npm and native packages,
   rejecting generated Python caches and bytecode before publication.
@@ -100,6 +90,24 @@ database migration, CI, and implementation details.
 - Managed OpenClaw WhatsApp now installs the exact plugin version compatible with the runtime.
 - Hosted OpenClaw upgrades now retire the legacy Clawdi provider plugin even
   when OpenClaw requires capability consent before it can inspect the plugin.
+
+## Clawdi CLI v0.14.57
+
+Package: `clawdi@0.14.57`
+
+### Added
+
+- Share a whole Session, a conversation up to a chosen message, or one response
+  from the CLI. Review and turn off active links, or export without sharing.
+- `clawdi memory update` edits one Memory while preserving its category and source.
+- `clawdi agent skills` inspects, installs, and removes supported Cloud Agent
+  Skills from public GitHub or Library, with installation status and failures.
+
+### Fixed
+
+- Deploy with native saved AI Providers without supplying a model. Existing
+  scripts that pass `--model` still work and receive a warning; choose models
+  inside the Agent.
 
 ## Clawdi CLI v0.14.51
 

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.56",
+      "version": "0.14.57",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.56",
+	"version": "0.14.57",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Publish the completed CLI workflows from #1420 as clawdi@0.14.57. Update the package and lockfile version together and move the corresponding user-facing notes from Unreleased into the versioned entry.

Includes Session snapshot/link management and private export, exact Memory updates, remote Cloud Agent Skill management, and native-provider deployment without mandatory model selection. Existing native-provider scripts remain compatible.

Validation: official isolated CLI runner passed frozen dependency installation, typecheck, and 21 smoke/native-publication tests. #1420 passed its complete CI before merge. The three-file two-dot diff was reviewed and whitespace checks passed.

Release order: Core server deployment at 3e8b7d3f2d563e4671e4044e6756e7a1d86ff67f and the Hosted authorization release must be verified before merging this PR. Merge triggers the standard immutable artifact/OIDC CLI publishing workflow. Verify npm and native release assets before publishing Clawdi-AI/clawdi-docs#28. No managed tenant CLI rollout is part of this package release.


Published: `clawdi@0.14.57` and all eight native release assets are available at https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.14.57. Publish run https://github.com/Clawdi-AI/clawdi/actions/runs/34217198614 succeeded from merge SHA 9f5c89d5b21b814a18bc59b99b140754814f5fe0. npm latest was verified as 0.14.57; an isolated install of the public package reports that version and exposes Session sharing/export, Memory update and remote Skill command help. Core and Hosted services were verified before this publication; docs #28 followed.
