### PR TITLE
release(cli): publish 0.14.60 with native Composio account guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.60 updates bundled and Hosted Skill guidance to manage connector
+  accounts through Composio with explicit list, add, rename, and remove actions.
 - Resources opened from an Agent stay in that Agent, including unlinked Projects,
   newly created Projects, and resource source links. Agent and Library entry points
   use the same Project detail page and controls.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.59",
+      "version": "0.14.60",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.59",
+	"version": "0.14.60",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -138,7 +138,8 @@ to have changed:
 - Use the Clawdi connector when no direct option can perform the operation.
 
 Before a side effect, establish the exact service account and organization, Project, or tenant.
-Use `connector_account_list` when the connector is a candidate and its identity is not already clear.
+Use connection details from Composio discovery, or explicitly list accounts with
+`COMPOSIO_MANAGE_CONNECTIONS`, when the connector identity is not already clear.
 Fallback must not silently change that identity. Do not scan for credentials, start an interactive
 login, invent API details, or expose secrets. Choose the path before a side effect and advance
 only after a definite preflight failure. If a mutation's result is ambiguous, inspect it through
@@ -146,16 +147,18 @@ the same path; never repeat it through another path.
 
 ## Connector Account Management
 
-For account cleanup, call `connector_account_list` with `include_inactive: true`
-to include expired, failed, and disabled accounts. The default list contains only
-active, enabled accounts.
+Use `COMPOSIO_MANAGE_CONNECTIONS` for account management, following its live schema.
+For the multi-account schema, each `toolkits` item has `name` and `action`:
 
-For explicit account management, use `connector_account_update` with the exact
-`connection_id` and `alias` (an empty string clears it), or `connector_account_delete`
-with the exact `connection_id` to disconnect it. These tools require
-`connectors:invoke` and affect the account across all agents. Deletion removes the
-Clawdi connection; it does not revoke the provider's grant. Use only tools present
-in `tools/list`, and do not guess an account ID or automatically retry an ambiguous mutation.
+- `list`: Read account IDs, aliases, and statuses. Always specify this action for a
+  lookup: omitting `action` defaults to `add` and creates an authorization link.
+- `add`: Create a new authorization link when the user wants another connection.
+- `rename`: Set `alias` on the exact `account_id` returned by discovery.
+- `remove`: Delete the exact `account_id` selected by the user.
+
+Reuse the returned `session_id` when available. Never guess account IDs, use a
+mutation to discover accounts, or automatically retry an ambiguous mutation.
+Do not assume an empty alias clears it unless the live contract confirms that behavior.
 
 ## Connector Workflow
 
@@ -171,8 +174,9 @@ authoritative; never assume a fixed meta-tool set.
    Explicit intent authorizes the exact requested action and target, but never authorizes
    guessing a missing recipient, account, resource, or other target. Ask only for what is
    missing, and do not request redundant confirmation once the exact action is authorized.
-3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
-   exposed schema and interpret only the fields it returns. Continue on `active`. On
+3. When search reports no active connection and the user wants to connect, call
+   `COMPOSIO_MANAGE_CONNECTIONS` with explicit `action: "add"` in the multi-account schema.
+   Follow its exposed schema and interpret only the fields it returns. Continue on `active`. On
    `initiated`, present its non-empty `redirect_url` as a clickable authentication link with
    a concise explanation that authorization is pending; the link URL must be exactly that
    value. If `initiated` has no non-empty `redirect_url`, report that authorization cannot

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -108,11 +108,27 @@ to have changed:
 - Use the Clawdi connector when no direct option can perform the operation.
 
 Before a side effect, establish the exact service account and organization, Project, or tenant.
-Use `connector_account_list` when the connector is a candidate and its identity is not already clear.
+Use connection details from Composio discovery, or explicitly list accounts with
+`COMPOSIO_MANAGE_CONNECTIONS`, when the connector identity is not already clear.
 Fallback must not silently change that identity. Do not scan for credentials, start an interactive
 login, invent API details, or expose secrets. Choose the path before a side effect and advance
 only after a definite preflight failure. If a mutation's result is ambiguous, inspect it through
 the same path; never repeat it through another path.
+
+## Connector Account Management
+
+Use `COMPOSIO_MANAGE_CONNECTIONS` for account management, following its live schema.
+For the multi-account schema, each `toolkits` item has `name` and `action`:
+
+- `list`: Read account IDs, aliases, and statuses. Always specify this action for a
+  lookup: omitting `action` defaults to `add` and creates an authorization link.
+- `add`: Create a new authorization link when the user wants another connection.
+- `rename`: Set `alias` on the exact `account_id` returned by discovery.
+- `remove`: Delete the exact `account_id` selected by the user.
+
+Reuse the returned `session_id` when available. Never guess account IDs, use a
+mutation to discover accounts, or automatically retry an ambiguous mutation.
+Do not assume an empty alias clears it unless the live contract confirms that behavior.
 
 ## Connector Workflow
 
