### PR TITLE
Fix Hermes credential bridges and current migration evidence

### DIFF
--- a/backend/app/services/ai_provider_connection_ownership.py
+++ b/backend/app/services/ai_provider_connection_ownership.py
@@ -86,6 +86,9 @@ async def require_connection_ownership_migration(
                     for state in batch
                 ]
             ),
+            expected_generations={
+                state.environment_id: state.apply_generation or state.generation for state in batch
+            },
         )
         by_environment = {state.environment_id: state for state in batch}
         for summary in summaries.items:

--- a/backend/app/services/runtime_drift_summary.py
+++ b/backend/app/services/runtime_drift_summary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
@@ -32,8 +33,15 @@ from app.services.runtime_source_revision import runtime_source_contract_revisio
 async def read_runtime_drift_summaries(
     db: AsyncSession,
     body: RuntimeDriftSummaryReadRequest,
+    *,
+    expected_generations: Mapping[UUID, int] | None = None,
 ) -> RuntimeDriftSummaryReadResponse:
-    """Read persisted drift evidence without writes in the caller's RR snapshot."""
+    """Read persisted drift evidence without writes in the caller's RR snapshot.
+
+    Trusted callers may scope a binding to its persisted generation without
+    inventing a receipt or boot nonce. Multiple fresh boots remain ambiguous;
+    unscoped legacy reads retain their conservative historical-head behavior.
+    """
     observed_at = datetime.now(UTC)
     environment_ids = [binding.environment_id for binding in body.bindings]
     rows = (
@@ -62,6 +70,7 @@ async def read_runtime_drift_summaries(
     active: list[tuple[UUID, str]] = []
     expected: list[tuple[UUID, str, int, str, str, str]] = []
     legacy: list[tuple[UUID, str]] = []
+    generation_scoped: list[tuple[UUID, str, int]] = []
     for requested in body.bindings:
         row = by_environment.get(requested.environment_id)
         if row is None:
@@ -78,7 +87,17 @@ async def read_runtime_drift_summaries(
             active.append((requested.environment_id, requested.deployment_id))
             identity = requested.expected_apply_identity
             if identity is None:
-                legacy.append((requested.environment_id, requested.deployment_id))
+                generation = (
+                    None
+                    if expected_generations is None
+                    else expected_generations.get(requested.environment_id)
+                )
+                if generation is None:
+                    legacy.append((requested.environment_id, requested.deployment_id))
+                else:
+                    generation_scoped.append(
+                        (requested.environment_id, requested.deployment_id, generation)
+                    )
             else:
                 expected.append(
                     (
@@ -116,6 +135,14 @@ async def read_runtime_drift_summaries(
                     V2RuntimeObservationHead.environment_id,
                     V2RuntimeObservationHead.deployment_id,
                 ).in_(legacy)
+            )
+        if generation_scoped:
+            predicates.append(
+                tuple_(
+                    V2RuntimeObservationHead.environment_id,
+                    V2RuntimeObservationHead.deployment_id,
+                    V2RuntimeObservationHead.generation,
+                ).in_(generation_scoped)
             )
         ranked_heads = (
             select(

--- a/backend/tests/test_ai_provider_connection_ownership.py
+++ b/backend/tests/test_ai_provider_connection_ownership.py
@@ -7,7 +7,12 @@ from sqlalchemy import select
 from app.models.ai_provider import AiProviderAuthPayload
 from app.models.app_setting import AppSetting
 from app.models.hosted_runtime import HostedRuntimeState
-from app.schemas.runtime_observation import RuntimeObservationEventV2
+from app.schemas.runtime_observation import (
+    RuntimeDriftBindingRequest,
+    RuntimeDriftSummaryReadRequest,
+    RuntimeObservationEventV2,
+)
+from app.services.runtime_drift_summary import read_runtime_drift_summaries
 from app.services.runtime_observation import (
     ingest_runtime_observation,
     provision_runtime_environment_fence,
@@ -120,6 +125,71 @@ async def consumer(
     )
     await db.commit()
     return state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("history", ["expired", "previous-generation", "competing-fresh"])
+async def test_handoff_uses_one_fresh_current_generation_without_weakening_legacy_reads(
+    client, db_session, seed_user, history
+):
+    await create_provider(client)
+    now = datetime.now(UTC)
+    state = await consumer(
+        db_session,
+        seed_user.id,
+        captured_at=now - timedelta(minutes=20) if history == "expired" else now,
+    )
+    generation = 2 if history == "previous-generation" else 1
+    state.generation = generation
+    state.apply_generation = generation
+    db_session.add(AppSetting(key="supported_connection_cli_versions", value_json=[VERSION]))
+    observation = RuntimeObservationEventV2.model_validate(
+        {
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": now,
+            "capturedAt": now,
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": VERSION,
+            "applied": {
+                "etag": f'"sha256:{REVISION}"',
+                "sourceRevision": REVISION,
+                "generation": generation,
+                "instanceId": state.instance_id,
+                "appliedProviderIds": [PROVIDER],
+            },
+            "boot": None,
+            "cli": None,
+            "applyReceiptId": "apply-connection-0002",
+            "bootNonce": "boot-nonce-connection-0002",
+            "bootSessionId": "current-connection-boot",
+            "sequence": 1,
+            "eventId": str(uuid4()),
+        }
+    )
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=state.environment_id,
+        credential_deployment_id=state.deployment_id,
+        value=observation,
+        received_at=now,
+    )
+    await db_session.commit()
+    legacy = await read_runtime_drift_summaries(
+        db_session,
+        RuntimeDriftSummaryReadRequest(
+            bindings=[
+                RuntimeDriftBindingRequest(
+                    environmentId=state.environment_id, deploymentId=state.deployment_id
+                )
+            ]
+        ),
+    )
+    assert legacy.items[0].observation.status == "ambiguous"
+    response = await client.patch(
+        f"/v1/ai-providers/{PROVIDER}", json={"configuration_mode": "connection"}
+    )
+    assert response.status_code == (409 if history == "competing-fresh" else 200), response.text
 
 
 @pytest.mark.asyncio

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.58",
+      "version": "0.14.59",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.58",
+	"version": "0.14.59",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/connection-provider-config.test.ts
+++ b/packages/cli/src/runtime/connection-provider-config.test.ts
@@ -126,7 +126,7 @@ with open(path, "w") as file: json.dump(config, file)
 	};
 	if (runtime === "hermes") {
 		const app = join(home, ".hermes/hermes-agent");
-		for (const directory of ["agent", "hermes_cli", ".venv/bin"])
+		for (const directory of ["agent", "hermes_cli", "venv/bin"])
 			mkdirSync(join(app, directory), { recursive: true });
 		// Public API contract doubles; no private pool layout knowledge in the adapter.
 		writeFileSync(
@@ -137,7 +137,7 @@ with open(path, "w") as file: json.dump(config, file)
 			join(app, "hermes_cli/auth.py"),
 			"import os\ndef read_credential_pool(key):\n    return [object()] if os.path.exists(os.path.join(os.environ['HERMES_HOME'], 'pool-conflict')) else []\n",
 		);
-		symlinkSync("/usr/bin/python3", join(app, ".venv/bin/python"));
+		symlinkSync("/usr/bin/python3", join(app, "venv/bin/python"));
 	}
 	const observation: RuntimeInstallObservation = {
 		runtime,
@@ -405,6 +405,48 @@ test("Hermes public pool conflict prevents ownership transfer and config mutatio
 		const before = f.read();
 		expect(() => f.prepare()).toThrow("credential conflict");
 		expect(f.read()).toEqual(before);
+		expect(f.input().ownership.providers).toEqual({});
+	} finally {
+		f.cleanup();
+	}
+});
+
+test.each(["empty", "occupied", "no-match"])(
+	"Hermes uses the installed legacy public pool resolver: %s",
+	(state) => {
+		const f = fixture("hermes");
+		try {
+			const app = join(f.home, ".hermes/hermes-agent");
+			writeFileSync(
+				join(app, "agent/credential_pool.py"),
+				`def get_custom_provider_pool_key(base_url, provider_name=None):\n    return ${state === "no-match" ? "None" : '"custom:resolved-by-native"'}\n`,
+			);
+			writeFileSync(
+				join(app, "hermes_cli/auth.py"),
+				state === "no-match"
+					? "def read_credential_pool(key):\n    raise AssertionError('No native pool matched')\n"
+					: `def read_credential_pool(key):\n    assert key == "custom:resolved-by-native"\n    return ${state === "occupied" ? "[object()]" : "[]"}\n`,
+			);
+			const before = f.read();
+			if (state === "occupied") {
+				expect(() => f.prepare()).toThrow("credential conflict");
+				expect(f.input().ownership.providers).toEqual({});
+			} else {
+				f.prepare();
+				expect(f.input().ownership.providers[id]?.envName).toBe(envName);
+			}
+			expect(f.read()).toEqual(before);
+		} finally {
+			f.cleanup();
+		}
+	},
+);
+
+test("Hermes refuses unknown public pool APIs", () => {
+	const f = fixture("hermes");
+	try {
+		writeFileSync(join(f.home, ".hermes/hermes-agent/agent/credential_pool.py"), "pass\n");
+		expect(() => f.prepare()).toThrow("unsupported public pool API");
 		expect(f.input().ownership.providers).toEqual({});
 	} finally {
 		f.cleanup();

--- a/packages/cli/src/runtime/connection-provider-config.ts
+++ b/packages/cli/src/runtime/connection-provider-config.ts
@@ -59,14 +59,26 @@ const HERMES_API: Partial<Record<AiProviderApiMode, string>> = {
 
 // Public installed APIs only. Never load_pool(): it can seed/write credentials.
 // NousResearch/hermes-agent@0d08cd295fd73427833ee349eb858569d4d0dd3a.
+// The deployed 7a963456 baseline resolves one pool via get_custom_provider_pool_key.
 const HERMES_POOL_GUARD = `
 import contextlib, io, json, sys
 sys.path.insert(0, sys.argv[1])
 with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
-    from agent.credential_pool import custom_provider_pool_key_candidates
+    from agent import credential_pool
     from hermes_cli.auth import read_credential_pool
+    candidates = getattr(credential_pool, "custom_provider_pool_key_candidates", None)
+    legacy_key = getattr(credential_pool, "get_custom_provider_pool_key", None)
     for connection in json.load(sys.stdin):
-        for key in custom_provider_pool_key_candidates(connection["baseUrl"], provider_name=connection["id"]):
+        if callable(candidates):
+            keys = candidates(connection["baseUrl"], provider_name=connection["id"])
+        elif callable(legacy_key):
+            key = legacy_key(connection["baseUrl"], provider_name=connection["id"])
+            keys = [] if key is None else [key]
+        else:
+            raise ValueError("Custom provider public pool API is unavailable")
+        if not isinstance(keys, (list, tuple)) or any(not isinstance(key, str) or not key for key in keys):
+            raise ValueError("Custom provider public pool API returned invalid keys")
+        for key in keys:
             rows = read_credential_pool(key)
             if not isinstance(rows, list) or rows:
                 raise ValueError("Custom provider credential pool conflicts with connection ownership")
@@ -118,7 +130,7 @@ function guardHermesPools(input: ConnectionContext): void {
 	const appRoot = runtimeAppRoot("hermes", input.home);
 	if (!appRoot) throw new Error("Hermes application path is unavailable");
 	const result = spawnRuntimeUserCommand(
-		join(appRoot, ".venv", "bin", "python"),
+		join(appRoot, "venv", "bin", "python"),
 		["-c", HERMES_POOL_GUARD, appRoot],
 		input.home,
 		input.workspaceRoot,

--- a/packages/cli/src/runtime/hermes-native-credentials.test.ts
+++ b/packages/cli/src/runtime/hermes-native-credentials.test.ts
@@ -1,9 +1,20 @@
 import { afterEach, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { HERMES_NATIVE_CREDENTIALS_HELPER } from "./hermes-native-credentials";
+import {
+	HERMES_NATIVE_CREDENTIALS_HELPER,
+	reconcileHermesNativeCredentials,
+} from "./hermes-native-credentials";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -108,6 +119,29 @@ const credential = {
 	apiKey: "connected-key",
 	baseUrl: "https://api.anthropic.com",
 };
+
+test("native credentials use the official managed Hermes interpreter", () => {
+	const f = fixture();
+	const bin = join(f.home, ".hermes", "hermes-agent", "venv", "bin");
+	mkdirSync(bin, { recursive: true });
+	symlinkSync("/usr/bin/python3", join(bin, "python"));
+	const result = reconcileHermesNativeCredentials({
+		home: f.home,
+		workspaceRoot: f.home,
+		providers: [credential],
+		previousProviderIds: [],
+		strategies: {},
+	});
+	expect(result.changed).toBe(true);
+	expect(
+		f
+			.pool()
+			.anthropic.some(
+				(row: { id: string; access_token: string }) =>
+					row.id === "clawdi-native-api-key" && row.access_token === credential.apiKey,
+			),
+	).toBe(true);
+});
 
 test("native credentials take priority, rotate only their row, and retain cooldown until rotation", () => {
 	const f = fixture();

--- a/packages/cli/src/runtime/hermes-native-credentials.ts
+++ b/packages/cli/src/runtime/hermes-native-credentials.ts
@@ -42,7 +42,7 @@ export function reconcileHermesNativeCredentials(input: HermesNativeCredentialsI
 	const appRoot = runtimeAppRoot("hermes", input.home);
 	if (!appRoot) throw new Error("Hermes application path is unavailable");
 	const result = spawnRuntimeUserCommand(
-		join(appRoot, ".venv", "bin", "python"),
+		join(appRoot, "venv", "bin", "python"),
 		["-c", HERMES_NATIVE_CREDENTIALS_HELPER, appRoot],
 		input.home,
 		input.workspaceRoot,


### PR DESCRIPTION
Managed Hermes installs use `venv/bin/python`, while the credential bridges launched the development `.venv` path. Use the managed interpreter for both bridges and delegate custom pool lookup to the installed public API, including the older `get_custom_provider_pool_key` interface.

The model ownership gate also treated expired historical observation heads as active conflicts. Scope its internal read to the persisted apply generation and require one fresh head; competing fresh boots still reject migration. Public legacy drift reads retain their existing conservative behavior, and source, instance, version, and provider-ownership checks remain required.

Validation: bounded isolated Docker, 22 backend cases and 32 CLI cases passed; CLI typecheck, strict Python checks, Ruff, Biome, and diff checks passed. Added regressions for expired/history versus competing fresh boots, the managed interpreter, and both native pool APIs. Full local convergence setup was blocked by HTTP 429 while fetching upstream fixtures; full CI is required before merge.

CLI release candidate: 0.14.59. The migration version allowlist remains disabled until publication and qualification are complete.
