### PR TITLE
fix(web): remove homepage agent count subtitle

### DIFF
--- a/apps/web/e2e/query-refresh-no-flicker.pw.ts
+++ b/apps/web/e2e/query-refresh-no-flicker.pw.ts
@@ -103,7 +103,7 @@ for (const viewport of [
 		// only resolve on a client retry, so the first paint allowance matches
 		// the suite-wide 15s convention instead of the 5s default.
 		await expect(link).toBeVisible({ timeout: 15_000 });
-		await expect(page.getByText("1 agent", { exact: true })).toBeVisible();
+		await expect(page.getByText("1 agent", { exact: true })).toHaveCount(0);
 		const card = link.locator("..");
 		const before = await card.boundingBox();
 		if (!before) throw new Error("Expected the Agent card to have layout bounds");
@@ -112,7 +112,7 @@ for (const viewport of [
 		await refresh.refreshStarted.promise;
 		try {
 			await expect(link).toBeVisible();
-			await expect(page.getByText("1 agent", { exact: true })).toBeVisible();
+			await expect(page.getByText("1 agent", { exact: true })).toHaveCount(0);
 			expect(await card.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
 			expect(await card.locator(".animate-pulse").count()).toBe(0);
 			const during = await card.boundingBox();

--- a/apps/web/src/components/dashboard/agent-onboarding.test.ts
+++ b/apps/web/src/components/dashboard/agent-onboarding.test.ts
@@ -30,9 +30,6 @@ describe("dashboard agent onboarding", () => {
 		expect(
 			dashboardSource.match(/canDeployOnClawdi=\{hostedAccess\.canCreateCloudAgents\}/g),
 		).toHaveLength(2);
-		expect(
-			dashboardSource.match(/showCloudDeployments=\{cloudDeploymentManagementEnabled\}/g),
-		).toHaveLength(3);
 		expect(agentsIndexSource).toContain("canDeployOnClawdi={hostedAccess.canCreateCloudAgents}");
 		expect(agentsIndexSource).toContain("showCloudDeployments={cloudDeploymentManagementEnabled}");
 		expect(hostedSectionSource).toContain(

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -4,7 +4,6 @@ import {
 	type AgentTile,
 	agentTileCardProjection,
 	agentTileMatchesRouteId,
-	fleetSummaryFromTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
 
@@ -265,35 +264,5 @@ describe("agentTileMatchesRouteId", () => {
 		expect(agentTileMatchesRouteId(tile, projected.id)).toBe(true);
 		expect(agentTileMatchesRouteId(tile, projected.id.toUpperCase())).toBe(true);
 		expect(agentTileMatchesRouteId(tile, "hdep_paid")).toBe(false);
-	});
-});
-
-describe("fleetSummaryFromTiles", () => {
-	it("summarizes inventory without inventing an activity clock", () => {
-		const selfManaged = selfManagedAgentTiles([
-			env({
-				last_seen_at: new Date().toISOString(),
-			}),
-		]);
-		const hostedRunningWithoutEnv: AgentTile = {
-			id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-			source: "on-clawdi",
-			name: "Codex",
-			agentType: "codex",
-			href: "/agents/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-			env: null,
-		};
-		const hostedStoppedWithFreshEnv: AgentTile = {
-			id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
-			source: "on-clawdi",
-			name: "Stopped Codex",
-			agentType: "codex",
-			href: "/agents/cccccccc-cccc-4ccc-8ccc-cccccccccccc",
-			env: env({ last_seen_at: new Date().toISOString() }),
-		};
-
-		expect(
-			fleetSummaryFromTiles([...selfManaged, hostedRunningWithoutEnv, hostedStoppedWithFreshEnv]),
-		).toEqual({ total: 3 });
 	});
 });

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -88,14 +88,6 @@ export function agentTileMatchesRouteId(tile: AgentTile, routeId: string): boole
 	return tile.href ? agentRouteIdsEqual(parseAgentPathname(tile.href)?.agentId, routeId) : false;
 }
 
-export interface AgentFleetSummary {
-	total: number;
-}
-
-export function fleetSummaryFromTiles(agents: readonly AgentTile[]): AgentFleetSummary {
-	return { total: agents.length };
-}
-
 export function AgentsCard({
 	agents,
 	isLoading,
@@ -121,10 +113,6 @@ export function AgentsCard({
 }) {
 	const ordered = [...agents].sort(compareAgentTiles);
 
-	// No section header: the greeting directly above already carries the
-	// fleet summary ("N agents"), and a bare
-	// text header here pushed the tile wall below the right rail's card
-	// top — the two columns read as misaligned (Marvin's screenshot).
 	// Tiles start flush with the column, level with the cards on the right.
 	return (
 		<section className="space-y-3">

--- a/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
+++ b/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { agentGreetingSummary } from "@/components/dashboard/greeting";
 import { ThisWeekCard } from "@/components/dashboard/this-week-card";
 import type { DashboardStats } from "@/lib/api-schemas";
 import { getProjectResourceDefinition, projectResourceCount } from "@/lib/project-resource-model";
@@ -45,13 +44,5 @@ describe("dashboard data contracts", () => {
 		expect(markup).toContain("+ 11 automated");
 		expect(markup).toContain(">7<");
 		expect(markup).toContain(">5<");
-	});
-
-	test("does not show first-agent empty copy while membership is unresolved", () => {
-		expect(agentGreetingSummary(0, "loading")).toBe("Loading agent status…");
-		expect(agentGreetingSummary(0, "resolved")).toBe(
-			"Get your first agent running to start syncing.",
-		);
-		expect(agentGreetingSummary(0, "error")).toBe("Agent status is unavailable right now.");
 	});
 });

--- a/apps/web/src/components/dashboard/greeting.ts
+++ b/apps/web/src/components/dashboard/greeting.ts
@@ -1,9 +1,0 @@
-export type AgentGreetingState = "loading" | "resolved" | "error";
-
-export function agentGreetingSummary(total: number, state: AgentGreetingState): string {
-	if (state === "loading") return "Loading agent status…";
-	if (state === "error") return "Agent status is unavailable right now.";
-	return total === 0
-		? "Get your first agent running to start syncing."
-		: `${total} agent${total === 1 ? "" : "s"}`;
-}

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -1,13 +1,8 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { type ReactNode, useEffect, useMemo } from "react";
-import {
-	type AgentFleetSummary,
-	type AgentTile,
-	fleetSummaryFromTiles,
-	selfManagedAgentTiles,
-} from "@/components/dashboard/agents-card";
+import { useEffect, useMemo } from "react";
+import { type AgentTile, selfManagedAgentTiles } from "@/components/dashboard/agents-card";
 import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
 import type { HostedInventoryStatus } from "@/hosted/hosted-agent-resolution";
 import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
@@ -155,31 +150,4 @@ export function HostedUnifiedAgentListSensor({
 	useEffect(() => () => onChange(null, false, false), [onChange]);
 
 	return null;
-}
-
-export function HostedFleetSummary({
-	cloudEnvs,
-	showCloudDeployments = true,
-	showLegacyAgents = false,
-	children,
-}: {
-	cloudEnvs: Env[];
-	showCloudDeployments?: boolean;
-	showLegacyAgents?: boolean;
-	children: (
-		summary: AgentFleetSummary,
-		state: { membershipResolved: boolean; error: Error | null; isLoading: boolean },
-	) => ReactNode;
-}) {
-	const unified = useUnifiedAgentList({
-		cloudEnvs,
-		showCloudDeployments,
-		showLegacyAgents,
-	});
-	const summary = useMemo(() => fleetSummaryFromTiles(unified.tiles), [unified.tiles]);
-	return children(summary, {
-		membershipResolved: unified.membershipResolved,
-		error: unified.error,
-		isLoading: unified.isLoading,
-	});
 }

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -3,16 +3,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
-import { lazy, type ReactNode, Suspense, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
-import {
-	AgentsCard,
-	fleetSummaryFromTiles,
-	selfManagedAgentTiles,
-} from "@/components/dashboard/agents-card";
+import { AgentsCard, selfManagedAgentTiles } from "@/components/dashboard/agents-card";
 import { ContributionGraph } from "@/components/dashboard/contribution-graph";
-import { type AgentGreetingState, agentGreetingSummary } from "@/components/dashboard/greeting";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { ResourcesCard } from "@/components/dashboard/resources-card";
 import { ThisWeekCard } from "@/components/dashboard/this-week-card";
@@ -55,14 +50,6 @@ const HostedSecondaryCTA = IS_HOSTED_BUILD
 			})),
 		)
 	: null;
-const HostedFleetSummary = IS_HOSTED_BUILD
-	? lazy(() =>
-			import("@/hosted/use-unified-agent-list").then((m) => ({
-				default: m.HostedFleetSummary,
-			})),
-		)
-	: null;
-
 export default function DashboardPage() {
 	const $api = useOpenApi();
 	const hostedAccess = useProductAccess();
@@ -126,10 +113,6 @@ export default function DashboardPage() {
 		: null;
 
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
-	const selfManagedFleetSummary = useMemo(
-		() => fleetSummaryFromTiles(selfManagedTiles),
-		[selfManagedTiles],
-	);
 
 	// Zero-state promotion: when the user has no agents yet, the
 	// secondary CTA (connect one) lives in the right column. The
@@ -146,43 +129,10 @@ export default function DashboardPage() {
 		HostedAgentsSection && hostedAccess.canUseLegacyHostedDashboard,
 	);
 	const hostedSectionEnabled = cloudDeploymentManagementEnabled || legacyHostedAgentsEnabled;
-	const greetingState: AgentGreetingState =
-		hostedAccessLoading || envsLoading
-			? "loading"
-			: blockingEnvsError || hostedAccess.isError
-				? "error"
-				: "resolved";
-	const greeting = agentGreetingSummary(selfManagedFleetSummary.total, greetingState);
-	const loadingGreeting = agentGreetingSummary(selfManagedFleetSummary.total, "loading");
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<Greeting>
-				{hostedAccessLoading ? (
-					loadingGreeting
-				) : hostedSectionEnabled && HostedFleetSummary ? (
-					<Suspense fallback={loadingGreeting}>
-						<HostedFleetSummary
-							cloudEnvs={environments ?? []}
-							showCloudDeployments={cloudDeploymentManagementEnabled}
-							showLegacyAgents={legacyHostedAgentsEnabled}
-						>
-							{(summary, state) =>
-								agentGreetingSummary(
-									summary.total,
-									blockingEnvsError || hostedAccess.isError || state.error
-										? "error"
-										: envsLoading || state.isLoading || !state.membershipResolved
-											? "loading"
-											: "resolved",
-								)
-							}
-						</HostedFleetSummary>
-					</Suspense>
-				) : (
-					greeting
-				)}
-			</Greeting>
+			<Greeting />
 
 			<div className="grid gap-4 lg:grid-cols-3">
 				<div className="min-w-0 lg:col-span-2 lg:row-start-1">
@@ -359,13 +309,13 @@ function ConnectAnotherCard() {
 	);
 }
 
-/** Time-of-day greeting — personal, no emoji, one quiet fleet summary line. */
+/** Personal time-of-day greeting. */
 function currentDaypart(): "morning" | "afternoon" | "evening" {
 	const hour = new Date().getHours();
 	return hour < 5 ? "evening" : hour < 12 ? "morning" : hour < 18 ? "afternoon" : "evening";
 }
 
-function Greeting({ children }: { children: ReactNode }) {
+function Greeting() {
 	const { user, isLoaded } = useCurrentUser();
 	const [daypart, setDaypart] = useState<ReturnType<typeof currentDaypart> | null>(null);
 	useEffect(() => {
@@ -381,7 +331,6 @@ function Greeting({ children }: { children: ReactNode }) {
 					<Skeleton className="h-8 w-64 max-w-full" />
 				)}
 			</h1>
-			<p className="mt-1 text-sm text-muted-foreground tabular-nums">{children}</p>
 		</div>
 	);
 }


### PR DESCRIPTION
Remove the agent-count subtitle beneath the homepage greeting. The greeting and full agent grid remain visible. Delete the unused fleet-summary component, count helper, loading/empty/error subtitle text, and tests dedicated to the removed summary.

Validation in isolated Docker: Biome, frontend typecheck, existing agent-card/dashboard contract tests, and OSS build passed. No new tests added.
