### PR TITLE
test(web): remove redundant checkout and plan checks

### DIFF
--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -208,8 +208,6 @@ test("popular BYOK providers support credential-only product setup", async ({ pa
 	]) {
 		await dialog.getByRole("textbox", { name: "Search providers" }).fill(choice.query);
 		await dialog.getByRole("button", { name: new RegExp(`^${choice.name}`) }).click();
-		await expect(dialog.getByText("Choose and manage models inside your agent.")).toHaveCount(0);
-		await expect(dialog.getByText("Encrypted at rest and never shown again.")).toHaveCount(0);
 		const credentialInput = dialog.getByLabel(choice.credential, { exact: true });
 		await expect(credentialInput).toHaveAttribute(
 			"placeholder",

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { StripeCheckoutStatus } from "@stripe/stripe-js";
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
 import {
-	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
-	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
 	completedCheckoutPaymentStatus,
 } from "@/hosted/billing/components/stripe-checkout.logic";
@@ -30,18 +28,6 @@ describe("stripe checkout logic", () => {
 		});
 
 		expect(checkoutRedirectUrl(result)).toBe("https://checkout.stripe.com/primary");
-	});
-
-	test("detects elements checkout responses from a client secret", () => {
-		const result = checkoutResult({
-			client_secret: "cs_test_elements",
-		});
-
-		expect(checkoutSessionClientSecret(result) === "cs_test_elements").toBe(true);
-	});
-
-	test("documents the checkout elements ui mode for the installed Stripe SDK", () => {
-		expect(CHECKOUT_ELEMENTS_UI_MODE).toBe("custom");
 	});
 
 	test("reads payment settlement only from a completed Checkout Session", () => {

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -83,12 +83,6 @@ describe("compute plan resolvers", () => {
 		expect(resolvePerformancePlan([basic, paid])).toBeUndefined();
 	});
 
-	test("resolvePerformancePlan never treats compute_basic as the positive-price fallback", () => {
-		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 900 });
-
-		expect(resolvePerformancePlan([basic])).toBeUndefined();
-	});
-
 	test("resolveBasicPlan only resolves the canonical Basic plan", () => {
 		const otherPaid = plan({ slug: "legacy_paid", price_cents: 900 });
 		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 1_100 });


### PR DESCRIPTION
Remove three redundant checks: the Stripe UI-mode constant is already exercised by the configured/unconfigured selection test, the re-exported checkout-secret function has stronger direct coverage, and the Basic-only fallback case is contained in the mixed noncanonical-plan case. Also remove two obsolete BYOK help-text absence assertions. Existing behavior, protocol, accessibility, and security tests remain unchanged.

Validation in isolated Docker: focused checkout, subscription resolver, and client-secret tests; frontend typecheck; OSS build; Biome. No product code or new tests added; 22 lines removed.
