### PR TITLE
fix(cli): reject connection authentication header overrides

### DIFF
--- a/packages/cli/src/runtime/connection-provider-config.test.ts
+++ b/packages/cli/src/runtime/connection-provider-config.test.ts
@@ -219,6 +219,34 @@ function applyProjector(f: ReturnType<typeof fixture>, previousProviderIds: stri
 	);
 }
 
+test("openclaw: reject authentication header overrides before handoff and rotation", () => {
+	const f = fixture("openclaw");
+	try {
+		for (const phase of ["handoff", "rotation"]) {
+			const original = recordValue(f.read()) ?? {};
+			for (const override of [
+				{ authHeader: false },
+				...["Authorization", "X-API-Key", "api-key", "COOKIE"].map((name) => ({
+					headers: { [name]: "user-owned-credential" },
+				})),
+			]) {
+				f.set({ ...original, ...override });
+				const before = f.read();
+				expect(() => f.prepare()).toThrow("authentication header conflict");
+				expect(f.read()).toEqual(before);
+			}
+			f.set({ ...original, headers: { "X-Request-Source": "user-agent" } });
+			if (phase === "rotation")
+				f.secretValues["secret://provider.saved-provider.apiKey"] = "rotated-key";
+			f.prepare();
+			applyConnectionProviderTransfers(f.input());
+			expect(recordValue(f.read())?.headers).toEqual({ "X-Request-Source": "user-agent" });
+		}
+	} finally {
+		f.cleanup();
+	}
+});
+
 for (const runtime of ["openclaw", "hermes"] as const) {
 	test(`${runtime}: explicit catalog primary supersedes connection selection despite permanent tombstone`, () => {
 		const f = fixture(runtime);

--- a/packages/cli/src/runtime/connection-provider-config.ts
+++ b/packages/cli/src/runtime/connection-provider-config.ts
@@ -193,6 +193,13 @@ export function prepareConnectionProviderTransfers(
 				throw new Error("OpenClaw connection credential ownership conflict");
 			if (existing.auth !== undefined && existing.auth !== "api-key")
 				throw new Error("OpenClaw connection auth mode conflict");
+			if (
+				existing.authHeader === false ||
+				Object.keys(recordValue(existing.headers) ?? {}).some((name) =>
+					["authorization", "x-api-key", "api-key", "cookie"].includes(name.toLowerCase()),
+				)
+			)
+				throw new Error("OpenClaw connection authentication header conflict");
 			fields.auth = "api-key";
 			fields.apiKey = { source: "env", provider: "clawdi-connection", id: envName };
 			if (previous && endpoint !== baseUrl) fields.baseUrl = baseUrl;


### PR DESCRIPTION
OpenClaw connection preflight checked `apiKey` and `auth`, but allowed `authHeader: false` or separate authentication headers to disable or override the supplied credential. Handoff or key rotation could therefore succeed without ensuring that the selected API key controls authentication.

Reject these conflicts before durable transfer preparation; preserve ordinary custom headers. One focused regression covers both initial handoff and rotation, case-insensitive authentication headers, unchanged config on rejection, and retention of a non-auth header.

Validation: canonical Docker CLI runner, 4 CPU/4 GiB; CLI typecheck and 26 tests (418 assertions) passed. Biome 2.5.11 and diff checks passed. Upstream field semantics verified against [OpenClaw 2026.9.2 types](https://github.com/openclaw/openclaw/blob/3928bad9badfcb6c7d140530435e806fb8092190/src/config/types.models.ts#L218). No version bump or release in this PR.