@@ -128,8 +144,9 @@ authoritative; never assume a fixed meta-tool set.
    Explicit intent authorizes the exact requested action and target, but never authorizes
    guessing a missing recipient, account, resource, or other target. Ask only for what is
    missing, and do not request redundant confirmation once the exact action is authorized.
-3. When search reports no active connection, call `COMPOSIO_MANAGE_CONNECTIONS` with its
-   exposed schema and interpret only the fields it returns. Continue on `active`. On
+3. When search reports no active connection and the user wants to connect, call
+   `COMPOSIO_MANAGE_CONNECTIONS` with explicit `action: "add"` in the multi-account schema.
+   Follow its exposed schema and interpret only the fields it returns. Continue on `active`. On
    `initiated`, present its non-empty `redirect_url` as a clickable authentication link with
    a concise explanation that authorization is pending; the link URL must be exactly that
    value. If `initiated` has no non-empty `redirect_url`, report that authorization cannot

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -44,21 +44,33 @@ describe("bundled Clawdi skill connector contract", () => {
 	const genericWorkflow = section(genericSkill, "Connector Workflow");
 	const hostedWorkflow = section(hostedSkill, "Connector Workflow");
 
-	it("keeps the connector protocol aligned across runtimes", () => {
-		expect(hostedWorkflow).toBe(genericWorkflow);
+	it("uses explicit upstream actions for current account management", () => {
+		const management = section(genericSkill, "Connector Account Management");
+		expect(section(hostedSkill, "Connector Account Management")).toBe(management);
+		expect(management).toContain("`COMPOSIO_MANAGE_CONNECTIONS`");
+		for (const action of ["list", "add", "rename", "remove"]) {
+			expect(management).toContain(`\`${action}\``);
+		}
+		expect(management).toContain("omitting `action` defaults to `add`");
+		expect(management).toContain("exact `account_id`");
+		for (const skill of [genericSkill, hostedSkill]) {
+			expect(skill).not.toMatch(/connector_account_(list|update|delete)/);
+		}
 	});
 
-	it("keeps the same guarded direct-tool selection policy", () => {
-		expect(hostedRouting).toBe(genericRouting);
-
-		const policy = genericRouting.replace(/\s+/g, " ").toLowerCase();
-		expect(policy).toMatch(/installed and authenticated official cli .* use it directly/);
-		expect(policy).toContain("service's official documentation");
-		expect(policy).toContain("trusted direct mcp already configured");
-		expect(policy).toContain("official api or sdk with a verified contract");
-		expect(policy).toContain("clawdi connector when no direct option");
-		expect(policy).toContain("must not silently change that identity");
-		expect(policy).toContain("do not automatically download, install, or start an unfamiliar mcp");
+	it("keeps the guarded direct-tool selection policy across runtimes", () => {
+		for (const routing of [genericRouting, hostedRouting]) {
+			const policy = routing.replace(/\s+/g, " ").toLowerCase();
+			expect(policy).toMatch(/installed and authenticated official cli .* use it directly/);
+			expect(policy).toContain("service's official documentation");
+			expect(policy).toContain("trusted direct mcp already configured");
+			expect(policy).toContain("official api or sdk with a verified contract");
+			expect(policy).toContain("clawdi connector when no direct option");
+			expect(policy).toContain("must not silently change that identity");
+			expect(policy).toContain(
+				"do not automatically download, install, or start an unfamiliar mcp",
+			);
+		}
 	});
 
 	it("limits only Clawdi host management in Hosted", () => {
@@ -144,7 +156,6 @@ describe("bundled Clawdi skill connector contract", () => {
 			"`memory_delete`",
 			"`memory_extract`",
 			"`session_list`",
-			"`connector_account_list`",
 		]) {
 			expect(hostedSkill).toContain(tool);
 			expect(genericSkill).toContain(tool);

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "83f2187debe672cf8a9c9bf05d07d702eb8e3a1dab52740d16a1eb38ee355e3d",
+					digest: "198f91caf3f3b1f3d72d377f61dd178b1ae1110bf080a8af845a770d63e0f052",
 				}),
 			],
 		]),


### PR DESCRIPTION
Publish CLI 0.14.60 with current and Hosted packaged Skill instructions using Composio's native list/add/rename/remove actions. Keep the existing Hosted v1 compatibility label and update its catalog digest together with the content. Existing backend connector_account_* tools remain available in this prerequisite release, allowing CLI/Skill rollout before their removal in #1434.

Validation in isolated Docker with Bun 1.4.0: lockfile regeneration, CLI typecheck, publish-manifest check, 11 Skill/catalog tests, 3 native publication tests, Biome, build and packing passed. The four Skill/catalog/test files exactly match the reviewed #1434 update. Version 0.14.60 was confirmed unpublished before preparing this commit.

Owner authorized release and rollout. Merge triggers the protected CLI publisher; verify exact npm integrity/provenance and qualify the CLI against existing production Incus image cohorts before canary/fleet rollout. No backend tool removal or tenant image change is included.
