### PR TITLE
fix(web): restore Activity card and unify agent status dots

### DIFF
--- a/apps/web/src/components/dashboard/contribution-graph.tsx
+++ b/apps/web/src/components/dashboard/contribution-graph.tsx
@@ -130,7 +130,7 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 									<div
 										key={di}
 										className={cn(
-											"rounded-[2px]",
+											"rounded-[3px]",
 											day.date ? LEVEL_COLORS[clampLevel(day.level)] : "bg-transparent",
 										)}
 										style={{ width: CELL, height: CELL }}

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -13,6 +13,7 @@ import { Rocket, Terminal } from "lucide-react";
 import { useState } from "react";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { statusDotVariants } from "@/components/ui/status-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn, relativeTime } from "@/lib/utils";
@@ -120,10 +121,10 @@ const STATUS_TOOLTIP: Record<DaemonStatusKind, string> = {
 };
 
 const DOT_TONE: Record<DaemonStatusKind, string> = {
-	live: "bg-success ring-2 ring-success/20",
-	"set-up": "border-dashed border border-muted-foreground/50 bg-transparent",
-	errored: "bg-destructive ring-2 ring-destructive/20",
-	paused: "bg-warning ring-2 ring-warning/20",
+	live: statusDotVariants({ status: "success" }),
+	"set-up": statusDotVariants({ status: "neutral" }),
+	errored: statusDotVariants({ status: "destructive" }),
+	paused: statusDotVariants({ status: "warning" }),
 };
 
 const TEXT_TONE: Record<DaemonStatusKind, string> = {

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -219,21 +219,23 @@ export default function DashboardPage() {
 
 				<section className="min-w-0 space-y-2 lg:col-span-2 lg:row-start-2">
 					<h2 className="text-base font-semibold">Activity</h2>
-					<div>
-						{blockingStatsError ? (
-							<ApiErrorPanel
-								error={blockingStatsError}
-								onRetry={() => {
-									void refetchStats();
-								}}
-								title="Couldn't load activity"
-							/>
-						) : statsLoading ? (
-							<ActivityGraphSkeleton />
-						) : contribution ? (
-							<ContributionGraph data={contribution} />
-						) : null}
-					</div>
+					<Card>
+						<CardContent>
+							{blockingStatsError ? (
+								<ApiErrorPanel
+									error={blockingStatsError}
+									onRetry={() => {
+										void refetchStats();
+									}}
+									title="Couldn't load activity"
+								/>
+							) : statsLoading ? (
+								<ActivityGraphSkeleton />
+							) : contribution ? (
+								<ContributionGraph data={contribution} />
+							) : null}
+						</CardContent>
+					</Card>
 				</section>
 
 				{/* This source order is also the mobile reading and focus order. */}
@@ -312,7 +314,7 @@ function ActivityGraphSkeleton() {
 					{Array.from({ length: 7 }).map((_, index) => (
 						<Skeleton
 							key={index}
-							className={cn("h-[11px] rounded-[2px]", index % 2 === 1 ? "w-5" : "w-2")}
+							className={cn("h-[11px] rounded-[3px]", index % 2 === 1 ? "w-5" : "w-2")}
 						/>
 					))}
 				</div>
@@ -324,7 +326,7 @@ function ActivityGraphSkeleton() {
 									<Skeleton
 										key={dayIndex}
 										className={cn(
-											"size-[11px] rounded-[2px]",
+											"size-[11px] rounded-[3px]",
 											(weekIndex + dayIndex) % 5 === 0 && "opacity-50",
 										)}
 									/>


### PR DESCRIPTION
Restore the Activity card background, border, and padding while keeping its heading outside. Increase heatmap and loading-cell corners from 2px to 3px.

Connected agents now reuse the same status-dot variants as hosted agents, removing the outer rings and rendering setup as a neutral solid dot. Existing status labels and classification remain unchanged.

Validation in isolated Docker: Biome, frontend typecheck, two existing daemon-status tests, OSS build, and six production SSR checks passed. No tests added. This revision has not received a browser visual check.
