### PR TITLE
fix(web): refine dashboard activity and show the full agent fleet

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4960,9 +4960,7 @@ test("Breadcrumbs show the full trail on desktop and only the current page on na
 	});
 });
 
-test("Console shows the full fleet without replacing its greeting during loading", async ({
-	page,
-}) => {
+test("Console shows every agent when the fleet exceeds six", async ({ page }) => {
 	const agents = Array.from({ length: 8 }, (_, index) => ({
 		...railConnectedCloudAgent,
 		id: `99999999-9999-4999-8999-${String(index).padStart(12, "0")}`,
@@ -4970,90 +4968,27 @@ test("Console shows the full fleet without replacing its greeting during loading
 		sort_order: index,
 	}));
 	await stubHostedApi(page, { cloudAgents: agents });
-	await page.addInitScript(() => {
-		const headings = new Set<Element>();
-		const texts = new Set<string>();
-		const observer = new MutationObserver(() => {
-			const heading = document.querySelector("main h1");
-			if (!heading) return;
-			headings.add(heading);
-			if (heading.textContent) texts.add(heading.textContent);
-			document.documentElement.dataset.consoleGreetingCount = String(headings.size);
-			document.documentElement.dataset.consoleGreetingTexts = JSON.stringify([...texts]);
-		});
-		observer.observe(document, { subtree: true, childList: true, characterData: true });
-	});
 	await page.goto("/");
 	const main = page.locator("main");
-	await expect(main.getByRole("heading", { level: 1 })).toHaveText(
-		/^Good (morning|afternoon|evening), Dev$/,
-	);
 	for (const agent of agents) {
 		await expect(
 			main.getByRole("link", { name: `Open ${agent.display_name}.`, exact: false }),
 		).toBeVisible();
 	}
-	await expect(main.getByText("8 agents", { exact: true })).toBeVisible();
-	await expect(main.getByRole("button", { name: /Show all|Show fewer/ })).toHaveCount(0);
-	await expect(page.locator("html")).toHaveAttribute("data-console-greeting-count", "1");
-	const texts: string[] = JSON.parse(
-		(await page.locator("html").getAttribute("data-console-greeting-texts")) ?? "[]",
-	);
-	expect(texts).toHaveLength(1);
 });
 
 test("Console keeps its desktop columns and places Recent sessions last on narrow screens", async ({
 	page,
 }, testInfo) => {
 	await stubHostedApi(page);
-	await page.route(`${CLOUD_API}/v1/dashboard/stats`, (route) =>
-		fulfillJson(route, {
-			manual_sessions_last_7_days: 0,
-			automated_sessions_last_7_days: 0,
-			top_model_last_7_days: null,
-			sessions_today: 0,
-			current_streak: 0,
-			contribution: Array.from({ length: 365 }, (_, index) => ({
-				date: new Date(Date.UTC(2025, 8, 9 + index)).toISOString().slice(0, 10),
-				count: index % 5,
-				level: index % 5,
-			})),
-		}),
-	);
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/");
 
 	const main = page.locator("main");
-	const activity = main.getByRole("heading", { name: "Activity", exact: true });
+	const activity = main.getByText("Activity", { exact: true });
 	const library = main.getByText("Library", { exact: true });
 	const recentSessions = main.getByRole("heading", { name: "Recent sessions", exact: true });
 	await expect(recentSessions).toBeVisible();
-	const connectAgent = main.getByRole("button", { name: "Connect an agent on your machine" });
-	await expect(connectAgent).toBeVisible();
-	await expect(main.getByRole("heading", { level: 1 })).toHaveText(/^Good /);
-
-	const activitySection = activity.locator("..");
-	await expect(activitySection.locator('[data-slot="card"]')).toHaveCount(0);
-	await expect(main.getByText("Sessions per day in the last 12 months")).toHaveCount(0);
-	await expect(activitySection.getByText(/^(Less|More)$/)).toHaveCount(0);
-	const cells = activitySection.locator('[title*="sessions on"]');
-	await expect(cells.first()).toHaveCSS("border-radius", "2px");
-	const assertMonthGeometry = async () => {
-		const gridBottom = await cells.evaluateAll((elements) =>
-			Math.max(...elements.map((element) => element.getBoundingClientRect().bottom)),
-		);
-		const months = activitySection.getByText(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/);
-		await expect(months.first()).toBeVisible();
-		const boxes = await months.evaluateAll((elements) =>
-			elements.map((element) => element.getBoundingClientRect().toJSON()),
-		);
-		for (const [index, box] of boxes.entries()) {
-			expect(box.y).toBeGreaterThan(gridBottom);
-			if (index > 0) expect(box.x).toBeGreaterThanOrEqual(boxes[index - 1].right);
-		}
-		await expectNoHorizontalOverflow(activitySection, "Activity month labels");
-	};
-	await assertMonthGeometry();
 
 	const [desktopActivity, desktopLibrary, desktopRecent] = await Promise.all([
 		activity.boundingBox(),
@@ -5065,7 +5000,6 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	}
 	expect(desktopRecent.y).toBeGreaterThan(desktopActivity.y);
 	expect(desktopLibrary.x).toBeGreaterThan(desktopActivity.x);
-	await page.screenshot({ path: testInfo.outputPath("console-1280x900.png"), fullPage: true });
 
 	await page.setViewportSize({ width: 320, height: 568 });
 	const sectionOrder = await main
@@ -5079,6 +5013,7 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 		);
 	expect(sectionOrder).toEqual(["Activity", "Library", "Last 7 days", "Recent sessions"]);
 
+	const connectAgent = main.getByRole("button", { name: "Connect an agent on your machine" });
 	await expect(connectAgent).toBeVisible();
 	await expectContainedInOwnerAndViewport(
 		page,
@@ -5086,7 +5021,6 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 		connectAgent.locator(".."),
 		"320px onboarding action",
 	);
-	await assertMonthGeometry();
 	await expectNoHorizontalOverflow(page.locator("html"), "320px Console document");
 	await page.screenshot({
 		path: testInfo.outputPath("console-320x568.png"),
@@ -5094,7 +5028,6 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	});
 
 	await page.setViewportSize({ width: 390, height: 844 });
-	await assertMonthGeometry();
 	await expectNoHorizontalOverflow(page.locator("html"), "390px Console document");
 	await page.screenshot({
 		path: testInfo.outputPath("console-390x844.png"),

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4960,18 +4960,100 @@ test("Breadcrumbs show the full trail on desktop and only the current page on na
 	});
 });
 
+test("Console shows the full fleet without replacing its greeting during loading", async ({
+	page,
+}) => {
+	const agents = Array.from({ length: 8 }, (_, index) => ({
+		...railConnectedCloudAgent,
+		id: `99999999-9999-4999-8999-${String(index).padStart(12, "0")}`,
+		display_name: `Console Agent ${index + 1}`,
+		sort_order: index,
+	}));
+	await stubHostedApi(page, { cloudAgents: agents });
+	await page.addInitScript(() => {
+		const headings = new Set<Element>();
+		const texts = new Set<string>();
+		const observer = new MutationObserver(() => {
+			const heading = document.querySelector("main h1");
+			if (!heading) return;
+			headings.add(heading);
+			if (heading.textContent) texts.add(heading.textContent);
+			document.documentElement.dataset.consoleGreetingCount = String(headings.size);
+			document.documentElement.dataset.consoleGreetingTexts = JSON.stringify([...texts]);
+		});
+		observer.observe(document, { subtree: true, childList: true, characterData: true });
+	});
+	await page.goto("/");
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { level: 1 })).toHaveText(
+		/^Good (morning|afternoon|evening), Dev$/,
+	);
+	for (const agent of agents) {
+		await expect(
+			main.getByRole("link", { name: `Open ${agent.display_name}.`, exact: false }),
+		).toBeVisible();
+	}
+	await expect(main.getByText("8 agents", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: /Show all|Show fewer/ })).toHaveCount(0);
+	await expect(page.locator("html")).toHaveAttribute("data-console-greeting-count", "1");
+	const texts: string[] = JSON.parse(
+		(await page.locator("html").getAttribute("data-console-greeting-texts")) ?? "[]",
+	);
+	expect(texts).toHaveLength(1);
+});
+
 test("Console keeps its desktop columns and places Recent sessions last on narrow screens", async ({
 	page,
 }, testInfo) => {
 	await stubHostedApi(page);
+	await page.route(`${CLOUD_API}/v1/dashboard/stats`, (route) =>
+		fulfillJson(route, {
+			manual_sessions_last_7_days: 0,
+			automated_sessions_last_7_days: 0,
+			top_model_last_7_days: null,
+			sessions_today: 0,
+			current_streak: 0,
+			contribution: Array.from({ length: 365 }, (_, index) => ({
+				date: new Date(Date.UTC(2025, 8, 9 + index)).toISOString().slice(0, 10),
+				count: index % 5,
+				level: index % 5,
+			})),
+		}),
+	);
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/");
 
 	const main = page.locator("main");
-	const activity = main.getByText("Activity", { exact: true });
+	const activity = main.getByRole("heading", { name: "Activity", exact: true });
 	const library = main.getByText("Library", { exact: true });
 	const recentSessions = main.getByRole("heading", { name: "Recent sessions", exact: true });
 	await expect(recentSessions).toBeVisible();
+	const connectAgent = main.getByRole("button", { name: "Connect an agent on your machine" });
+	await expect(connectAgent).toBeVisible();
+	await expect(main.getByRole("heading", { level: 1 })).toHaveText(/^Good /);
+
+	const activitySection = activity.locator("..");
+	await expect(activitySection.locator('[data-slot="card"]')).toHaveCount(0);
+	await expect(main.getByText("Sessions per day in the last 12 months")).toHaveCount(0);
+	await expect(activitySection.getByText(/^(Less|More)$/)).toHaveCount(0);
+	const cells = activitySection.locator('[title*="sessions on"]');
+	await expect(cells.first()).toHaveCSS("border-radius", "2px");
+	const assertMonthGeometry = async () => {
+		const gridBottom = await cells.evaluateAll((elements) =>
+			Math.max(...elements.map((element) => element.getBoundingClientRect().bottom)),
+		);
+		const months = activitySection.getByText(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/);
+		await expect(months.first()).toBeVisible();
+		const boxes = await months.evaluateAll((elements) =>
+			elements.map((element) => element.getBoundingClientRect().toJSON()),
+		);
+		for (const [index, box] of boxes.entries()) {
+			expect(box.y).toBeGreaterThan(gridBottom);
+			if (index > 0) expect(box.x).toBeGreaterThanOrEqual(boxes[index - 1].right);
+		}
+		await expectNoHorizontalOverflow(activitySection, "Activity month labels");
+	};
+	await assertMonthGeometry();
 
 	const [desktopActivity, desktopLibrary, desktopRecent] = await Promise.all([
 		activity.boundingBox(),
@@ -4983,6 +5065,7 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	}
 	expect(desktopRecent.y).toBeGreaterThan(desktopActivity.y);
 	expect(desktopLibrary.x).toBeGreaterThan(desktopActivity.x);
+	await page.screenshot({ path: testInfo.outputPath("console-1280x900.png"), fullPage: true });
 
 	await page.setViewportSize({ width: 320, height: 568 });
 	const sectionOrder = await main
@@ -4996,7 +5079,6 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 		);
 	expect(sectionOrder).toEqual(["Activity", "Library", "Last 7 days", "Recent sessions"]);
 
-	const connectAgent = main.getByRole("button", { name: "Connect an agent on your machine" });
 	await expect(connectAgent).toBeVisible();
 	await expectContainedInOwnerAndViewport(
 		page,
@@ -5004,6 +5086,7 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 		connectAgent.locator(".."),
 		"320px onboarding action",
 	);
+	await assertMonthGeometry();
 	await expectNoHorizontalOverflow(page.locator("html"), "320px Console document");
 	await page.screenshot({
 		path: testInfo.outputPath("console-320x568.png"),
@@ -5011,6 +5094,7 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	});
 
 	await page.setViewportSize({ width: 390, height: 844 });
+	await assertMonthGeometry();
 	await expectNoHorizontalOverflow(page.locator("html"), "390px Console document");
 	await page.screenshot({
 		path: testInfo.outputPath("console-390x844.png"),

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -3,7 +3,6 @@
 import type { components } from "@clawdi/shared/api";
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
-import { useState } from "react";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -120,11 +119,7 @@ export function AgentsCard({
 		normalizer?: ApiErrorNormalizer;
 	};
 }) {
-	const [showAll, setShowAll] = useState(false);
-	const total = agents.length;
 	const ordered = [...agents].sort(compareAgentTiles);
-	const visible = showAll ? ordered : ordered.slice(0, 6);
-	const hiddenCount = ordered.length - visible.length;
 
 	// No section header: the greeting directly above already carries the
 	// fleet summary ("N agents"), and a bare
@@ -143,25 +138,14 @@ export function AgentsCard({
 						))}
 					</div>
 				) : agents.length || hostedStatus?.isLoading ? (
-					<>
-						<div className={ENTITY_GRID_CLASS}>
-							{visible.map((tile) => (
-								<AgentTileView key={`${tile.source}:${tile.id}`} tile={tile} />
-							))}
-							{hostedStatus?.isLoading ? (
-								<EntityCardSkeleton iconSize="sm" statusDot titleBadge />
-							) : null}
-						</div>
-						{hiddenCount > 0 || showAll ? (
-							<button
-								type="button"
-								onClick={() => setShowAll((v) => !v)}
-								className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-							>
-								{showAll ? "Show fewer" : `Show all ${total} Agents`}
-							</button>
+					<div className={ENTITY_GRID_CLASS}>
+						{ordered.map((tile) => (
+							<AgentTileView key={`${tile.source}:${tile.id}`} tile={tile} />
+						))}
+						{hostedStatus?.isLoading ? (
+							<EntityCardSkeleton iconSize="sm" statusDot titleBadge />
 						) : null}
-					</>
+					</div>
 				) : hostedStatus?.error ? null : (
 					// When the hosted fetch failed, the error banner below carries
 					// the message — render no empty state to avoid contradicting it.

--- a/apps/web/src/components/dashboard/contribution-graph.tsx
+++ b/apps/web/src/components/dashboard/contribution-graph.tsx
@@ -108,7 +108,7 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 			<div className="flex gap-1.5">
 				{/* Day-of-week labels: only label odd rows so they don't overflow the cell heights. */}
 				<div
-					className="flex shrink-0 flex-col gap-[3px] pt-5 text-3xs text-muted-foreground tabular-nums"
+					className="flex shrink-0 flex-col gap-[3px] text-3xs text-muted-foreground tabular-nums"
 					style={{ width: DAY_LABEL_W - 6 }}
 					aria-hidden
 				>
@@ -122,21 +122,6 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 				</div>
 
 				<div className="min-w-0 flex-1">
-					{/* Month labels, positioned absolutely above the week they start. */}
-					<div className="relative mb-1 h-4 text-3xs leading-4 text-muted-foreground">
-						{monthLabels.map((m, i) =>
-							m ? (
-								<span
-									key={i}
-									className="absolute whitespace-nowrap"
-									style={{ left: i * WEEK_STRIDE }}
-								>
-									{m}
-								</span>
-							) : null,
-						)}
-					</div>
-
 					{/* Week columns grid. */}
 					<div className="flex gap-[3px]">
 						{weeks.map((week, wi) => (
@@ -145,7 +130,7 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 									<div
 										key={di}
 										className={cn(
-											"rounded-sm",
+											"rounded-[2px]",
 											day.date ? LEVEL_COLORS[clampLevel(day.level)] : "bg-transparent",
 										)}
 										style={{ width: CELL, height: CELL }}
@@ -155,16 +140,21 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 							</div>
 						))}
 					</div>
+					{/* Keep the final month inside the row; omit a partial first month if its label would overlap the next. */}
+					<div className="relative mt-1 h-4 text-3xs leading-4 text-muted-foreground">
+						{monthLabels.map((m, i) =>
+							m && !monthLabels[i + 1] ? (
+								<span
+									key={i}
+									className="absolute whitespace-nowrap"
+									style={{ left: `min(${i * WEEK_STRIDE}px, calc(100% - 3ch))` }}
+								>
+									{m}
+								</span>
+							) : null,
+						)}
+					</div>
 				</div>
-			</div>
-
-			{/* Legend, right-aligned like GitHub's. */}
-			<div className="mt-3 flex items-center justify-end gap-1.5 text-xs text-muted-foreground">
-				<span>Less</span>
-				{LEVEL_COLORS.map((c, i) => (
-					<div key={i} className={cn("rounded-sm", c)} style={{ width: CELL, height: CELL }} />
-				))}
-				<span>More</span>
 			</div>
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -3,11 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { lazy, type ReactNode, Suspense, useEffect, useMemo, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import {
-	type AgentFleetSummary,
 	AgentsCard,
 	fleetSummaryFromTiles,
 	selfManagedAgentTiles,
@@ -20,7 +19,7 @@ import { ThisWeekCard } from "@/components/dashboard/this-week-card";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useOpenApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
@@ -153,35 +152,37 @@ export default function DashboardPage() {
 			: blockingEnvsError || hostedAccess.isError
 				? "error"
 				: "resolved";
-	const greeting = renderGreeting(selfManagedFleetSummary, { state: greetingState });
-	const loadingGreeting = renderGreeting(selfManagedFleetSummary, { state: "loading" });
+	const greeting = agentGreetingSummary(selfManagedFleetSummary.total, greetingState);
+	const loadingGreeting = agentGreetingSummary(selfManagedFleetSummary.total, "loading");
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			{hostedAccessLoading ? (
-				loadingGreeting
-			) : hostedSectionEnabled && HostedFleetSummary ? (
-				<Suspense fallback={loadingGreeting}>
-					<HostedFleetSummary
-						cloudEnvs={environments ?? []}
-						showCloudDeployments={cloudDeploymentManagementEnabled}
-						showLegacyAgents={legacyHostedAgentsEnabled}
-					>
-						{(summary, state) =>
-							renderGreeting(summary, {
-								state:
+			<Greeting>
+				{hostedAccessLoading ? (
+					loadingGreeting
+				) : hostedSectionEnabled && HostedFleetSummary ? (
+					<Suspense fallback={loadingGreeting}>
+						<HostedFleetSummary
+							cloudEnvs={environments ?? []}
+							showCloudDeployments={cloudDeploymentManagementEnabled}
+							showLegacyAgents={legacyHostedAgentsEnabled}
+						>
+							{(summary, state) =>
+								agentGreetingSummary(
+									summary.total,
 									blockingEnvsError || hostedAccess.isError || state.error
 										? "error"
 										: envsLoading || state.isLoading || !state.membershipResolved
 											? "loading"
 											: "resolved",
-							})
-						}
-					</HostedFleetSummary>
-				</Suspense>
-			) : (
-				greeting
-			)}
+								)
+							}
+						</HostedFleetSummary>
+					</Suspense>
+				) : (
+					greeting
+				)}
+			</Greeting>
 
 			<div className="grid gap-4 lg:grid-cols-3">
 				<div className="min-w-0 lg:col-span-2 lg:row-start-1">
@@ -216,12 +217,9 @@ export default function DashboardPage() {
 					)}
 				</div>
 
-				<Card className="min-w-0 lg:col-span-2 lg:row-start-2">
-					<CardHeader>
-						<CardTitle>Activity</CardTitle>
-						<CardDescription>Sessions per day in the last 12 months</CardDescription>
-					</CardHeader>
-					<CardContent>
+				<section className="min-w-0 space-y-2 lg:col-span-2 lg:row-start-2">
+					<h2 className="text-base font-semibold">Activity</h2>
+					<div>
 						{blockingStatsError ? (
 							<ApiErrorPanel
 								error={blockingStatsError}
@@ -235,8 +233,8 @@ export default function DashboardPage() {
 						) : contribution ? (
 							<ContributionGraph data={contribution} />
 						) : null}
-					</CardContent>
-				</Card>
+					</div>
+				</section>
 
 				{/* This source order is also the mobile reading and focus order. */}
 				<div className="min-w-0 space-y-4 lg:col-start-3 lg:row-span-3 lg:row-start-1">
@@ -306,28 +304,19 @@ export default function DashboardPage() {
 	);
 }
 
-function renderGreeting(summary: AgentFleetSummary, options: { state?: AgentGreetingState } = {}) {
-	return <Greeting total={summary.total} state={options.state} />;
-}
-
 function ActivityGraphSkeleton() {
 	return (
 		<div className="w-full">
 			<div className="flex gap-1.5">
-				<div className="flex w-[22px] shrink-0 flex-col gap-[3px] pt-5">
+				<div className="flex w-[22px] shrink-0 flex-col gap-[3px]">
 					{Array.from({ length: 7 }).map((_, index) => (
 						<Skeleton
 							key={index}
-							className={cn("h-[11px] rounded-sm", index % 2 === 1 ? "w-5" : "w-2")}
+							className={cn("h-[11px] rounded-[2px]", index % 2 === 1 ? "w-5" : "w-2")}
 						/>
 					))}
 				</div>
 				<div className="min-w-0 flex-1">
-					<div className="mb-1 flex h-4 items-center gap-10">
-						{Array.from({ length: 6 }).map((_, index) => (
-							<Skeleton key={index} className="h-2.5 w-6" />
-						))}
-					</div>
 					<div className="flex max-h-[95px] overflow-hidden gap-[3px]">
 						{Array.from({ length: 52 }).map((_, weekIndex) => (
 							<div key={weekIndex} className="flex flex-col gap-[3px]">
@@ -335,7 +324,7 @@ function ActivityGraphSkeleton() {
 									<Skeleton
 										key={dayIndex}
 										className={cn(
-											"size-[11px] rounded-sm",
+											"size-[11px] rounded-[2px]",
 											(weekIndex + dayIndex) % 5 === 0 && "opacity-50",
 										)}
 									/>
@@ -343,14 +332,12 @@ function ActivityGraphSkeleton() {
 							</div>
 						))}
 					</div>
+					<div className="mt-1 flex h-4 items-center gap-10">
+						{Array.from({ length: 6 }).map((_, index) => (
+							<Skeleton key={index} className="h-2.5 w-6" />
+						))}
+					</div>
 				</div>
-			</div>
-			<div className="mt-3 flex justify-end gap-1.5">
-				<Skeleton className="h-3 w-7" />
-				{Array.from({ length: 5 }).map((_, index) => (
-					<Skeleton key={index} className="size-[11px] rounded-sm" />
-				))}
-				<Skeleton className="h-3 w-8" />
 			</div>
 		</div>
 	);
@@ -379,21 +366,23 @@ function currentDaypart(): "morning" | "afternoon" | "evening" {
 	return hour < 5 ? "evening" : hour < 12 ? "morning" : hour < 18 ? "afternoon" : "evening";
 }
 
-function Greeting({ total, state = "resolved" }: { total: number; state?: AgentGreetingState }) {
-	const { user } = useCurrentUser();
+function Greeting({ children }: { children: ReactNode }) {
+	const { user, isLoaded } = useCurrentUser();
 	const [daypart, setDaypart] = useState<ReturnType<typeof currentDaypart> | null>(null);
 	useEffect(() => {
 		setDaypart(currentDaypart());
 	}, []);
 	const firstName = user?.fullName?.split(" ")[0];
-	const summary = agentGreetingSummary(total, state);
 	return (
 		<div>
 			<h1 className="text-2xl font-semibold tracking-tight">
-				{daypart ? `Good ${daypart}` : "Welcome"}
-				{firstName ? `, ${firstName}` : ""}
+				{daypart && isLoaded ? (
+					`Good ${daypart}${firstName ? `, ${firstName}` : ""}`
+				) : (
+					<Skeleton className="h-8 w-64 max-w-full" />
+				)}
 			</h1>
-			<p className="mt-1 text-sm text-muted-foreground tabular-nums">{summary}</p>
+			<p className="mt-1 text-sm text-muted-foreground tabular-nums">{children}</p>
 		</div>
 	);
 }


### PR DESCRIPTION
Activity uses a standalone heading matching Recent sessions, small rounded heatmap cells, month labels below, and no subtitle or density legend. The full sorted agent fleet is visible, and the greeting remains mounted outside loading boundaries to prevent flicker.

Added coverage is limited to one short browser regression checking that all eight agents are visible. Existing responsive tests are unchanged; no CSS pixel assertions or DOM identity instrumentation are added.

Validation: isolated Docker typecheck, 103 focused tests, OSS build, Biome, and Chromium desktop/mobile verification passed during implementation. Screenshots reviewed. After trimming tests, Docker Biome and diff checks passed; browser tests were not rerun for this simplification. Browser verification used mock APIs and development authentication.
