### PR TITLE
fix(web): balance Activity margins and use single-letter weekdays

### DIFF
--- a/apps/web/src/components/dashboard/contribution-graph.tsx
+++ b/apps/web/src/components/dashboard/contribution-graph.tsx
@@ -18,7 +18,7 @@ const LEVEL_COLORS = [
 const CELL = 11; // px, matches GitHub's ~11px heatmap cell
 const GAP = 3; // px gap between cells and columns
 const WEEK_STRIDE = CELL + GAP; // horizontal distance from one week's column to the next
-const DAY_LABEL_W = 28; // px reserved for "Mon"/"Wed"/"Fri" labels on the left
+const DAY_LABEL_W = 18; // px reserved for single-letter weekday labels and their gap
 const MIN_WEEKS = 4; // never show fewer than a month of data, even on tiny viewports
 
 function clampLevel(level: number): number {
@@ -105,23 +105,21 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 
 	return (
 		<div ref={containerRef} className="w-full">
-			<div className="flex gap-1.5">
-				{/* Day-of-week labels: only label odd rows so they don't overflow the cell heights. */}
+			<div className="mx-auto flex w-fit gap-1.5">
+				{/* Weekday labels align with the Sunday-first rows. */}
 				<div
-					className="flex shrink-0 flex-col gap-[3px] text-3xs text-muted-foreground tabular-nums"
+					className="flex shrink-0 flex-col gap-[3px] text-center text-3xs text-muted-foreground tabular-nums"
 					style={{ width: DAY_LABEL_W - 6 }}
 					aria-hidden
 				>
-					<span style={{ height: CELL }} />
-					<span style={{ height: CELL, lineHeight: `${CELL}px` }}>Mon</span>
-					<span style={{ height: CELL }} />
-					<span style={{ height: CELL, lineHeight: `${CELL}px` }}>Wed</span>
-					<span style={{ height: CELL }} />
-					<span style={{ height: CELL, lineHeight: `${CELL}px` }}>Fri</span>
-					<span style={{ height: CELL }} />
+					{["S", "M", "T", "W", "T", "F", "S"].map((day, index) => (
+						<span key={index} style={{ height: CELL, lineHeight: `${CELL}px` }}>
+							{day}
+						</span>
+					))}
 				</div>
 
-				<div className="min-w-0 flex-1">
+				<div style={{ width: weeks.length * WEEK_STRIDE - GAP }}>
 					{/* Week columns grid. */}
 					<div className="flex gap-[3px]">
 						{weeks.map((week, wi) => (

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -310,12 +310,9 @@ function ActivityGraphSkeleton() {
 	return (
 		<div className="w-full">
 			<div className="flex gap-1.5">
-				<div className="flex w-[22px] shrink-0 flex-col gap-[3px]">
+				<div className="flex w-3 shrink-0 flex-col items-center gap-[3px]">
 					{Array.from({ length: 7 }).map((_, index) => (
-						<Skeleton
-							key={index}
-							className={cn("h-[11px] rounded-[3px]", index % 2 === 1 ? "w-5" : "w-2")}
-						/>
+						<Skeleton key={index} className="h-[11px] w-2 rounded-[3px]" />
 					))}
 				</div>
 				<div className="min-w-0 flex-1">


### PR DESCRIPTION
Center the weekday column and heatmap together so unused column space is shared evenly between the card's left and right edges. Display all seven weekdays as S M T W T F S, with narrower labels and matching loading placeholders.

Validation: Docker Biome and frontend typecheck passed. A temporary Chromium visual check verified equal side margins and weekday labels at 1280px and 320px; both screenshots reviewed. No test files added to the PR.
