### PR TITLE
Use shared resource pages without leaving the active Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- Resources opened from an Agent stay in that Agent, including unlinked Projects,
+  newly created Projects, and resource source links.
+
 - Agent Projects show Linked and Available groups with direct Link or Unlink
   actions. Agent Vaults show the keys available through those Projects and the
   existing Workspace, with their sources; Vaults are configured in Projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ database migration, CI, and implementation details.
 ### Changed
 
 - Resources opened from an Agent stay in that Agent, including unlinked Projects,
-  newly created Projects, and resource source links.
+  newly created Projects, and resource source links. Agent and Library entry points
+  use the same Project detail page and controls.
 
 - Agent Projects show Linked and Available groups with direct Link or Unlink
   actions. Agent Vaults show the keys available through those Projects and the

--- a/apps/web/e2e/hosted-workspace-skills.pw.ts
+++ b/apps/web/e2e/hosted-workspace-skills.pw.ts
@@ -147,6 +147,16 @@ test("Hosted Skills install, open pinned content, and uninstall without a Cloud 
 		`${source.url}/tree/${source.commit}/review-pr`,
 	);
 	await expect(page.getByRole("button", { name: "Copy skill" })).toBeVisible();
+	await page.getByRole("link", { name: "View source Skill" }).click();
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === `/agents/${agentId}/skills/team/review-pr` &&
+			url.searchParams.get("project") === libraryProjectId,
+	);
+	await expect(
+		page.locator("main").getByRole("heading", { name: "review-pr", exact: true, level: 1 }),
+	).toBeVisible();
+	await page.goBack();
 	await page.getByRole("link", { name: "Skills", exact: true }).last().click();
 	await page.getByRole("button", { name: "Uninstall review-pr from Agent" }).click();
 	await page
@@ -300,6 +310,9 @@ test("Library Skills use references from both entry points, show source content,
 				]
 			: [],
 	});
+	await page.route(`http://127.0.0.1:8000/v1/projects/${libraryProjectId}/skills/**`, (route) =>
+		route.fulfill({ json: sourceSkill }),
+	);
 	await page.route(apiPath, (route) => route.fulfill({ json: inventory() }));
 	await page.route("http://127.0.0.1:8000/v1/projects", (route) =>
 		route.fulfill({ json: [project] }),
@@ -354,9 +367,9 @@ test("Library Skills use references from both entry points, show source content,
 	await expect(page.getByRole("button", { name: "Copy skill" })).toBeDisabled();
 	await page.getByRole("button", { name: "Retry", exact: true }).click();
 	await expect(page.getByRole("heading", { name: "Team review", exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "View in Library" })).toHaveAttribute(
+	await expect(page.getByRole("link", { name: "View source Skill" })).toHaveAttribute(
 		"href",
-		/project=project-library/,
+		/\/agents\/[^/]+\/skills\/[^?]+\?project=project-library/,
 	);
 	await page.getByRole("link", { name: "Skills", exact: true }).last().click();
 	await page.getByRole("button", { name: "Uninstall review-pr from Agent" }).click();

--- a/apps/web/e2e/hosted-workspace-skills.pw.ts
+++ b/apps/web/e2e/hosted-workspace-skills.pw.ts
@@ -147,16 +147,6 @@ test("Hosted Skills install, open pinned content, and uninstall without a Cloud 
 		`${source.url}/tree/${source.commit}/review-pr`,
 	);
 	await expect(page.getByRole("button", { name: "Copy skill" })).toBeVisible();
-	await page.getByRole("link", { name: "View source Skill" }).click();
-	await expect(page).toHaveURL(
-		(url) =>
-			url.pathname === `/agents/${agentId}/skills/team/review-pr` &&
-			url.searchParams.get("project") === libraryProjectId,
-	);
-	await expect(
-		page.locator("main").getByRole("heading", { name: "review-pr", exact: true, level: 1 }),
-	).toBeVisible();
-	await page.goBack();
 	await page.getByRole("link", { name: "Skills", exact: true }).last().click();
 	await page.getByRole("button", { name: "Uninstall review-pr from Agent" }).click();
 	await page
@@ -371,6 +361,16 @@ test("Library Skills use references from both entry points, show source content,
 		"href",
 		/\/agents\/[^/]+\/skills\/[^?]+\?project=project-library/,
 	);
+	await page.getByRole("link", { name: "View source Skill" }).click();
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === `/agents/${agentId}/skills/team/review-pr` &&
+			url.searchParams.get("project") === libraryProjectId,
+	);
+	await expect(
+		page.locator("main").getByRole("heading", { name: "review-pr", exact: true, level: 1 }),
+	).toBeVisible();
+	await page.goBack();
 	await page.getByRole("link", { name: "Skills", exact: true }).last().click();
 	await page.getByRole("button", { name: "Uninstall review-pr from Agent" }).click();
 	await page

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1128,6 +1128,10 @@ async function stubConnectedAgentResources(page: Page) {
 		{
 			id: "project-context-first",
 			name: "Team Knowledge",
+			skill_count: 2,
+			vault_count: 2,
+			member_count: 0,
+			agent_count: 1,
 			slug: "team-knowledge",
 			description: "Shared review instructions and protected Vault access",
 			kind: "workspace",
@@ -1780,78 +1784,50 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first",
 	);
 	await expect(main.getByRole("heading", { name: "Team Knowledge", level: 1 })).toBeVisible();
+	await expect(main.getByRole("tablist", { name: "Project pages" }).getByRole("tab")).toHaveText([
+		"Overview",
+		"Skills",
+		"Vaults",
+		"Agents",
+		"Access",
+	]);
+	await main.getByRole("tab", { name: "Skills", exact: true }).click();
 	await expect(main.getByText("Team-only Skill", { exact: true })).toBeVisible();
 	await expect(main.getByText("Shared Workflow", { exact: true })).toBeVisible();
 	await expect(main.getByText("Primary-only Skill", { exact: true })).toHaveCount(0);
-	await expect(main.getByText("Team Vault", { exact: true })).toBeVisible();
-	await expect(main.getByText("Shared Vault", { exact: true })).toBeVisible();
-	await expect(main.getByText("Scoped Vault", { exact: true })).toHaveCount(0);
-	await expect(
-		main
-			.getByRole("region", { name: "In this Project Vaults", exact: true })
-			.getByTestId("project-vault-card"),
-	).toHaveCount(2);
-	await expect(main.getByRole("region", { name: "Available Project Vaults" })).toHaveCount(0);
-	await expect(
-		main.getByRole("button", { name: /^(Link|Unlink) .* (to|from) Project$/ }),
-	).toHaveCount(0);
 	await expect(main.getByRole("link", { name: "Open Team-only Skill" })).toHaveAttribute(
 		"href",
 		"/agents/11111111-1111-4111-8111-111111111111/skills/team-only?project=project-context-first",
 	);
-	await expect(main.getByRole("link", { name: "Open vault Team Vault" })).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/vaults/team-vault?project=project-context-first&vault=vault-team&from=" +
-			encodeURIComponent(
-				"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first",
-			),
-	);
-	await expect(main.getByRole("button", { name: "View all Skills", exact: true })).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first/skills",
-	);
-	await expect(main.getByRole("button", { name: "View all Vaults", exact: true })).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first/vaults",
-	);
-	await main.getByRole("button", { name: "View all Skills", exact: true }).click();
-	await expect(page).toHaveURL(
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first/skills",
-	);
-	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
-	await expect(
-		page
-			.getByRole("navigation", { name: "breadcrumb" })
-			.locator('[data-slot="breadcrumb-item"]:visible'),
-	).toHaveText(["Smoke Codex", "Projects", "Team Knowledge", "Skills"]);
-	await expect(main.getByRole("button", { name: "Back to Team Knowledge" })).toHaveCount(0);
+	await main.getByRole("tab", { name: "Vaults", exact: true }).click();
+	await expect(main.getByText("Team Vault", { exact: true })).toBeVisible();
+	await expect(main.getByText("Shared Vault", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: /^(Add|Remove) .* Project$/ })).toHaveCount(0);
+	await main.getByRole("tab", { name: "Access", exact: true }).click();
+	await expect(main.getByRole("button", { name: "Leave project" })).toBeVisible();
 	await page.goto(
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later",
+		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later?tab=vaults",
 	);
 	await expect(main.getByRole("heading", { name: longContextProjectName, level: 1 })).toBeVisible();
-	await expect(
-		main.getByTestId("project-vault-card").filter({ hasText: "Scoped Vault" }),
-	).toHaveCount(0);
-	await expect(
-		main.getByRole("region", { name: "In this Project Vaults", exact: true }),
-	).toHaveCount(0);
 	await expect(
 		main
 			.getByRole("region", { name: "Available Project Vaults" })
 			.getByTestId("project-vault-card"),
-	).toHaveCount(0);
-	await expect(main.getByRole("button", { name: "View all Skills" })).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later/skills",
+	).toHaveCount(4);
+	await expect(main.getByRole("button", { name: "Create vault", exact: true })).toBeVisible();
+	await main.getByRole("link", { name: "Open vault Unrelated Vault" }).click();
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === "/agents/11111111-1111-4111-8111-111111111111/vaults/unrelated-vault" &&
+			!url.searchParams.has("project"),
 	);
