### PR TITLE
feat(mcp): complete connector account discovery and management

### DIFF
--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -26,14 +26,13 @@ from app.services.composio import (
     connect_with_credentials,
     create_connect_link,
     create_mcp_bridge_token,
-    disconnect_account,
+    disconnect_owned_account,
     get_all_connected_accounts,
     get_app_by_name,
     get_app_tools,
     get_auth_fields,
     get_available_apps,
     get_connector_metadata,
-    get_owned_account,
     invalidate_tool_router_mcp_session,
     normalize_composio_failure,
     update_account_alias,
@@ -65,7 +64,7 @@ _REDIRECT_AUTH_TYPES = {
 }
 
 
-def _map_composio_error(exc: ComposioRouteError) -> HTTPException:
+def map_composio_error(exc: ComposioRouteError) -> HTTPException:
     """Map the adapter's sanitized failure record to the public HTTP contract."""
     failure = normalize_composio_failure(exc)
     if failure.kind == "metadata":
@@ -132,7 +131,7 @@ async def list_connections(
         if _is_composio_auth_error(exc):
             log.warning("composio_key_invalid path=connectors_list")
             return []
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     # The dashboard refetches connections after OAuth redirects complete.
     # Composio Tool Router sessions capture the active account set, so
     # observing the latest connected-account state should force the next
@@ -152,7 +151,7 @@ async def read_connector_metadata(
     try:
         return await get_connector_metadata(body.names)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
 
 
 @router.get("/available")
@@ -179,7 +178,7 @@ async def list_available_apps(
             return Paginated[ConnectorAvailableAppResponse](
                 items=[], total=0, page=page, page_size=page_size
             )
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     return Paginated[ConnectorAvailableAppResponse](
         items=page_data["items"],
         total=page_data["total"],
@@ -201,7 +200,7 @@ async def get_available_app(
     try:
         app = await get_app_by_name(app_name)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     if app is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
     return app
@@ -242,7 +241,7 @@ async def connect_app(
             require_clerk_id(auth), app_name, redirect_url, alias=body.alias if body else None
         )
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     return result
 
 
@@ -263,7 +262,7 @@ async def auth_fields(
     try:
         fields = await get_auth_fields(app_name)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     return fields
 
 
@@ -295,7 +294,7 @@ async def connect_credentials(
             require_clerk_id(auth), app_name, body.credentials, alias=body.alias
         )
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     if not result.ok:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
@@ -316,7 +315,7 @@ async def update_connection(
     try:
         return await update_account_alias(require_clerk_id(auth), connection_id, body.alias)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
 
 
 @router.delete("/{connection_id}")
@@ -333,19 +332,12 @@ async def disconnect(
     if not settings.composio_api_key:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
 
-    clerk_id = require_clerk_id(auth)
     try:
-        await get_owned_account(clerk_id, connection_id)
+        success = await disconnect_owned_account(require_clerk_id(auth), connection_id)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
-
-    try:
-        success = await disconnect_account(connection_id)
-    except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     if not success:
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to disconnect")
-    await invalidate_tool_router_mcp_session(clerk_id)
     return ConnectorDisconnectResponse(status="disconnected")
 
 
@@ -374,5 +366,5 @@ async def list_app_tools(
     try:
         tools = await get_app_tools(app_name)
     except ComposioRouteError as exc:
-        raise _map_composio_error(exc) from exc
+        raise map_composio_error(exc) from exc
     return [ConnectorToolResponse.model_validate(tool) for tool in tools]

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -47,17 +47,21 @@ from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.session_share import SessionShare
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
+from app.routes.connectors import map_composio_error
 from app.routes.memories import attach_source_machines
 from app.routes.public_sessions import resolve_session_for_view
+from app.schemas.connector import ConnectorAlias, ConnectorDisconnectResponse
 from app.schemas.vault import VaultCreate, VaultItemDelete, VaultItemUpsert
 from app.services.composio import (
     ComposioMcpUpstreamError,
     ComposioRouteError,
     call_tool_router_mcp_tool,
+    disconnect_owned_account,
     get_connected_account_identities,
     get_tool_router_mcp_session,
     get_tool_router_mcp_tools,
     get_tool_router_mcp_tools_result,
+    update_account_alias,
     verify_mcp_bridge_token,
 )
 from app.services.file_store import get_file_store
@@ -110,6 +114,16 @@ class _ToolArguments(BaseModel):
 
 class _NoArguments(_ToolArguments):
     pass
+
+
+class _ConnectorAccountIdentityArguments(_ToolArguments):
+    connection_id: StrictStr = Field(
+        min_length=1, max_length=200, pattern=r"\S", description="Exact connected account ID."
+    )
+
+
+class _ConnectorAccountUpdateArguments(_ConnectorAccountIdentityArguments):
+    alias: ConnectorAlias = Field(description="Account alias; an empty string clears it.")
 
 
 class _MemorySearchArguments(_ToolArguments):
@@ -614,6 +628,30 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
         input_schema=_NoArguments.model_json_schema(),
         scopes=("connectors:read",),
         handler=lambda arguments, auth, db: _tool_connector_account_list(
+            arguments, auth=auth, db=db
+        ),
+    ),
+    "connector_account_update": _NativeToolSpec(
+        description=(
+            "Update the alias of one exact connected account only when authorized by the user. "
+            "An empty alias clears it; credentials cannot be updated. This change is "
+            "account-wide and affects all agents."
+        ),
+        input_schema=_ConnectorAccountUpdateArguments.model_json_schema(),
+        scopes=("connectors:invoke",),
+        handler=lambda arguments, auth, db: _tool_connector_account_update(
+            arguments, auth=auth, db=db
+        ),
+    ),
+    "connector_account_delete": _NativeToolSpec(
+        description=(
+            "Disconnect one exact connected account only when authorized by the user. "
+            "Verify the connection ID before calling. Disconnection is account-wide and "
+            "removes this account's connector access for all agents."
+        ),
+        input_schema=_ConnectorAccountIdentityArguments.model_json_schema(),
+        scopes=("connectors:invoke",),
+        handler=lambda arguments, auth, db: _tool_connector_account_delete(
             arguments, auth=auth, db=db
         ),
     ),
@@ -1485,6 +1523,34 @@ async def _tool_connector_account_list(
     return _tool_json(
         {"accounts": [account.model_dump(mode="json", exclude_none=True) for account in accounts]}
     )
+
+
+async def _tool_connector_account_update(
+    arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
+) -> JsonObject:
+    parsed = _validate_arguments(_ConnectorAccountUpdateArguments, arguments)
+    del db
+    try:
+        account = await update_account_alias(
+            require_clerk_id(auth), parsed.connection_id, parsed.alias
+        )
+    except ComposioRouteError as exc:
+        raise map_composio_error(exc) from exc
+    return _tool_json(account.model_dump(mode="json"))
+
+
+async def _tool_connector_account_delete(
+    arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
+) -> JsonObject:
+    parsed = _validate_arguments(_ConnectorAccountIdentityArguments, arguments)
+    del db
+    try:
+        success = await disconnect_owned_account(require_clerk_id(auth), parsed.connection_id)
+    except ComposioRouteError as exc:
+        raise map_composio_error(exc) from exc
+    if not success:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Failed to disconnect")
+    return _tool_json(ConnectorDisconnectResponse(status="disconnected").model_dump(mode="json"))
 
 
 async def _tool_connector_call(

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -17,6 +17,7 @@ from pydantic import (
     ConfigDict,
     Field,
     JsonValue,
+    StrictBool,
     StrictInt,
     StrictStr,
     TypeAdapter,
@@ -114,6 +115,13 @@ class _ToolArguments(BaseModel):
 
 class _NoArguments(_ToolArguments):
     pass
+
+
+class _ConnectorAccountListArguments(_ToolArguments):
+    include_inactive: StrictBool = Field(
+        default=False,
+        description="Include inactive, expired, and disabled accounts for management.",
+    )
 
 
 class _ConnectorAccountIdentityArguments(_ToolArguments):
@@ -621,11 +629,11 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
     ),
     "connector_account_list": _NativeToolSpec(
         description=(
-            "List active Clawdi connector accounts and credential-free account, organization, "
-            "or tenant labels. Use it to verify the exact service identity before selecting "
-            "the connector for a side effect."
+            "List active, enabled Clawdi connector accounts and credential-free account, "
+            "organization, or tenant labels. Verify the service identity before a side effect. "
+            "Set include_inactive to true for account management."
         ),
-        input_schema=_NoArguments.model_json_schema(),
+        input_schema=_ConnectorAccountListArguments.model_json_schema(),
         scopes=("connectors:read",),
         handler=lambda arguments, auth, db: _tool_connector_account_list(
             arguments, auth=auth, db=db
@@ -1510,10 +1518,12 @@ async def _tool_vault_item_delete(
 async def _tool_connector_account_list(
     arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
 ) -> JsonObject:
-    _validate_arguments(_NoArguments, arguments)
+    parsed = _validate_arguments(_ConnectorAccountListArguments, arguments)
     del db
     try:
-        accounts = await get_connected_account_identities(require_clerk_id(auth))
+        accounts = await get_connected_account_identities(
+            require_clerk_id(auth), include_inactive=parsed.include_inactive
+        )
     except ComposioRouteError:
         logger.info("Connector account identities unavailable")
         raise HTTPException(

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -1131,11 +1131,23 @@ async def _wait_for_connection_status(
 
 
 async def disconnect_account(connected_account_id: str) -> bool:
-    """Disconnect/revoke a connected account."""
+    """Delete a connected account."""
     client = get_composio_client()
-    raw_response = await _call_generated_sdk(client.connected_accounts.delete(connected_account_id))
+    # A failed response may follow a completed deletion; never replay it automatically.
+    raw_response = await _call_generated_sdk(
+        client.with_options(max_retries=0).connected_accounts.delete(connected_account_id)
+    )
     response = _normalize_sdk_response(raw_response, _ConnectedAccountDeleteResponse)
     return response.success
+
+
+async def disconnect_owned_account(user_id: str, connected_account_id: str) -> bool:
+    """Disconnect one owned account and discard sessions even after ambiguous failures."""
+    await get_owned_account(user_id, connected_account_id)
+    try:
+        return await disconnect_account(connected_account_id)
+    finally:
+        await invalidate_tool_router_mcp_session(user_id)
 
 
 async def get_owned_account(user_id: str, connected_account_id: str) -> _ConnectedAccount:

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -177,6 +177,7 @@ class ConnectorAccountIdentity(BaseModel):
     id: str
     app_name: str
     status: ComposioStatus
+    is_disabled: bool = False
     alias: str | None = None
     account_display: str | None = None
     organization_display: str | None = None
@@ -829,9 +830,15 @@ async def get_connected_accounts(user_id: str) -> list[ConnectorConnectionRespon
     return [_serialize_connected_account(account) for account in accounts]
 
 
-async def get_connected_account_identities(user_id: str) -> list[ConnectorAccountIdentity]:
-    """List safe account and tenant labels without exposing provider payloads."""
-    accounts = await _get_active_connected_accounts(user_id)
+async def get_connected_account_identities(
+    user_id: str, *, include_inactive: bool = False
+) -> list[ConnectorAccountIdentity]:
+    """List safe identity labels, optionally including unavailable accounts for management."""
+    accounts = (
+        await _list_connected_accounts(user_id)
+        if include_inactive
+        else await _get_active_connected_accounts(user_id)
+    )
     return [_serialize_connected_account_identity(account) for account in accounts]
 
 
@@ -895,6 +902,7 @@ def _serialize_connected_account_identity(account: _ConnectedAccount) -> Connect
         id=account.id,
         app_name=account.toolkit.slug,
         status=account.status,
+        is_disabled=account.is_disabled,
         alias=account.alias,
         account_display=_account_display_label(account),
         organization_display=_first_identity_label(

--- a/backend/tests/test_connector_lifecycle.py
+++ b/backend/tests/test_connector_lifecycle.py
@@ -49,7 +49,10 @@ async def test_management_lists_nonactive_but_identity_availability_does_not(mon
     accounts = [account(status) for status in ["ACTIVE", "EXPIRED", "FAILED", "INACTIVE"]]
     accounts.append(account("ACTIVE", disabled=True))
 
+    statuses = []
+
     def handle(request):
+        statuses.append(request.url.params.get("statuses"))
         assert request.url.params["user_ids"] == "owner"
         return httpx.Response(200, json={"items": accounts})
 
@@ -57,10 +60,16 @@ async def test_management_lists_nonactive_but_identity_availability_does_not(mon
         all_accounts = await composio.get_all_connected_accounts("owner")
         available = await composio.get_connected_account_identities("owner")
         counts = await composio.get_connected_accounts("owner")
+        identities = await composio.get_connected_account_identities("owner", include_inactive=True)
     assert {item.status for item in all_accounts} == {"ACTIVE", "EXPIRED", "FAILED", "INACTIVE"}
     assert len(all_accounts) == 5
     assert len(available) == len(counts) == 1
-    assert "private-old-key" not in str(all_accounts)
+    assert statuses == [None, "ACTIVE", "ACTIVE", None]
+    assert [(item.status, item.is_disabled) for item in identities] == [
+        (item.status, item.is_disabled) for item in all_accounts
+    ]
+    assert identities[-1].status == "ACTIVE" and identities[-1].is_disabled
+    assert "private-" not in str([all_accounts, available, identities])
 
 
 async def test_delete_owned_expired_account(monkeypatch):

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -1243,8 +1243,8 @@ async def test_disconnect_invalidates_tool_router_session(monkeypatch: pytest.Mo
         return True
 
     monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
-    monkeypatch.setattr(connectors, "get_owned_account", fake_get_owned_account)
-    monkeypatch.setattr(connectors, "disconnect_account", fake_disconnect_account)
+    monkeypatch.setattr(composio, "get_owned_account", fake_get_owned_account)
+    monkeypatch.setattr(composio, "disconnect_account", fake_disconnect_account)
     composio._tool_router_session_cache["clerk_user_123"] = composio.ComposioMcpSession(
         url="https://app.composio.dev/tool_router/v3/trs_old/mcp",
         headers={},
@@ -1284,7 +1284,7 @@ async def test_map_composio_client_bad_request_to_safe_credential_error():
             credentials={"generic_api_key": "mb_secret_123"},
         )
 
-    mapped = connectors._map_composio_error(exc_info.value)
+    mapped = connectors.map_composio_error(exc_info.value)
 
     assert mapped.status_code == 400
     assert mapped.detail == "Metabase rejected API key ***"
@@ -1306,14 +1306,14 @@ async def test_map_composio_client_not_found_to_connector_not_found():
     with pytest.raises(composio.ComposioProviderError) as exc_info:
         await composio._call_generated_sdk(fail_request())
 
-    mapped = connectors._map_composio_error(exc_info.value)
+    mapped = connectors.map_composio_error(exc_info.value)
 
     assert mapped.status_code == 404
     assert mapped.detail == "Connector not found"
 
 
 def test_map_custom_oauth_config_required_to_actionable_bad_request():
-    mapped = connectors._map_composio_error(
+    mapped = connectors.map_composio_error(
         composio.ConnectorCustomAuthConfigRequired("twitter", "OAUTH2")
     )
 
@@ -1347,7 +1347,7 @@ async def test_catalog_rejects_malformed_sdk_page_instead_of_returning_empty(
     with pytest.raises(composio.ComposioProtocolError):
         await composio.get_available_apps()
 
-    mapped = connectors._map_composio_error(
+    mapped = connectors.map_composio_error(
         composio.ComposioProtocolError("provider detail must stay private")
     )
     assert mapped.status_code == 502

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -1610,6 +1610,7 @@ def test_connected_account_identity_exposes_only_allowlisted_labels() -> None:
         "alias": "Work GitHub",
         "app_name": "github",
         "status": "ACTIVE",
+        "is_disabled": False,
         "account_display": "octocat@example.test",
         "organization_display": "Clawdi AI",
         "tenant_display": "tenant-primary",

--- a/backend/tests/test_mcp_capability_parity.py
+++ b/backend/tests/test_mcp_capability_parity.py
@@ -1021,7 +1021,10 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
             {"name": "connector_account_delete", "inputSchema": {"type": "object"}},
         ]
 
-    async def connected_account_identities(_user_id: str) -> list[ConnectorAccountIdentity]:
+    async def connected_account_identities(
+        _user_id: str, *, include_inactive: bool = False
+    ) -> list[ConnectorAccountIdentity]:
+        assert include_inactive is False
         return [
             ConnectorAccountIdentity(
                 id="ca_github",
@@ -1063,6 +1066,7 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
                     "id": "ca_github",
                     "app_name": "github",
                     "status": "ACTIVE",
+                    "is_disabled": False,
                     "account_display": "octocat",
                     "organization_display": "clawdi-ai",
                     "tenant_display": "tenant-primary",

--- a/backend/tests/test_mcp_capability_parity.py
+++ b/backend/tests/test_mcp_capability_parity.py
@@ -1017,6 +1017,8 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
             {"name": "project_get", "inputSchema": {"type": "object"}},
             {"name": "vault_create", "inputSchema": {"type": "object"}},
             {"name": "connector_safe", "inputSchema": {"type": "object"}},
+            {"name": "connector_account_update", "inputSchema": {"type": "object"}},
+            {"name": "connector_account_delete", "inputSchema": {"type": "object"}},
         ]
 
     async def connected_account_identities(_user_id: str) -> list[ConnectorAccountIdentity]:
@@ -1112,6 +1114,28 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
             )
             assert missing_write["isError"] is True
             assert "missing scope: vault:write" in missing_write["content"][0]["text"]
+
+            for name in ("connector_account_update", "connector_account_delete"):
+                assert name not in names
+                missing_mutation = await _tool_call(
+                    client, 44, name, {"connection_id": "ca_github"}
+                )
+                assert missing_mutation["isError"] is True
+                assert "missing scope: connectors:invoke" in missing_mutation["content"][0]["text"]
+
+            runtime_auth.api_key.scopes = ["connectors:invoke"]
+            mutation_tools = (await _rpc(client, 45, "tools/list", {}))["tools"]
+            mutation_names = [tool["name"] for tool in mutation_tools]
+            assert "connector_account_list" not in mutation_names
+            for name in ("connector_account_update", "connector_account_delete"):
+                assert mutation_names.count(name) == 1
+                schema = next(
+                    tool["inputSchema"] for tool in mutation_tools if tool["name"] == name
+                )
+                assert schema["additionalProperties"] is False
+                assert "connection_id" in schema["required"]
+                if name == "connector_account_update":
+                    assert "alias" in schema["required"]
 
             runtime_auth.api_key.scopes = ["projects:read", "vault:write"]
             missing_accounts = await _tool_call(client, 43, "connector_account_list")

--- a/backend/tests/test_mcp_connector_accounts.py
+++ b/backend/tests/test_mcp_connector_accounts.py
@@ -1,0 +1,177 @@
+"""Native account mutations through MCP HTTP and the pinned Composio HTTP client."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from composio_client import AsyncComposio
+from mcp.types import ListToolsResult
+
+from app.services import composio
+from tests.test_mcp_capability_parity import _tool_call, _tool_json
+
+
+@pytest.fixture
+async def account_provider(monkeypatch, seed_user):
+    account = {
+        "id": "account-exact",
+        "toolkit": {"slug": "gmail"},
+        "status": "EXPIRED",
+        "created_at": "2026-09-03T00:00:00Z",
+        "alias": "old",
+        "is_disabled": True,
+        "data": {"email": "work@example.test", "access_token": "private-token"},
+        "state": {},
+    }
+    requests = []
+    responses = {}
+
+    def handle(request):
+        requests.append(request)
+        if request.url.path.endswith("/connected_accounts"):
+            assert request.method == "GET"
+            assert request.url.params["user_ids"] == seed_user.clerk_id
+            assert request.url.params["limit"] == "1"
+            assert "statuses" not in request.url.params
+            owned = request.url.params["connected_account_ids"] == account["id"]
+            return httpx.Response(200, json={"items": [account] if owned else []})
+        assert request.url.path.endswith("/connected_accounts/account-exact")
+        if request.method in responses:
+            return responses[request.method]
+        if request.method == "PATCH":
+            body = json.loads(request.content)
+            assert set(body) == {"alias"}
+            account["alias"] = body["alias"] or None
+            return httpx.Response(
+                200, json={"id": account["id"], "status": account["status"], "success": True}
+            )
+        if request.method == "DELETE":
+            return httpx.Response(200, json={"success": True})
+        assert request.method == "GET"
+        return httpx.Response(200, json=account)
+
+    cached = composio.ComposioMcpSession(
+        url="https://example.test/mcp",
+        headers={},
+        expires_at=datetime.now(UTC) + timedelta(minutes=30),
+    )
+    monkeypatch.setattr(composio, "_tool_router_session_cache", {seed_user.clerk_id: cached})
+    monkeypatch.setattr(
+        composio,
+        "_tool_router_tools_cache",
+        {seed_user.clerk_id: (cached, ListToolsResult(tools=[]))},
+    )
+    async with AsyncComposio(
+        api_key="test", http_client=httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    ) as sdk:
+        monkeypatch.setattr(composio, "get_composio_client", lambda: sdk)
+        yield account, requests, responses
+
+
+@pytest.mark.parametrize("alias", ["工作邮箱", ""])
+async def test_mcp_account_alias_update_and_clear(client, account_provider, seed_user, alias):
+    account, requests, _ = account_provider
+    result = await _tool_call(
+        client, 1, "connector_account_update", {"connection_id": account["id"], "alias": alias}
+    )
+    assert not result.get("isError")
+    assert _tool_json(result) == {
+        "id": account["id"],
+        "app_name": "gmail",
+        "status": "EXPIRED",
+        "created_at": account["created_at"],
+        "is_disabled": True,
+        "alias": alias or None,
+        "account_display": "work@example.test",
+    }
+    assert [r.method for r in requests] == ["GET", "PATCH", "GET"]
+    assert "private-token" not in json.dumps(result)
+    assert seed_user.clerk_id not in composio._tool_router_session_cache
+    assert seed_user.clerk_id not in composio._tool_router_tools_cache
+
+
+async def test_mcp_account_delete_expired_account(client, account_provider, seed_user):
+    account, requests, _ = account_provider
+    result = await _tool_call(
+        client, 1, "connector_account_delete", {"connection_id": account["id"]}
+    )
+    assert not result.get("isError")
+    assert _tool_json(result) == {"status": "disconnected"}
+    assert [r.method for r in requests] == ["GET", "DELETE"]
+    assert seed_user.clerk_id not in composio._tool_router_session_cache
+    assert seed_user.clerk_id not in composio._tool_router_tools_cache
+
+
+@pytest.mark.parametrize("name", ["connector_account_update", "connector_account_delete"])
+async def test_mcp_account_mutations_refuse_nonowned_id(client, account_provider, seed_user, name):
+    _, requests, _ = account_provider
+    arguments = {"connection_id": "another-users-account"}
+    if name == "connector_account_update":
+        arguments["alias"] = "should not change"
+    result = await _tool_call(client, 1, name, arguments)
+    assert result["isError"] is True
+    assert result["content"][0]["text"] == "Error: Connector not found"
+    assert [r.method for r in requests] == ["GET"]
+    assert seed_user.clerk_id in composio._tool_router_session_cache
+
+
+async def test_mcp_account_mutations_reject_invalid_arguments_before_provider(
+    client, account_provider
+):
+    _, requests, _ = account_provider
+    invalid = [
+        ("connector_account_update", {"connection_id": "account-exact"}),
+        (
+            "connector_account_update",
+            {
+                "connection_id": "account-exact",
+                "alias": "ok",
+                "credentials": {"token": "private-token"},
+            },
+        ),
+        ("connector_account_delete", {"connection_id": " \t"}),
+    ]
+    for request_id, (name, arguments) in enumerate(invalid, start=1):
+        result = await _tool_call(client, request_id, name, arguments)
+        assert result["isError"] is True
+        assert result["content"][0]["text"] == "Error: Invalid tool arguments"
+    assert requests == []
+
+
+@pytest.mark.parametrize(
+    "name,method,status_code,body,error",
+    [
+        (
+            "connector_account_update",
+            "PATCH",
+            409,
+            {"message": "private-token"},
+            "Connection conflict. Check the alias or retry shortly.",
+        ),
+        (
+            "connector_account_delete",
+            "DELETE",
+            500,
+            {"message": "private-token"},
+            "Composio request failed",
+        ),
+        ("connector_account_delete", "DELETE", 200, {"success": False}, "Failed to disconnect"),
+    ],
+)
+async def test_mcp_account_provider_failures_are_safe_and_not_retried(
+    client, account_provider, seed_user, name, method, status_code, body, error
+):
+    account, requests, responses = account_provider
+    responses[method] = httpx.Response(status_code, json=body)
+    arguments = {"connection_id": account["id"]}
+    if method == "PATCH":
+        arguments["alias"] = "new"
+    result = await _tool_call(client, 1, name, arguments)
+    assert result["isError"] is True
+    assert result["content"][0]["text"] == f"Error: {error}"
+    assert "private-token" not in json.dumps(result)
+    assert [r.method for r in requests] == ["GET", method]
+    if method == "DELETE":
+        assert seed_user.clerk_id not in composio._tool_router_session_cache
+        assert seed_user.clerk_id not in composio._tool_router_tools_cache

--- a/backend/tests/test_mcp_connector_accounts.py
+++ b/backend/tests/test_mcp_connector_accounts.py
@@ -1,4 +1,4 @@
-"""Native account mutations through MCP HTTP and the pinned Composio HTTP client."""
+"""Native account management through MCP HTTP and the pinned Composio HTTP client."""
 
 import json
 from datetime import UTC, datetime, timedelta
@@ -32,6 +32,9 @@ async def account_provider(monkeypatch, seed_user):
         if request.url.path.endswith("/connected_accounts"):
             assert request.method == "GET"
             assert request.url.params["user_ids"] == seed_user.clerk_id
+            if "connected_account_ids" not in request.url.params:
+                assert request.url.params["limit"] == "100"
+                return httpx.Response(200, json={"items": [account]})
             assert request.url.params["limit"] == "1"
             assert "statuses" not in request.url.params
             owned = request.url.params["connected_account_ids"] == account["id"]
@@ -67,6 +70,32 @@ async def account_provider(monkeypatch, seed_user):
     ) as sdk:
         monkeypatch.setattr(composio, "get_composio_client", lambda: sdk)
         yield account, requests, responses
+
+
+@pytest.mark.parametrize("arguments", [{}, {"include_inactive": False}, {"include_inactive": True}])
+async def test_mcp_account_list_management_opt_in(client, account_provider, arguments):
+    account, requests, _ = account_provider
+    result = await _tool_call(client, 1, "connector_account_list", arguments)
+    expected = (
+        [
+            {
+                "id": account["id"],
+                "app_name": "gmail",
+                "status": "EXPIRED",
+                "is_disabled": True,
+                "alias": "old",
+                "account_display": "work@example.test",
+            }
+        ]
+        if arguments.get("include_inactive")
+        else []
+    )
+    assert _tool_json(result) == {"accounts": expected}
+    assert len(requests) == 1
+    assert requests[0].url.params.get("statuses") == (
+        None if arguments.get("include_inactive") else "ACTIVE"
+    )
+    assert "private-token" not in json.dumps(result)
 
 
 @pytest.mark.parametrize("alias", ["工作邮箱", ""])
@@ -116,11 +145,12 @@ async def test_mcp_account_mutations_refuse_nonowned_id(client, account_provider
     assert seed_user.clerk_id in composio._tool_router_session_cache
 
 
-async def test_mcp_account_mutations_reject_invalid_arguments_before_provider(
-    client, account_provider
-):
+async def test_mcp_account_tools_reject_invalid_arguments_before_provider(client, account_provider):
     _, requests, _ = account_provider
     invalid = [
+        ("connector_account_list", {"include_inactive": "true"}),
+        ("connector_account_list", {"include_inactive": 1}),
+        ("connector_account_list", {"unexpected": True}),
         ("connector_account_update", {"connection_id": "account-exact"}),
         (
             "connector_account_update",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,7 +404,9 @@ re-embedding is unavailable; Mem0 updates verify account ownership before the
 provider mutation. `session_list` uses the same account/legacy-environment fence
 as Session search/get and supports bounded time, Agent, and visible Project
 filters. `connector_account_list` exposes active, enabled connection IDs,
-toolkit names, aliases, statuses, and allowlisted display labels; raw provider
+toolkit names, aliases, statuses, disabled state, and allowlisted display labels.
+Its optional `include_inactive: true` flag includes non-active and disabled accounts
+for management without changing the default execution-oriented list. Raw provider
 `data`, `state`, tokens, and credentials never enter the MCP result.
 
 `connector_account_update` changes only an owned account's alias; an empty string

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -392,8 +392,8 @@ tool names use singular `<resource>[_<subresource>]_<action>` identifiers;
 connector-provided names remain unchanged. Native tools cover Memory
 search/list/create/exact update/delete, Session search/list/get,
 read-only Project metadata, Vault metadata/references, explicit single-reference
-Vault plaintext resolution, narrow Vault writes, and credential-free connector
-account identity.
+Vault plaintext resolution, narrow Vault writes, and connector account identity
+and management.
 Tools requiring unavailable scopes are omitted from `tools/list`, while direct
 calls still fail the scope check. Connector names can never shadow a declared
 native tool, including one hidden by scope.
@@ -406,6 +406,13 @@ as Session search/get and supports bounded time, Agent, and visible Project
 filters. `connector_account_list` exposes active, enabled connection IDs,
 toolkit names, aliases, statuses, and allowlisted display labels; raw provider
 `data`, `state`, tokens, and credentials never enter the MCP result.
+
+`connector_account_update` changes only an owned account's alias; an empty string
+clears it. `connector_account_delete` disconnects the exact owned connection.
+Both require `connectors:invoke`, affect all agents using that account, and reuse
+the dashboard's service-layer ownership checks and session invalidation. Deleting
+a connection does not revoke the provider's authorization grant. Account discovery
+retains the separate `connectors:read` permission.
 
 Composio sessions enable multiple accounts per toolkit with
 `require_explicit_selection=False` explicitly set. The pinned SDK otherwise

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -146,6 +146,13 @@ the same path; never repeat it through another path.
 
 ## Connector Workflow
 
+For explicit account management, use `connector_account_update` with the exact
+`connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
+with the exact `connection_id` to disconnect it. These tools require
+`connectors:invoke` and affect the account across all agents. Deletion removes the
+Clawdi connection; it does not revoke the provider's grant. Use only tools present
+in `tools/list`, and do not guess an account ID or automatically retry an ambiguous mutation.
+
 When the Clawdi connector path is selected, use the Composio Tool Router meta-tools returned
 by `tools/list` on the `clawdi` MCP server. Treat their live names and schemas as
 authoritative; never assume a fixed meta-tool set.

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -144,7 +144,7 @@ login, invent API details, or expose secrets. Choose the path before a side effe
 only after a definite preflight failure. If a mutation's result is ambiguous, inspect it through
 the same path; never repeat it through another path.
 
-## Connector Workflow
+## Connector Account Management
 
 For explicit account management, use `connector_account_update` with the exact
 `connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
@@ -152,6 +152,8 @@ with the exact `connection_id` to disconnect it. These tools require
 `connectors:invoke` and affect the account across all agents. Deletion removes the
 Clawdi connection; it does not revoke the provider's grant. Use only tools present
 in `tools/list`, and do not guess an account ID or automatically retry an ambiguous mutation.
+
+## Connector Workflow
 
 When the Clawdi connector path is selected, use the Composio Tool Router meta-tools returned
 by `tools/list` on the `clawdi` MCP server. Treat their live names and schemas as

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -146,6 +146,10 @@ the same path; never repeat it through another path.
 
 ## Connector Account Management
 
+For account cleanup, call `connector_account_list` with `include_inactive: true`
+to include expired, failed, and disabled accounts. The default list contains only
+active, enabled accounts.
+
 For explicit account management, use `connector_account_update` with the exact
 `connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
 with the exact `connection_id` to disconnect it. These tools require

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -116,6 +116,13 @@ the same path; never repeat it through another path.
 
 ## Connector Workflow
 
+For explicit account management, use `connector_account_update` with the exact
+`connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
+with the exact `connection_id` to disconnect it. These tools require
+`connectors:invoke` and affect the account across all agents. Deletion removes the
+Clawdi connection; it does not revoke the provider's grant. Use only tools present
+in `tools/list`, and do not guess an account ID or automatically retry an ambiguous mutation.
+
 When the Clawdi connector path is selected, use the Composio Tool Router meta-tools returned
 by `tools/list` on the `clawdi` MCP server. Treat their live names and schemas as
 authoritative; never assume a fixed meta-tool set.

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -116,13 +116,6 @@ the same path; never repeat it through another path.
 
 ## Connector Workflow
 
-For explicit account management, use `connector_account_update` with the exact
-`connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
-with the exact `connection_id` to disconnect it. These tools require
-`connectors:invoke` and affect the account across all agents. Deletion removes the
-Clawdi connection; it does not revoke the provider's grant. Use only tools present
-in `tools/list`, and do not guess an account ID or automatically retry an ambiguous mutation.
-
 When the Clawdi connector path is selected, use the Composio Tool Router meta-tools returned
 by `tools/list` on the `clawdi` MCP server. Treat their live names and schemas as
 authoritative; never assume a fixed meta-tool set.


### PR DESCRIPTION
Complete connector account management through the existing native MCP registry:

- `connector_account_list` keeps its active/enabled-only default. Optional `include_inactive: true` includes expired, failed and disabled accounts for cleanup. The safe identity result includes alias and disabled state, never raw credentials.
- `connector_account_update` requires an exact `connection_id` and `alias`; an empty alias clears it. No credential update is exposed.
- `connector_account_delete` disconnects the exact owned account, including inactive/expired accounts.

Discovery retains `connectors:read`; both mutations require existing `connectors:invoke`. Scope filtering and direct-call enforcement use the existing registry, and upstream tools cannot shadow the native names. Web and MCP share ownership checks, sanitized errors and deletion cache invalidation. Deletion is not automatically retried and invalidates cached sessions even on an ambiguous failure. Deleting a connection does not revoke the provider's grant.

Validation: isolated Docker targeted backend tests passed (70), covering default/opt-in discovery, safe identity projection, account update/clear/delete, nonowned IDs, invalid arguments, scope/name collisions and provider failures. Ruff/format and strict production-file types passed. Eleven current Skill and immutable Hosted catalog tests passed. No database migration or public HTTP schema change is needed. Current generic Skill docs are updated; immutable Hosted v1 content remains unchanged. Tools are dynamically served by the backend, so no CLI binary/npm release is required.

Final review head: `f3f4318387db6529ce1b80c4b9e8954563b65e95`. Owner authorized merge and deployment after checks pass. Standard main Backend CI and Clawdi Image Release will deploy the merged commit. No live aliases or connections have been modified.