-	await expect(main.getByRole("button", { name: "Add skill", exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: "View all Vaults" })).toHaveAttribute(
-		"href",
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later/vaults",
+	await expect(main.getByRole("heading", { name: "Unrelated Vault", level: 1 })).toBeVisible();
+	await main.getByRole("button", { name: "Back to Project" }).click();
+	await expect(main.getByRole("tab", { name: "Vaults", exact: true })).toHaveAttribute(
+		"aria-selected",
+		"true",
 	);
-	await expect(
-		main.getByRole("button", { name: /^(Link|Unlink|Add|Remove) .* (Workspace|Project)$/ }),
-	).toHaveCount(0);
+
 	const requestsBeforeInvalidScope = skillRequests.length;
 	await page.goto(
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-inaccessible/skills",
@@ -1917,8 +1893,11 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 	await expect(page).toHaveURL(
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first/skills",
 	);
-	await expect(main.getByRole("heading", { name: "Skills", level: 1 })).toBeVisible();
-	await expect(main.getByText("Project: Team Knowledge", { exact: true })).toBeVisible();
+	await expect(main.getByRole("heading", { name: "Team Knowledge", level: 1 })).toBeVisible();
+	await expect(main.getByRole("tab", { name: "Skills", exact: true })).toHaveAttribute(
+		"aria-selected",
+		"true",
+	);
 	await expect(main.getByText("Team-only Skill", { exact: true })).toBeVisible();
 	await expect(main.getByText("Primary-only Skill", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Add skill", exact: true })).toHaveCount(0);
@@ -1926,7 +1905,7 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 	await page.goto(
 		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-later/skills",
 	);
-	await expect(main.getByText(`Project: ${longContextProjectName}`, { exact: true })).toBeVisible();
+	await expect(main.getByRole("heading", { name: longContextProjectName, level: 1 })).toBeVisible();
 	const addSkillButton = main.getByRole("button", { name: "Add skill", exact: true });
 	await expect(addSkillButton).toBeVisible();
 	await addSkillButton.click();
@@ -2510,6 +2489,12 @@ test("unlinked Project resources stay inside the Agent without granting runtime 
 }, testInfo) => {
 	const { projectLinkDeltaBodies } = await stubConnectedAgentResources(page);
 	const base = "/agents/11111111-1111-4111-8111-111111111111";
+	await page.goto("/projects/project-context-first");
+	await expect(page.getByRole("tablist", { name: "Project pages" })).toBeVisible();
+	const libraryTabs = await page
+		.getByRole("tablist", { name: "Project pages" })
+		.getByRole("tab")
+		.allTextContents();
 	await page.goto(`${base}/project-access?q=Team`);
 	const card = page.getByTestId("agent-project-card").filter({ hasText: "Team Knowledge" });
 	await card.getByRole("button", { name: "Unlink Team Knowledge" }).click();
@@ -2522,13 +2507,27 @@ test("unlinked Project resources stay inside the Agent without granting runtime 
 	);
 	const main = page.locator("main");
 	await expect(main.getByRole("heading", { name: "Team Knowledge", level: 1 })).toBeVisible();
-	await expect(
-		main.getByText("Not linked to this Agent. Link it from Projects to enable access."),
-	).toBeVisible();
+	await expect(main.getByRole("tablist", { name: "Project pages" }).getByRole("tab")).toHaveText([
+		"Overview",
+		"Skills",
+		"Vaults",
+		"Agents",
+		"Access",
+	]);
+	await expect(main.getByRole("tablist", { name: "Project pages" }).getByRole("tab")).toHaveText(
+		libraryTabs,
+	);
 	await page.screenshot({
 		path: testInfo.outputPath("unlinked-project-desktop.png"),
 		fullPage: true,
 	});
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.screenshot({
+		path: testInfo.outputPath("unlinked-project-mobile.png"),
+		fullPage: true,
+	});
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await main.getByRole("tab", { name: "Skills", exact: true }).click();
 	await main.getByRole("link", { name: "Open Team-only Skill" }).click();
 	await expect(page).toHaveURL(
 		(url) =>
@@ -2539,6 +2538,7 @@ test("unlinked Project resources stay inside the Agent without granting runtime 
 	await page.reload();
 	await expect(main.getByRole("heading", { name: "Team-only Skill", level: 1 })).toBeVisible();
 	await page.goBack();
+	await main.getByRole("tab", { name: "Vaults", exact: true }).click();
 	await main.getByRole("link", { name: "Open vault Team Vault" }).click();
 	await expect(page).toHaveURL((url) => url.pathname === `${base}/vaults/team-vault`);
 	await expect(main.getByRole("heading", { name: "Team Vault", level: 1 })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -193,7 +193,7 @@ const memories = {
 			category: "context",
 			tags: ["shared"],
 			source: "web",
-			source_session_id: null,
+			source_session_id: "session-smoke-1",
 			source_machine_name: "smoke-machine.local",
 			access_count: 1,
 			created_at: now.toISOString(),
@@ -863,6 +863,10 @@ test("connected Agent Memories keeps established UI through nested list and deta
 	await expect(main.getByText("All agents", { exact: true })).toHaveCount(0);
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Open in resource library" })).toHaveCount(0);
+	await expect(main.getByRole("link", { name: "View session" })).toHaveAttribute(
+		"href",
+		"/agents/11111111-1111-4111-8111-111111111111/sessions/session-smoke-1",
+	);
 
 	const sidebar = page.getByTestId("app-sidebar");
 	const sessionsLink = sidebar.getByRole("link", { name: "Sessions", exact: true });
@@ -1202,6 +1206,12 @@ async function stubConnectedAgentResources(page: Page) {
 	await stubDashboardApi(page, [], {
 		projectBindings: projectAccessBindings,
 		projects: projectAccessProjects,
+		skillDetailResponses: {
+			"project-context-first/team-only": {
+				body: projectSkill("project-context-first", "team-only", "Team-only Skill"),
+				status: 200,
+			},
+		},
 		skillsByProjectId: {
 			"project-smoke": [
 				projectSkill("project-smoke", "primary-only", "Primary-only Skill"),
@@ -1445,7 +1455,7 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await expect(projectStack.getByRole("link", { name: "Open Smoke Project" })).toHaveCount(0);
 	await expect(releaseCard.getByRole("link", { name: "Open Release Project" })).toHaveAttribute(
 		"href",
-		/\/projects\/project-batch-second\?from=/,
+		/\/agents\/[^/]+\/project-access\/project-batch-second$/,
 	);
 	const search = projectStack.getByPlaceholder("Search projects…");
 	await search.fill("protected");
@@ -1501,7 +1511,8 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	await createdToast.getByRole("button", { name: "Open project" }).click();
 	await expect(page).toHaveURL((url) => {
 		return (
-			url.pathname === "/projects/project-created" &&
+			url.pathname ===
+				"/agents/11111111-1111-4111-8111-111111111111/project-access/project-created" &&
 			url.searchParams.get("from") === "/agents/11111111-1111-4111-8111-111111111111/project-access"
 		);
 	});
@@ -1843,7 +1854,7 @@ test("connected agent shares the Project catalog and preserves scoped Skills and
 	).toHaveCount(0);
 	const requestsBeforeInvalidScope = skillRequests.length;
 	await page.goto(
-		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-unrelated/skills",
+		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-inaccessible/skills",
 	);
 	await expect(
 		main.getByText("Project not available to this Agent", { exact: true }),
@@ -1987,9 +1998,9 @@ test("agent scoped Skills and Vaults preserve context for mutations", async ({ p
 		(url) =>
 			url.pathname.endsWith("/vaults/scoped-vault") && url.searchParams.get("from") === vaultOrigin,
 	);
-	await expect(main.getByRole("link", { name: "Manage in Vault Library" })).toHaveAttribute(
+	await expect(main.getByRole("link", { name: "Workspace", exact: true }).last()).toHaveAttribute(
 		"href",
-		"/vaults/scoped-vault?vault=vault-scoped",
+		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-smoke?tab=vaults",
 	);
 	const requestedVaultProjectIds = vaultRequests.map((request) =>
 		new URL(request).searchParams.get("project_id"),
@@ -2137,7 +2148,7 @@ test("agent Skill details resolve only through effective Projects", async ({ pag
 
 	const requestsBeforeTamperedProject = skillDetailRequests.length;
 	await page.goto(
-		`/agents/11111111-1111-4111-8111-111111111111/skills/scoped-skill?project=project-unrelated&${routeQuery}`,
+		`/agents/11111111-1111-4111-8111-111111111111/skills/scoped-skill?project=project-inaccessible&${routeQuery}`,
 	);
 	await expect(
 		main.getByText("Project not available to this Agent", { exact: true }),
@@ -2434,7 +2445,10 @@ test("Agent Vault inventory aggregates bound Projects and retains safe data on r
 	).toHaveCount(0);
 	await expect(
 		main.getByRole("link", { name: "Team Knowledge", exact: true }).last(),
-	).toHaveAttribute("href", "/projects/project-context-first?tab=vaults");
+	).toHaveAttribute(
+		"href",
+		"/agents/11111111-1111-4111-8111-111111111111/project-access/project-context-first?tab=vaults",
+	);
 	await main.getByRole("button", { name: "Back to Agent Vaults" }).click();
 	await expect(inventory.getByPlaceholder("Search vaults…")).toHaveValue("Team");
 	await page.goto("/agents/11111111-1111-4111-8111-111111111111");
@@ -2489,4 +2503,53 @@ test("Project card menu dialogs survive menu dismissal", async ({ page }) => {
 		await expect(archive).toBeHidden();
 		await expect(card.getByRole("link", { name: "Open Unrelated Project" })).toBeVisible();
 	}
+});
+
+test("unlinked Project resources stay inside the Agent without granting runtime access", async ({
+	page,
+}, testInfo) => {
+	const { projectLinkDeltaBodies } = await stubConnectedAgentResources(page);
+	const base = "/agents/11111111-1111-4111-8111-111111111111";
+	await page.goto(`${base}/project-access?q=Team`);
+	const card = page.getByTestId("agent-project-card").filter({ hasText: "Team Knowledge" });
+	await card.getByRole("button", { name: "Unlink Team Knowledge" }).click();
+	await expect(
+		card.getByRole("button", { name: "Link Team Knowledge", exact: true }),
+	).toBeEnabled();
+	await card.getByRole("link", { name: "Open Team Knowledge" }).click();
+	await expect(page).toHaveURL(
+		(url) => url.pathname === `${base}/project-access/project-context-first`,
+	);
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { name: "Team Knowledge", level: 1 })).toBeVisible();
+	await expect(
+		main.getByText("Not linked to this Agent. Link it from Projects to enable access."),
+	).toBeVisible();
+	await page.screenshot({
+		path: testInfo.outputPath("unlinked-project-desktop.png"),
+		fullPage: true,
+	});
+	await main.getByRole("link", { name: "Open Team-only Skill" }).click();
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === `${base}/skills/team-only` &&
+			url.searchParams.get("project") === "project-context-first",
+	);
+	await expect(main.getByRole("heading", { name: "Team-only Skill", level: 1 })).toBeVisible();
+	await page.reload();
+	await expect(main.getByRole("heading", { name: "Team-only Skill", level: 1 })).toBeVisible();
+	await page.goBack();
+	await main.getByRole("link", { name: "Open vault Team Vault" }).click();
+	await expect(page).toHaveURL((url) => url.pathname === `${base}/vaults/team-vault`);
+	await expect(main.getByRole("heading", { name: "Team Vault", level: 1 })).toBeVisible();
+	const source = main.getByRole("link", { name: "Team Knowledge", exact: true }).last();
+	await source.click();
+	await expect(page).toHaveURL(
+		(url) => url.pathname === `${base}/project-access/project-context-first`,
+	);
+	await page.goto(`${base}/project-access?q=Team`);
+	await expect(
+		card.getByRole("button", { name: "Link Team Knowledge", exact: true }),
+	).toBeEnabled();
+	expect(projectLinkDeltaBodies).toHaveLength(1);
 });

--- a/apps/web/src/components/dashboard/agent-project-browse-access.ts
+++ b/apps/web/src/components/dashboard/agent-project-browse-access.ts
@@ -1,0 +1,39 @@
+import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { isCustomProject } from "@/components/projects/project-metadata";
+import { useOpenApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
+import { shouldBlockQueryError } from "@/lib/query-state";
+
+/** Browsing an account Project does not grant the Agent runtime access to it. */
+export function useAgentProjectBrowseAccess(
+	agentId: string | null | undefined,
+	projectId: string | null | undefined,
+) {
+	const enabled = Boolean(agentId && projectId);
+	const bindings = useAgentProjectBindings(agentId, { enabled });
+	const bound = Boolean(
+		projectId && bindings.data?.some((binding) => binding.project_id === projectId),
+	);
+	const projects = useOpenApi().useQuery("get", "/v1/projects", {}, { enabled: enabled && !bound });
+	const error = !enabled
+		? null
+		: shouldBlockQueryError(bindings.error, bindings.data)
+			? bindings.error
+			: !bound &&
+					(isApiNotFoundError(projects.error) ||
+						shouldBlockQueryError(projects.error, projects.data))
+				? projects.error
+				: null;
+	return {
+		readable:
+			enabled &&
+			!error &&
+			(bound ||
+				Boolean(
+					projects.data?.some((project) => project.id === projectId && isCustomProject(project)),
+				)),
+		isLoading: enabled && (bindings.isLoading || (!bound && projects.isLoading)),
+		error,
+		refetch: () => Promise.all([bindings.refetch(), projects.refetch()]),
+	};
+}

--- a/apps/web/src/components/dashboard/agent-resource-route-gate.tsx
+++ b/apps/web/src/components/dashboard/agent-resource-route-gate.tsx
@@ -3,7 +3,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { useAgentProjectBrowseAccess } from "@/components/dashboard/agent-project-browse-access";
 import { DetailBackLink } from "@/components/detail/back-link";
 import { DetailNotFound } from "@/components/detail/layout";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -130,17 +130,10 @@ function AgentProjectAccessGate({
 	children: ReactNode;
 }) {
 	const projectId = rawProjectId?.trim() || null;
-	const bindings = useAgentProjectBindings(agentId, { enabled: Boolean(projectId) });
-	const blockingError = projectId
-		? shouldBlockQueryError(bindings.error, bindings.data)
-			? bindings.error
-			: null
-		: null;
-	const projectIsBound = Boolean(
-		projectId && bindings.data?.some((binding) => binding.project_id === projectId),
-	);
+	const access = useAgentProjectBrowseAccess(agentId, projectId);
+	const blockingError = access.error;
 
-	if (projectId && bindings.isLoading) {
+	if (access.isLoading) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-4 px-4 lg:px-6")}>
 				<DetailBackLink href={returnHref} label={returnLabel} mobileOnly={false} />
@@ -150,7 +143,7 @@ function AgentProjectAccessGate({
 		);
 	}
 
-	if (blockingError || !projectIsBound) {
+	if (blockingError || !access.readable) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-4 px-4 lg:px-6")}>
 				<DetailBackLink href={returnHref} label={returnLabel} mobileOnly={false} />
@@ -158,7 +151,7 @@ function AgentProjectAccessGate({
 					<ApiErrorPanel
 						error={blockingError}
 						onRetry={() => {
-							void bindings.refetch();
+							void access.refetch();
 						}}
 						title="Couldn't verify Workspace or Project access"
 					/>

--- a/apps/web/src/components/dashboard/agent-skill-detail-scope.test.ts
+++ b/apps/web/src/components/dashboard/agent-skill-detail-scope.test.ts
@@ -1,44 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import {
-	fetchAgentScopedSkillDetail,
-	resolveAgentSkillProjectAccess,
-} from "./agent-skill-detail-scope";
+import { fetchAgentScopedSkillDetail } from "./agent-skill-detail-scope";
 
 class NotFoundError extends Error {}
 
 describe("Agent Skill detail Project scope", () => {
-	const bindings = [
-		{ project_id: "primary", binding_type: "primary" },
-		{ project_id: "context", binding_type: "context" },
-	];
-
-	test("accepts only bound explicit Projects and never turns a tampered Project into a candidate", () => {
-		expect(resolveAgentSkillProjectAccess(bindings, "context")).toEqual({
-			kind: "bound",
-			projectIds: ["context"],
-		});
-		expect(resolveAgentSkillProjectAccess(bindings, "other")).toEqual({
-			kind: "unbound",
-			projectId: "other",
-		});
-	});
-
-	test("resolves omitted legacy context only to one primary Workspace", () => {
-		expect(resolveAgentSkillProjectAccess(bindings, "")).toEqual({
-			kind: "bound",
-			projectIds: ["primary"],
-		});
-		expect(
-			resolveAgentSkillProjectAccess([{ project_id: "context", binding_type: "context" }], ""),
-		).toEqual({ kind: "unavailable" });
-		expect(
-			resolveAgentSkillProjectAccess(
-				[...bindings, { project_id: "other-primary", binding_type: "primary" }],
-				"",
-			),
-		).toEqual({ kind: "unavailable" });
-	});
-
 	test("fails closed on non-404 errors and mismatched Project responses", async () => {
 		const calls: string[] = [];
 		await expect(

--- a/apps/web/src/components/dashboard/agent-skill-detail-scope.ts
+++ b/apps/web/src/components/dashboard/agent-skill-detail-scope.ts
@@ -1,29 +1,3 @@
-export type AgentSkillProjectAccess =
-	| { kind: "bound"; projectIds: string[] }
-	| { kind: "unavailable" }
-	| { kind: "unbound"; projectId: string };
-
-/**
- * Resolve a detail URL against the Agent's bindings. Explicit Project context
- * stays strict. Legacy URLs without context may use only the unique primary
- * Workspace and never search or aggregate context Projects.
- */
-export function resolveAgentSkillProjectAccess(
-	bindings: readonly { project_id: string; binding_type: string }[],
-	requestedProjectId: string,
-): AgentSkillProjectAccess {
-	if (!requestedProjectId) {
-		const primaryBindings = bindings.filter((binding) => binding.binding_type === "primary");
-		return primaryBindings.length === 1 && primaryBindings[0]
-			? { kind: "bound", projectIds: [primaryBindings[0].project_id] }
-			: { kind: "unavailable" };
-	}
-	if (!bindings.some((binding) => binding.project_id === requestedProjectId)) {
-		return { kind: "unbound", projectId: requestedProjectId };
-	}
-	return { kind: "bound", projectIds: [requestedProjectId] };
-}
-
 /**
  * Read one Skill through Project-explicit endpoints. A 404 advances to the
  * next effective Project; every other failure stops resolution so access does

--- a/apps/web/src/components/projects/projects-surface.tsx
+++ b/apps/web/src/components/projects/projects-surface.tsx
@@ -36,15 +36,12 @@ import { Spinner } from "@/components/ui/spinner";
 import { agentDetailQueryKey } from "@/lib/agent-queries";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { normalizeApiError } from "@/lib/api-errors";
-import {
-	formatResourceCount,
-	getProjectResourceDefinition,
-	projectDetailHref,
-} from "@/lib/project-resource-model";
+import { formatResourceCount, getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
 	agentResourceScope,
 	LIBRARY_RESOURCE_SCOPE,
+	projectDetailHrefForScope,
 	projectDetailLink,
 	resourceCollectionTarget,
 } from "@/lib/resource-navigation";
@@ -183,7 +180,7 @@ export function ProjectsSurface({
 									label: "Open project",
 									onClick: () =>
 										void router.navigate({
-											href: `${projectDetailHref(project.id)}?from=${encodeURIComponent(from)}`,
+											href: `${projectDetailHrefForScope(scope, project.id)}?from=${encodeURIComponent(from)}`,
 										}),
 								},
 							});
@@ -272,11 +269,7 @@ export function ProjectsSurface({
 												className="h-full"
 												project={project}
 												searchQuery={search.trim() || undefined}
-												link={projectDetailLink(
-													linked ? scope : LIBRARY_RESOURCE_SCOPE,
-													project.id,
-													search || (agentId && !linked) ? from : undefined,
-												)}
+												link={projectDetailLink(scope, project.id, search ? from : undefined)}
 												footer={[
 													formatResourceCount(project.skill_count, "skill"),
 													formatResourceCount(project.vault_count, "vault"),

--- a/apps/web/src/components/vault/project-vault-catalog.tsx
+++ b/apps/web/src/components/vault/project-vault-catalog.tsx
@@ -8,7 +8,7 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { ListToolbar } from "@/components/list-toolbar";
-import { displayProjectName } from "@/components/projects/project-metadata";
+import { displayProjectName, isCustomProject } from "@/components/projects/project-metadata";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
@@ -21,6 +21,7 @@ import { normalizeApiError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
+	agentResourceScope,
 	LIBRARY_RESOURCE_SCOPE,
 	type ResourceNavigationScope,
 	resourceCollectionTarget,
@@ -73,7 +74,7 @@ export function ProjectVaultCatalog({
 	else returnSearch.delete("q");
 	const returnHref = `${location.pathname}${returnSearch.size ? `?${returnSearch}` : ""}`;
 	const locked = useRef(false);
-	const canAttach = scope.kind !== "agent" && project.is_owner !== false;
+	const canAttach = isCustomProject(project) && project.is_owner !== false;
 	const catalog = useVaultCatalog({ enabled: canAttach });
 	const context = project.kind === "environment" ? "Workspace" : "Project";
 	const attachedIds = new Set(attachedVaults?.map((vault) => vault.id));
@@ -203,7 +204,11 @@ export function ProjectVaultCatalog({
 										locked.current = true;
 										updateAttachment.mutate({ vault, attached });
 									};
-									const detailScope = attached ? scope : LIBRARY_RESOURCE_SCOPE;
+									const detailScope = attached
+										? scope
+										: scope.kind === "agent"
+											? agentResourceScope(scope.agentId)
+											: LIBRARY_RESOURCE_SCOPE;
 									return (
 										<div key={vault.id} data-testid="project-vault-card" className="min-w-0">
 											<VaultCard
@@ -213,7 +218,7 @@ export function ProjectVaultCatalog({
 													projects.error,
 													projects.data,
 												)}
-												visibleProjectIds={scope.kind === "agent" ? new Set([project.id]) : null}
+												visibleProjectIds={null}
 												projectId={attached ? project.id : undefined}
 												navigationScope={detailScope}
 												returnHref={

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -424,7 +424,7 @@ export function VaultCard({
 				usedBy.length > 0 ? (
 					<Tooltip>
 						<TooltipTrigger render={<span className="truncate" />}>
-							{navigationScope.kind === "agent" ? "From " : "used by "}
+							{visibleProjectIds ? "From " : "used by "}
 							{usedBy.slice(0, 2).join(", ")}
 							{usedBy.length > 2 ? ` +${usedBy.length - 2}` : ""}
 						</TooltipTrigger>

--- a/apps/web/src/hosted/agents/hosted-workspace-skill-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-workspace-skill-detail.tsx
@@ -21,7 +21,7 @@ import { useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { workspaceSkillErrorNormalizer } from "@/hosted/agents/workspace-skill-errors";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import { billingKeys } from "@/hosted/billing/query-keys";
-import { agentProjectResourceHref } from "@/lib/agent-routes";
+import { agentProjectResourceHref, agentSkillDetailLink } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
 import { useDeploymentEventStreamActive } from "@/lib/deployment-event-stream-context";
 import { shouldBlockQueryError } from "@/lib/query-state";
@@ -158,12 +158,14 @@ export default function HostedWorkspaceSkillDetail({
 						</a>
 					) : detail.data?.kind === "library" && detail.data.skill.project_id ? (
 						<Link
-							to="/skills/$key"
-							params={{ key: detail.data.skill.skill_key }}
-							search={{ project: detail.data.skill.project_id }}
+							{...agentSkillDetailLink(
+								agentId,
+								detail.data.skill.skill_key,
+								detail.data.skill.project_id,
+							)}
 							className="text-sm text-muted-foreground hover:text-foreground"
 						>
-							View in Library
+							View source Skill
 						</Link>
 					) : null}
 					<DetailPanel>

--- a/apps/web/src/lib/resource-navigation.test.ts
+++ b/apps/web/src/lib/resource-navigation.test.ts
@@ -6,7 +6,6 @@ import {
 	connectorDetailLink,
 	LIBRARY_RESOURCE_SCOPE,
 	legacyAgentResourceScope,
-	libraryManagementTarget,
 	memoryDetailHrefForScope,
 	memoryDetailLink,
 	projectDetailHrefForScope,
@@ -143,19 +142,6 @@ describe("resource navigation scopes", () => {
 			params: { id: "agent 1", name: "google drive" },
 		});
 		expect(connectorDetailLink(scope, "google drive")).not.toHaveProperty("search");
-	});
-
-	it("makes leaving the Agent shell an explicit library-management target", () => {
-		expect(libraryManagementTarget("projects", { projectId: "project 1" })).toEqual({
-			href: "/projects/project%201",
-			label: "Manage in resource library",
-		});
-		expect(
-			libraryManagementTarget("vaults", { vaultSlug: "prod keys", vaultId: "vault/1" }),
-		).toEqual({
-			href: "/vaults/prod%20keys?vault=vault%2F1",
-			label: "Manage in resource library",
-		});
 	});
 
 	it("ignores obsolete Hosted identity fields on legacy resource-return links", () => {

--- a/apps/web/src/lib/resource-navigation.ts
+++ b/apps/web/src/lib/resource-navigation.ts
@@ -187,21 +187,6 @@ export function connectorDetailLink(scope: ResourceNavigationScope, connectorNam
 		: linkOptions({ to: "/connectors/$name", params: { name: connectorName } });
 }
 
-export function libraryManagementTarget(
-	resource: ProjectAssignedResource,
-	identity: { projectId: string } | { vaultSlug: string; vaultId?: string | null },
-): ResourceNavigationTarget {
-	return {
-		href:
-			resource === "projects" && "projectId" in identity
-				? projectDetailHref(identity.projectId)
-				: "vaultSlug" in identity
-					? vaultDetailHref(identity.vaultSlug, identity.vaultId)
-					: PROJECT_RESOURCE_LIST_PATHS[resource],
-		label: "Manage in resource library",
-	};
-}
-
 type LegacyResourceNavigationQuery =
 	| URLSearchParams
 	| Readonly<Record<string, unknown>>

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
+import { agentSessionDetailLink } from "@/lib/agent-routes";
 import { useOpenApi } from "@/lib/api";
 import { isApiNotFoundError, normalizeApiError } from "@/lib/api-errors";
 import { MEMORY_CATEGORY_COLORS, memoryDisplayName } from "@/lib/memory-utils";
@@ -194,11 +195,12 @@ export default function MemoryDetailPage({
 									<>
 										<span>·</span>
 										<Link
-											to="/sessions/$id"
-											params={{ id: memory.source_session_id }}
+											{...(scope.kind === "agent"
+												? agentSessionDetailLink(scope.agentId, memory.source_session_id)
+												: { to: "/sessions/$id", params: { id: memory.source_session_id } })}
 											className="underline hover:text-foreground"
 										>
-											{scope.kind === "agent" ? "View in session library" : "View session"}
+											View session
 										</Link>
 									</>
 								) : null}

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -7,7 +7,6 @@ import {
 	Bot,
 	CheckCircle2,
 	ChevronRight,
-	ExternalLink,
 	Eye,
 	LogOut,
 	Plus,
@@ -108,7 +107,6 @@ import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 import { projectResourceHref } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
-	libraryManagementTarget,
 	projectDetailHrefForScope,
 	type ResourceNavigationScope,
 	type ResourceNavigationTarget,
@@ -203,7 +201,6 @@ export default function ProjectDetailPage({
 		? (requestedTab as ProjectLocalTab)
 		: "overview";
 	const projectsTarget = resourceCollectionTarget(scope, "projects");
-	const managementTarget = libraryManagementTarget("projects", { projectId });
 	const isAgentScope = scope.kind === "agent";
 	const showSkills = isAgentScope ? focus !== "vaults" : localTab === "skills";
 	const showVaults = isAgentScope ? focus !== "skills" : localTab === "vaults";
@@ -311,7 +308,10 @@ export default function ProjectDetailPage({
 					},
 				}),
 			),
-		enabled: showSkills && (!isAgentScope || !!scopedBinding) && !(IS_HOSTED_BUILD && isWorkspace),
+		enabled:
+			showSkills &&
+			(!isAgentScope || !!scopedBinding || Boolean(project && isCustomProject(project))) &&
+			!(IS_HOSTED_BUILD && isWorkspace),
 	});
 	const workspaceSkillProjections = useMemo(
 		() => (skills.data?.items ?? []).filter((skill) => skill.authority === "agent_sync"),
@@ -331,7 +331,9 @@ export default function ProjectDetailPage({
 					),
 				{ pageSize: 200, resourceName: "Project Vaults" },
 			),
-		enabled: showVaults && (!isAgentScope || !!scopedBinding),
+		enabled:
+			showVaults &&
+			(!isAgentScope || !!scopedBinding || Boolean(project && isCustomProject(project))),
 	});
 	useEffect(() => {
 		if (skills.data?.total === undefined) return;
@@ -522,32 +524,6 @@ export default function ProjectDetailPage({
 		);
 	}
 
-	if (isAgentScope && !scopedBinding) {
-		return (
-			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-				<DetailBackLink
-					href={catalogReturnTarget?.href ?? projectsTarget.href}
-					label={catalogReturnTarget?.label ?? projectsTarget.label}
-					mobileOnly={false}
-				/>
-				<DetailNotFound
-					title="Project not available to this Agent"
-					message="The Project may have been removed from this Agent. It remains available in the resource library if your account still has access."
-				/>
-				<Button
-					render={<Link to={managementTarget.href} />}
-					nativeButton={false}
-					variant="ghost"
-					size="sm"
-					className="w-fit text-muted-foreground"
-				>
-					<ExternalLink className="size-3.5" />
-					{managementTarget.label}
-				</Button>
-			</div>
-		);
-	}
-
 	const blockingSkillsError = shouldBlockQueryError(skills.error, skills.data)
 		? skills.error
 		: null;
@@ -677,12 +653,14 @@ export default function ProjectDetailPage({
 										? "Vaults available through this Agent’s Workspace."
 										: "This Agent's fixed Workspace for installed Skills and Vaults."
 								: focus === "skills"
-									? "Skills this Agent uses through this linked Project."
+									? "Skills included in this Project."
 									: focus === "vaults"
 										? isOwner
-											? "Vaults this Agent can use through this Project."
-											: "Vaults this Agent can use through this Project. Key values stay protected."
-										: "This Agent uses the Project's Skills and Vaults as one bundle."
+											? "Vaults included in this Project."
+											: "Vaults included in this Project. Key values stay protected."
+										: scopedBinding
+											? "This Agent uses the Project's Skills and Vaults as one bundle."
+											: "Not linked to this Agent. Link it from Projects to enable access."
 							: projectDetailDescription(project, isOwner)
 					}
 					status={
@@ -796,7 +774,7 @@ export default function ProjectDetailPage({
 					isAgentScope
 						? isWorkspace
 							? "Installed Skills in this Agent's fixed Workspace."
-							: "Skills this Agent uses through this linked Project."
+							: "Skills included in this Project."
 						: project.kind === "environment"
 							? "Skills synced from this Agent. Manage them on the Agent."
 							: isOwner
@@ -906,7 +884,7 @@ export default function ProjectDetailPage({
 					isAgentScope
 						? isWorkspace
 							? "Vaults available through this Agent’s Workspace."
-							: "Vaults this Agent can use through this Project."
+							: "Vaults included in this Project."
 						: isOwner
 							? "Vaults included in this Project."
 							: "Read-only vaults shared through this Project."

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -426,7 +426,7 @@ export default function ProjectDetailPage({
 	);
 	useSetBreadcrumbTitle(
 		projectName
-			? isWorkspaceView && focus
+			? focus
 				? agentSectionLabel(focus)
 				: isWorkspace
 					? "Workspace"

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -196,29 +196,29 @@ export default function ProjectDetailPage({
 	// keep matching the URL the user is still looking at.
 	const { pathname, search } = useCommittedLocation();
 	const searchParams = useMemo(() => searchRecordToSearchParams(search), [search]);
-	const requestedTab = searchParams.get("tab");
-	const localTab: ProjectLocalTab = PROJECT_LOCAL_TABS.some((tab) => tab.id === requestedTab)
-		? (requestedTab as ProjectLocalTab)
-		: "overview";
-	const projectsTarget = resourceCollectionTarget(scope, "projects");
-	const isAgentScope = scope.kind === "agent";
-	const showSkills = isAgentScope ? focus !== "vaults" : localTab === "skills";
-	const showVaults = isAgentScope ? focus !== "skills" : localTab === "vaults";
-	const [useWithAgentOpen, setUseWithAgentOpen] = useState(
-		searchParams.get("useWithAgent") === "1",
-	);
-	const [skillsPage, setSkillsPage] = useState(1);
-	const joinedFromShare = !isAgentScope && searchParams.get("joined") === "share";
-	const catalogReturnTarget = resourceCatalogReturnTarget(searchParams.get("from"));
-	useEffect(() => {
-		setSkillsPage(1);
-	}, [projectId]);
-
 	const projectQuery = $api.useQuery("get", "/v1/projects/{project_id}", {
 		params: { path: { project_id: projectId } },
 	});
 
 	const project = projectQuery.data ?? null;
+	const requestedTab = searchParams.get("tab");
+	const localTab: ProjectLocalTab = PROJECT_LOCAL_TABS.some((tab) => tab.id === requestedTab)
+		? (requestedTab as ProjectLocalTab)
+		: (focus ?? "overview");
+	const projectsTarget = resourceCollectionTarget(scope, "projects");
+	const isWorkspaceView = scope.kind === "agent" && project?.kind === "environment";
+	const showSkills = isWorkspaceView ? focus !== "vaults" : localTab === "skills";
+	const showVaults = isWorkspaceView ? focus !== "skills" : localTab === "vaults";
+	const [useWithAgentOpen, setUseWithAgentOpen] = useState(
+		searchParams.get("useWithAgent") === "1",
+	);
+	const [skillsPage, setSkillsPage] = useState(1);
+	const joinedFromShare = !isWorkspaceView && searchParams.get("joined") === "share";
+	const catalogReturnTarget = resourceCatalogReturnTarget(searchParams.get("from"));
+	useEffect(() => {
+		setSkillsPage(1);
+	}, [projectId]);
+
 	const projectName = project ? displayProjectName(project) : null;
 	const projectResourceTargets =
 		scope.kind === "agent"
@@ -242,10 +242,10 @@ export default function ProjectDetailPage({
 	);
 	const scopedBinding =
 		orderedScopedBindings.find((binding) => binding.project_id === projectId) ?? null;
-	const isWorkspace = isAgentScope && scopedBinding?.binding_type === "primary";
+	const isWorkspace = isWorkspaceView && scopedBinding?.binding_type === "primary";
 	const canManageProjectSkills = canManageSkills && !isWorkspace;
 	const pageReturnTarget: ResourceNavigationTarget =
-		focus && scope.kind === "agent"
+		isWorkspaceView && focus && scope.kind === "agent"
 			? isWorkspace
 				? {
 						href: agentSectionHref(scope.agentId, "overview"),
@@ -282,14 +282,15 @@ export default function ProjectDetailPage({
 		"get",
 		"/v1/agents",
 		{},
-		{ enabled: !isAgentScope && !!project && useWithAgentOpen },
+		{ enabled: !isWorkspaceView && !!project && useWithAgentOpen },
 	);
 	const agentsById = useMemo(
 		() => new Map((environments.data ?? []).map((agent) => [agent.id, agent])),
 		[environments.data],
 	);
 	const projectAgent = project ? projectAgentFor(project, agentsById) : null;
-	const localTabHref = (tab: ProjectLocalTab) => projectLocalTabHref(pathname, searchParams, tab);
+	const localTabHref = (tab: ProjectLocalTab) =>
+		projectLocalTabHref(projectDetailHrefForScope(scope, projectId), searchParams, tab);
 	const selectLocalTab = (tab: ProjectLocalTab) => {
 		void router.navigate({ href: localTabHref(tab), resetScroll: false });
 	};
@@ -310,7 +311,7 @@ export default function ProjectDetailPage({
 			),
 		enabled:
 			showSkills &&
-			(!isAgentScope || !!scopedBinding || Boolean(project && isCustomProject(project))) &&
+			(!isWorkspaceView || !!scopedBinding || Boolean(project && isCustomProject(project))) &&
 			!(IS_HOSTED_BUILD && isWorkspace),
 	});
 	const workspaceSkillProjections = useMemo(
@@ -333,7 +334,7 @@ export default function ProjectDetailPage({
 			),
 		enabled:
 			showVaults &&
-			(!isAgentScope || !!scopedBinding || Boolean(project && isCustomProject(project))),
+			(!isWorkspaceView || !!scopedBinding || Boolean(project && isCustomProject(project))),
 	});
 	useEffect(() => {
 		if (skills.data?.total === undefined) return;
@@ -351,14 +352,15 @@ export default function ProjectDetailPage({
 					params: { path: { project_id: projectId } },
 				}),
 			),
-		enabled: !isAgentScope && !!project && isOwner && isShareableProject && localTab === "access",
+		enabled:
+			!isWorkspaceView && !!project && isOwner && isShareableProject && localTab === "access",
 	});
 
 	const boundAgents = $api.useQuery(
 		"get",
 		"/v1/agents",
 		{ params: { query: { project_id: projectId } } },
-		{ enabled: !isAgentScope && !!project && (localTab === "agents" || useWithAgentOpen) },
+		{ enabled: !isWorkspaceView && !!project && (localTab === "agents" || useWithAgentOpen) },
 	);
 
 	const refresh = async () => {
@@ -424,7 +426,7 @@ export default function ProjectDetailPage({
 	);
 	useSetBreadcrumbTitle(
 		projectName
-			? focus
+			? isWorkspaceView && focus
 				? agentSectionLabel(focus)
 				: isWorkspace
 					? "Workspace"
@@ -432,7 +434,7 @@ export default function ProjectDetailPage({
 			: null,
 	);
 
-	if (projectQuery.isLoading || (isAgentScope && scopedBindings.isLoading)) {
+	if (projectQuery.isLoading || (isWorkspaceView && scopedBindings.isLoading)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<DetailBackLink
@@ -451,7 +453,7 @@ export default function ProjectDetailPage({
 		);
 	}
 
-	const blockingScopeError = isAgentScope
+	const blockingScopeError = isWorkspaceView
 		? shouldBlockQueryError(scopedBindings.error, scopedBindings.data)
 			? scopedBindings.error
 			: null
@@ -508,7 +510,7 @@ export default function ProjectDetailPage({
 		);
 	}
 
-	if (!isAgentScope && project.kind !== "workspace") {
+	if (!isWorkspaceView && project.kind !== "workspace") {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<DetailBackLink
@@ -545,14 +547,14 @@ export default function ProjectDetailPage({
 	const blockingEnvironmentsError = shouldBlockQueryError(environments.error, environments.data)
 		? environments.error
 		: null;
-	const skillCount: CountValue | undefined = isAgentScope
+	const skillCount: CountValue | undefined = isWorkspaceView
 		? isWorkspace || project.kind === "environment"
 			? undefined
 			: blockingSkillsError
 				? "unavailable"
 				: skills.data?.total
 		: project.skill_count;
-	const vaultCount: CountValue | undefined = isAgentScope
+	const vaultCount: CountValue | undefined = isWorkspaceView
 		? blockingVaultsError
 			? "unavailable"
 			: vaults.data?.total
@@ -579,7 +581,8 @@ export default function ProjectDetailPage({
 	);
 	const projectIdentity = identityFor(displayProjectName(project));
 	const workspaceIdentity = identityFor("Workspace");
-	const focusedResourceIdentity = focus ? AGENT_SECTION_NAVIGATION_ITEMS[focus] : null;
+	const focusedResourceIdentity =
+		isWorkspaceView && focus ? AGENT_SECTION_NAVIGATION_ITEMS[focus] : null;
 	const FocusedResourceIcon = focusedResourceIdentity?.icon ?? null;
 	const focusedWorkspaceSkillsPageHeaderProps: Omit<PageHeaderProps, "actions"> | undefined =
 		isWorkspace && focus === "skills"
@@ -645,48 +648,16 @@ export default function ProjectDetailPage({
 						)
 					}
 					description={
-						isAgentScope
-							? isWorkspace
-								? focus === "skills"
-									? "Skills available in this Agent's Workspace. Skills synced from the Agent are read-only."
-									: focus === "vaults"
-										? "Vaults available through this Agent’s Workspace."
-										: "This Agent's fixed Workspace for installed Skills and Vaults."
-								: focus === "skills"
-									? "Skills included in this Project."
-									: focus === "vaults"
-										? isOwner
-											? "Vaults included in this Project."
-											: "Vaults included in this Project. Key values stay protected."
-										: scopedBinding
-											? "This Agent uses the Project's Skills and Vaults as one bundle."
-											: "Not linked to this Agent. Link it from Projects to enable access."
+						isWorkspace
+							? focus === "vaults"
+								? "Vaults available through this Agent’s Workspace."
+								: "This Agent's fixed Workspace for installed Skills and Vaults."
 							: projectDetailDescription(project, isOwner)
 					}
-					status={
-						focus && !isWorkspace ? (
-							<span className="text-xs text-muted-foreground">
-								Project: {displayProjectName(project)}
-							</span>
-						) : undefined
-					}
 					actions={
-						focus === "skills" && canManageProjectSkills ? (
-							<CreateSkillDialog project={project} onCreated={refresh}>
-								<Button size="sm">
-									<Plus className="size-3.5" />
-									Add skill
-								</Button>
-							</CreateSkillDialog>
-						) : focus === "vaults" && isOwner && !isAgentScope ? (
-							<CreateProjectVaultDialog
-								projectId={project.id}
-								contextLabel={isWorkspace ? "Workspace" : "Project"}
-								onChanged={refresh}
-							/>
-						) : !focus && isShareableProject && (!isAgentScope || isOwner) ? (
+						isShareableProject ? (
 							<>
-								{!isAgentScope && !joinedFromShare
+								{!isWorkspaceView && !joinedFromShare
 									? manageAgentsDialog(
 											<Button size="sm">
 												<Bot className="mr-1.5 size-3.5" />
@@ -721,7 +692,7 @@ export default function ProjectDetailPage({
 				</Alert>
 			) : null}
 
-			{!isAgentScope ? (
+			{!isWorkspaceView ? (
 				<Tabs
 					value={localTab}
 					onValueChange={(value) => {
@@ -746,7 +717,7 @@ export default function ProjectDetailPage({
 				</Tabs>
 			) : null}
 
-			{!isAgentScope && localTab === "overview" ? (
+			{!isWorkspaceView && localTab === "overview" ? (
 				<DetailPanel className="space-y-5">
 					<div className="space-y-1">
 						<h2 className="text-sm font-semibold">Project bundle</h2>
@@ -766,12 +737,12 @@ export default function ProjectDetailPage({
 
 			<HubSection
 				visible={showSkills}
-				showHeading={!focus}
+				showHeading={!isWorkspaceView || !focus}
 				id="skills"
 				title="Skills"
 				count={skillCount}
 				description={
-					isAgentScope
+					isWorkspaceView
 						? isWorkspace
 							? "Installed Skills in this Agent's fixed Workspace."
 							: "Skills included in this Project."
@@ -782,7 +753,7 @@ export default function ProjectDetailPage({
 								: "Readable instructions shared by the owner."
 				}
 				action={
-					!focus && (projectResourceTargets || canManageProjectSkills) ? (
+					(!focus || !isWorkspaceView) && (projectResourceTargets || canManageProjectSkills) ? (
 						<>
 							{!focus && projectResourceTargets ? (
 								<ProjectResourceViewAllLink
@@ -876,12 +847,12 @@ export default function ProjectDetailPage({
 
 			<HubSection
 				visible={showVaults}
-				showHeading={!focus}
+				showHeading={!isWorkspaceView || !focus}
 				id="vaults"
 				title="Vaults"
-				count={isAgentScope ? vaultCount : undefined}
+				count={isWorkspaceView ? vaultCount : undefined}
 				description={
-					isAgentScope
+					isWorkspaceView
 						? isWorkspace
 							? "Vaults available through this Agent’s Workspace."
 							: "Vaults included in this Project."
@@ -890,15 +861,15 @@ export default function ProjectDetailPage({
 							: "Read-only vaults shared through this Project."
 				}
 				action={
-					!focus && (isAgentScope || isOwner) ? (
+					(!focus || !isWorkspaceView) && (isWorkspaceView || isOwner) ? (
 						<>
-							{!focus && isAgentScope && projectResourceTargets ? (
+							{!focus && isWorkspaceView && projectResourceTargets ? (
 								<ProjectResourceViewAllLink
 									href={projectResourceTargets.vaults}
 									resource="Vaults"
 								/>
 							) : null}
-							{isOwner && !isAgentScope ? (
+							{isOwner && !isWorkspaceView ? (
 								<CreateProjectVaultDialog
 									projectId={project.id}
 									contextLabel={isWorkspace ? "Workspace" : "Project"}
@@ -922,7 +893,7 @@ export default function ProjectDetailPage({
 				/>
 			</HubSection>
 
-			{!isAgentScope && localTab === "access" && isOwner && isShareableProject ? (
+			{!isWorkspaceView && localTab === "access" && isOwner && isShareableProject ? (
 				<HubSection
 					id="people"
 					title="People"
@@ -971,7 +942,7 @@ export default function ProjectDetailPage({
 				</HubSection>
 			) : null}
 
-			{!isAgentScope && localTab === "access" && !isOwner ? (
+			{!isWorkspaceView && localTab === "access" && !isOwner ? (
 				<HubSection
 					id="people"
 					title="Your access"
@@ -987,7 +958,7 @@ export default function ProjectDetailPage({
 				</HubSection>
 			) : null}
 
-			{!isAgentScope && localTab === "agents" ? (
+			{!isWorkspaceView && localTab === "agents" ? (
 				<HubSection
 					id="agents"
 					title="Your Agents"

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -375,7 +375,7 @@ export function SessionDetailContent({
 		? formatSessionSummary(session.summary) || session.local_session_id.slice(0, 12)
 		: null;
 	const sessionAgentIdentity = session ? sessionAgentIdentityInput(session) : null;
-	const detailAgentIdentity = scopedAgent ?? sessionAgentIdentity;
+	const detailAgentIdentity = sessionAgentIdentity ?? scopedAgent;
 	useSetBreadcrumbTitle(summaryText);
 
 	if (isSessionLoading) {

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -22,11 +22,9 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { agentDisplayName, cleanMachineName } from "@/components/dashboard/agent-label";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
+import { useAgentProjectBrowseAccess } from "@/components/dashboard/agent-project-browse-access";
 import { resolveAgentProjectScope } from "@/components/dashboard/agent-project-scope";
-import {
-	fetchAgentScopedSkillDetail,
-	resolveAgentSkillProjectAccess,
-} from "@/components/dashboard/agent-skill-detail-scope";
+import { fetchAgentScopedSkillDetail } from "@/components/dashboard/agent-skill-detail-scope";
 import {
 	AGENT_PROJECT_SKILLS_REFRESH_POLICY,
 	agentSkillForegroundRefetchInterval,
@@ -107,8 +105,8 @@ export function SkillDetailContent({
 	const queryClient = useQueryClient();
 
 	// Library routes keep their legacy resolver fallback for backwards
-	// compatibility. Agent routes must resolve one explicit binding first and
-	// only call the endpoint for the Project selected on the Project hub.
+	// compatibility. Agent routes verify the selected Project is readable and
+	// only call that Project’s endpoint; browsing never creates an Agent binding.
 	// Router-validated search (one ownership system — not nuqs), from the
 	// committed match so the page agrees with the rendered route.
 	const { search: committedSearch } = useCommittedLocation();
@@ -133,17 +131,10 @@ export function SkillDetailContent({
 			return error;
 		}
 	}, [isAgentScope, scopedBindings.data]);
-	const scopedProjectAccess = useMemo(
-		() => resolveAgentSkillProjectAccess(scopedBindings.data ?? [], selectedProjectId),
-		[scopedBindings.data, selectedProjectId],
-	);
-	const bindingsResolved = !isAgentScope || scopedBindings.data !== undefined;
-	const scopedSkillQueryEnabled =
-		!isAgentScope ||
-		(bindingsResolved &&
-			!scopedProjectError &&
-			scopedProjectAccess.kind === "bound" &&
-			scopedProjectAccess.projectIds.length > 0);
+	const browseAccess = useAgentProjectBrowseAccess(agentId, selectedProjectId);
+	const bindingsResolved = !isAgentScope || !browseAccess.isLoading;
+	const scopedSkillQueryEnabled = !isAgentScope || (!scopedProjectError && browseAccess.readable);
+
 	const projectionScope = agentId
 		? `agent:${JSON.stringify([agentId, selectedProjectId])}`
 		: "cloud";
@@ -156,11 +147,8 @@ export function SkillDetailContent({
 		enabled: skillKey.length > 0 && scopedSkillQueryEnabled,
 		queryFn: async () => {
 			if (isAgentScope) {
-				if (scopedProjectAccess.kind !== "bound") {
-					throw new Error("This Project is not available to this Agent.");
-				}
 				return fetchAgentScopedSkillDetail(
-					scopedProjectAccess.projectIds,
+					[selectedProjectId],
 					async (projectId) =>
 						unwrap(
 							await api.GET("/v1/projects/{project_id}/skills/{skill_key}", {
@@ -194,9 +182,9 @@ export function SkillDetailContent({
 			? scopedBindings.error
 			: null
 		: null;
-	const agentAccessError = blockingBindingsError ?? scopedProjectError;
+	const agentAccessError = blockingBindingsError ?? scopedProjectError ?? browseAccess.error;
 	const agentProjectUnavailable =
-		isAgentScope && bindingsResolved && !scopedProjectError && scopedProjectAccess.kind !== "bound";
+		isAgentScope && bindingsResolved && !scopedProjectError && !browseAccess.readable;
 	const skillIsLoading =
 		(isAgentScope && !bindingsResolved && !agentAccessError) ||
 		(!agentAccessError && !agentProjectUnavailable && skillQuery.isLoading);
@@ -446,7 +434,7 @@ export function SkillDetailContent({
 				<DetailNotFound
 					title="Project not available to this Agent"
 					message={
-						scopedProjectAccess.kind === "unavailable"
+						!selectedProjectId
 							? "The Workspace is not available yet. Return to Projects and try again."
 							: "The requested Project is not available through this Agent. Choose an available Project first."
 					}

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default function VaultDetailPage({
 	const router = useRouter();
 	const catalogReturnTarget = resourceCatalogReturnTarget(committedSearch.from);
 	const backTarget = catalogReturnTarget ?? resourceCollectionTarget(scope, "vaults");
-	const isAgentScope = scope.kind === "agent";
+	const isAgentScope = scope.kind === "agent" && Boolean(scope.projectId);
 	const requestedProjectId =
 		scope.kind === "agent" && scope.projectId?.trim() ? scope.projectId.trim() : null;
 	const scopedBindings = useAgentProjectBindings(scope.kind === "agent" ? scope.agentId : "", {
@@ -815,7 +815,7 @@ export default function VaultDetailPage({
 											</Link>
 										) : (
 											<span className="block text-sm font-medium">
-												{displayProjectName(project)}
+												{isWorkspaceAttachment ? "Workspace" : displayProjectName(project)}
 											</span>
 										)}
 										<p className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -2,21 +2,14 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
-import {
-	Copy as CopyIcon,
-	ExternalLink,
-	FolderInput,
-	ListChecks,
-	Plus,
-	Trash2,
-} from "lucide-react";
+import { Copy as CopyIcon, FolderInput, ListChecks, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { useAgentProjectBindings } from "@/components/dashboard/agent-project-bindings-query";
-import { effectiveAgentProjectIds } from "@/components/dashboard/agent-project-scope";
+import { useAgentProjectBrowseAccess } from "@/components/dashboard/agent-project-browse-access";
 import { DetailBackLink } from "@/components/detail/back-link";
 import { DetailNotFound } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
@@ -54,7 +47,7 @@ import { identityFor } from "@/lib/identity";
 import { decodeResourceRouteParam } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import {
-	libraryManagementTarget,
+	projectDetailLink,
 	type ResourceNavigationScope,
 	resourceCatalogReturnTarget,
 	resourceCollectionTarget,
@@ -107,15 +100,13 @@ export default function VaultDetailPage({
 	const scopedBindings = useAgentProjectBindings(scope.kind === "agent" ? scope.agentId : "", {
 		enabled: scope.kind === "agent" && Boolean(requestedProjectId),
 	});
-	const scopedProjectIds = useMemo(
-		() => effectiveAgentProjectIds(scopedBindings.data ?? []),
-		[scopedBindings.data],
+	const browseAccess = useAgentProjectBrowseAccess(
+		scope.kind === "agent" ? scope.agentId : null,
+		requestedProjectId,
 	);
-	const scopedProjectIdSet = useMemo(() => new Set(scopedProjectIds), [scopedProjectIds]);
-	const scopedBindingsResolved = !isAgentScope || scopedBindings.data !== undefined;
-	const requestedProjectIsBound = Boolean(
-		requestedProjectId && scopedProjectIdSet.has(requestedProjectId),
-	);
+	const scopedBindingsResolved = !isAgentScope || !browseAccess.isLoading;
+	const requestedProjectIsReadable = browseAccess.readable;
+
 	const requestedBinding = scopedBindings.data?.find(
 		(binding) => binding.project_id === requestedProjectId,
 	);
@@ -123,7 +114,7 @@ export default function VaultDetailPage({
 		requestedBinding?.binding_type === "primary" ? "Workspace" : "Project";
 
 	// One backend resolver owns both exact UUID links and legacy slug bookmarks.
-	// Agent scope always supplies the exact bound Project before this query runs.
+	// Agent scope supplies an exact readable Project before this query runs.
 	const vaultDetail = useQuery({
 		queryKey: ["vault-detail", slug, vaultId, requestedProjectId],
 		queryFn: async () =>
@@ -140,19 +131,15 @@ export default function VaultDetailPage({
 			),
 		enabled:
 			!isAgentScope ||
-			(Boolean(requestedProjectId) && scopedBindingsResolved && requestedProjectIsBound),
+			(Boolean(requestedProjectId) && scopedBindingsResolved && requestedProjectIsReadable),
 	});
 	const vault: VaultSummary | null = vaultDetail.data ?? null;
 	const resolvedVaultId = vault?.id ?? vaultId;
-	const managementTarget = libraryManagementTarget("vaults", {
-		vaultSlug: slug,
-		vaultId: resolvedVaultId,
-	});
 	const isOwner = vault?.is_owner !== false;
 	const canManageVault = isOwner;
 	const anyProjectId = isAgentScope
 		? requestedProjectId &&
-			requestedProjectIsBound &&
+			requestedProjectIsReadable &&
 			vault?.project_ids?.includes(requestedProjectId)
 			? requestedProjectId
 			: undefined
@@ -214,12 +201,13 @@ export default function VaultDetailPage({
 		? projects.error
 		: null;
 	const blockingScopeError = isAgentScope
-		? shouldBlockQueryError(scopedBindings.error, scopedBindings.data)
-			? scopedBindings.error
+		? shouldBlockQueryError(browseAccess.error, browseAccess.readable ? true : undefined)
+			? browseAccess.error
 			: null
 		: null;
 	const requestedProjectUnavailable =
-		isAgentScope && (!requestedProjectId || (scopedBindingsResolved && !requestedProjectIsBound));
+		isAgentScope &&
+		(!requestedProjectId || (scopedBindingsResolved && !requestedProjectIsReadable));
 
 	// Curation toolkit for grab-bag vaults (the default vault holds
 	// hundreds of keys): search by name, batch-select, then copy/move
@@ -390,10 +378,7 @@ export default function VaultDetailPage({
 
 	useSetBreadcrumbTitle(vault?.name ?? null);
 
-	if (
-		vaultDetail.isLoading ||
-		(isAgentScope && Boolean(requestedProjectId) && scopedBindings.isLoading)
-	) {
+	if (vaultDetail.isLoading || (isAgentScope && browseAccess.isLoading)) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<DetailBackLink href={backTarget.href} label={backTarget.label} mobileOnly={false} />
@@ -419,7 +404,7 @@ export default function VaultDetailPage({
 						error={blockingError}
 						onRetry={() => {
 							if (blockingVaultDetailError) void vaultDetail.refetch();
-							if (blockingScopeError) void scopedBindings.refetch();
+							if (blockingScopeError) void browseAccess.refetch();
 						}}
 						title={blockingScopeError ? "Couldn't load Agent Vault access" : "Couldn't load vault"}
 					/>
@@ -464,18 +449,8 @@ export default function VaultDetailPage({
 				<DetailBackLink href={backTarget.href} label={backTarget.label} mobileOnly={false} />
 				<DetailNotFound
 					title="Vault not available to this Agent"
-					message="This Vault is no longer available through the Agent's Projects. It remains in the resource library if your account still has access."
+					message="This Vault is no longer in the selected Project. Return to Vaults to choose another."
 				/>
-				<Button
-					render={<Link to={managementTarget.href} />}
-					nativeButton={false}
-					variant="ghost"
-					size="sm"
-					className="w-fit text-muted-foreground"
-				>
-					<ExternalLink className="size-3.5" />
-					{managementTarget.label}
-				</Button>
 			</div>
 		);
 	}
@@ -830,26 +805,13 @@ export default function VaultDetailPage({
 							return (
 								<div key={project.id} className="flex items-center gap-3 px-4 py-2.5">
 									<div className="min-w-0 flex-1">
-										{isWorkspaceAttachment ? (
-											<>
-												<span className="block text-sm font-medium">Workspace</span>
-												{isAgentScope && isOwner ? (
-													<Link
-														to={managementTarget.href}
-														className="text-xs text-muted-foreground underline"
-													>
-														Manage in Vault Library
-													</Link>
-												) : null}
-											</>
-										) : isCustomProject(project) ? (
+										{(isWorkspaceAttachment && isAgentScope) || isCustomProject(project) ? (
 											<Link
-												to="/projects/$id"
-												params={{ id: project.id }}
+												{...projectDetailLink(scope, project.id)}
 												search={{ tab: "vaults" }}
 												className="block truncate text-sm font-medium hover:underline"
 											>
-												{displayProjectName(project)}
+												{isWorkspaceAttachment ? "Workspace" : displayProjectName(project)}
 											</Link>
 										) : (
 											<span className="block text-sm font-medium">

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id.tsx
@@ -33,7 +33,8 @@ export const Route = createFileRoute("/_protected/_dashboard/agents/$id")({
 			currentRoute && agentRouteIdsEqual(currentRoute.agentId, params.id)
 				? currentRoute.section
 				: "overview";
-		const legacy = legacyAgentRoute(fallbackSection, search);
+		// Project tabs belong to the shared Project page, not legacy Agent section navigation.
+		const legacy = currentRoute?.projectId ? null : legacyAgentRoute(fallbackSection, search);
 		if (legacy) {
 			if (currentRoute?.sessionId) {
 				throw redirect({

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/vaults/$slug.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/vaults/$slug.tsx
@@ -34,6 +34,17 @@ function AgentVaultDetailRoute() {
 		? agentProjectResourceHref(id, projectId, "vaults")
 		: agentSectionHref(id, "projects");
 
+	if (!projectId && typeof search.vault === "string" && search.vault.trim()) {
+		return (
+			<AgentResourceRouteGate
+				agentId={id}
+				returnHref={agentSectionHref(id, "vaults")}
+				returnLabel="Vaults"
+			>
+				<VaultDetailPage slug={slug} scope={agentResourceScope(id)} />
+			</AgentResourceRouteGate>
+		);
+	}
 	if (!projectId) {
 		return (
 			<AgentResourceRouteGate agentId={id} returnHref={returnHref} returnLabel="Projects">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,7 +243,10 @@ kind names or offer the compatibility container as a Project.
 
 Every Agent has one fixed Workspace through `default_project_id` and a
 `primary` `agent_project_bindings` row. User Projects are ordered `context`
-bindings. Sharing grants existing read access only; Link Project is an explicit
+bindings. Agent resource navigation stays under `/agents/{id}` even when browsing an
+unlinked user Project. Account authorization controls browsing; Agent bindings
+control runtime use. Private Workspaces remain restricted to their bound Agent.
+Sharing grants existing read access only; Link Project is an explicit
 whole-bundle action. A linked Agent uses every Skill in the Project and resolves
 its attached Vaults. Link, unlink, Project Skill changes, and Project archival
 invalidate the affected managed Agent desired state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,7 +244,9 @@ kind names or offer the compatibility container as a Project.
 Every Agent has one fixed Workspace through `default_project_id` and a
 `primary` `agent_project_bindings` row. User Projects are ordered `context`
 bindings. Agent resource navigation stays under `/agents/{id}` even when browsing an
-unlinked user Project. Account authorization controls browsing; Agent bindings
+unlinked user Project. Agent and Library entry points use the same user Project
+page, tabs, and owner/viewer actions; navigation context only changes destinations.
+Account authorization controls browsing; Agent bindings
 control runtime use. Private Workspaces remain restricted to their bound Agent.
 Sharing grants existing read access only; Link Project is an explicit
 whole-bundle action. A linked Agent uses every Skill in the Project and resolves


### PR DESCRIPTION
Resources opened from an Agent could jump to Library, and Agent Project details used a separate resource overview instead of the standard Project page. Agent and Library now use the same Project page, tabs, content, and owner/viewer actions. Only navigation destinations retain their entry context. Project tabs no longer get consumed by the legacy Agent-tab redirect.

Project cards (including unlinked Projects), new-Project links, Vault Project/Workspace sources, Memory Session sources, and installed Skill sources stay under the active Agent. Account-readable Projects can be browsed without granting runtime access; private Workspaces still require the correct Agent binding. Unattached Vaults opened from a Project catalog use their exact UUID in the Agent route and preserve the return location. Existing Project/Vault/Skill identity validation and backend authorization remain in force. No schema, membership, runtime, or data migration.

Validation runs in isolated Docker: typecheck, web unit tests, OSS build, production SSR, and focused OSS/Hosted browser checks. Browser coverage compares the shared Project tabs through both entry points, opens an unlinked Project and its Skills/Vaults without creating a binding, exercises Project owner/viewer controls, source navigation, search/back/refresh, and rejects inaccessible Projects and missing Agents. The host hook points to another workspace; equivalent Biome checks run in Docker.
