### PR TITLE
fix(connectors): clarify account names and collapse inactive records

### DIFF
--- a/apps/web/e2e/connector-alias.pw.ts
+++ b/apps/web/e2e/connector-alias.pw.ts
@@ -45,7 +45,7 @@ async function stub(page: Page, authType = "oauth2") {
 	});
 }
 
-test("inactive accounts remain visible and can be deleted", async ({ page }) => {
+test("inactive accounts are collapsed and can be expanded and deleted", async ({ page }) => {
 	await stub(page);
 	let accounts = [{ id: "ca_expired", app_name: "gmail", alias: "work", status: "EXPIRED" }];
 	await page.route("**/v1/connectors", (route) => route.fulfill({ json: accounts }));
@@ -61,6 +61,8 @@ test("inactive accounts remain visible and can be deleted", async ({ page }) => 
 		.last();
 	await expect(rail.getByText("Needs attention")).toBeVisible();
 	await rail.getByRole("link", { name: "Gmail", exact: true }).click();
+	await expect(page.getByText("Expired", { exact: true })).toBeHidden();
+	await page.getByText("Inactive accounts (1)", { exact: true }).click();
 	await expect(page.getByText("Expired", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Connect account" })).toBeVisible();
 	await page.getByRole("button", { name: "Delete", exact: true }).click();
@@ -84,12 +86,12 @@ test("credentials connect includes alias without leaking failed response details
 	await page.getByRole("button", { name: "Connect account" }).click();
 	const dialog = page.getByRole("dialog");
 	await dialog.getByLabel("API key").fill("test-key");
-	await dialog.getByLabel("Account alias (optional)").fill("work-gmail");
+	await dialog.getByLabel("Name (optional)").fill("work-gmail");
 	await dialog.getByRole("button", { name: "Connect", exact: true }).click();
 	await expect(dialog.getByRole("alert")).toContainText("The account couldn’t be connected");
 	await expect(page.getByText("secret-upstream-error")).toHaveCount(0);
-	await dialog.getByLabel("Account alias (optional)").fill("");
-	await dialog.getByLabel("Account alias (optional)").press("Enter");
+	await dialog.getByLabel("Name (optional)").fill("");
+	await dialog.getByLabel("Name (optional)").press("Enter");
 	await expect(dialog).toBeHidden();
 	expect(requests).toEqual([
 		{ credentials: { api_key: "test-key" }, alias: "work-gmail" },
@@ -97,7 +99,7 @@ test("credentials connect includes alias without leaking failed response details
 	]);
 });
 
-test("Agent account alias edit, retry and clear retain identity", async ({ page }) => {
+test("Agent account rename, retry and clear retain identity", async ({ page }) => {
 	await page.setViewportSize({ width: 375, height: 900 });
 	await stub(page);
 	const accounts = [
@@ -111,10 +113,18 @@ test("Agent account alias edit, retry and clear retain identity", async ({ page 
 		{
 			id: "ca_personal",
 			app_name: "gmail",
-			alias: null,
+			alias: "personal@example.test",
 			account_display: "personal@example.test",
 			status: "ACTIVE",
 		},
+		{
+			id: "ca_named",
+			app_name: "gmail",
+			alias: "gmail-marvin-phala",
+			account_display: "",
+			status: "ACTIVE",
+		},
+		{ id: "ca_123456", app_name: "gmail", alias: null, account_display: "", status: "ACTIVE" },
 	];
 	await page.route("**/v1/connectors", (route) => route.fulfill({ json: accounts }));
 	let release = () => {};
@@ -130,37 +140,44 @@ test("Agent account alias edit, retry and clear retain identity", async ({ page 
 			return route.fulfill({ status: 409, json: { detail: "secret-upstream-error" } });
 		}
 		accounts[0] = { ...accounts[0], alias: body.alias || null };
-		accounts[0].account_display = body.alias || "work@example.test";
 		await route.fulfill({ json: accounts[0] });
 	});
 	await page.goto(`/agents/${agent.id}/connectors/gmail`);
+	await expect(page.getByText("personal@example.test", { exact: true })).toHaveCount(1);
+	await expect(page.getByText("personal@example.test", { exact: true })).toBeVisible();
+	await expect(page.getByText("gmail-marvin-phala", { exact: true })).toBeVisible();
+	await expect(page.getByText("Account ca_named", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("Account 123456", { exact: true })).toBeVisible();
+	await expect(page.getByText("Expired", { exact: true })).toBeHidden();
+	await page.getByText("Inactive accounts (1)", { exact: true }).click();
 	await expect(page.getByText("Expired", { exact: true })).toBeVisible();
-	await expect(page.getByText("1 active · 2 total", { exact: true })).toBeVisible();
+	await expect(page.getByText("3 active · 4 total", { exact: true })).toBeVisible();
 	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();
 	await expect(page.getByText("personal@example.test", { exact: true })).toBeVisible();
 	await expect(page.getByText("Shared across all agents")).toBeVisible();
-	await page.getByRole("button", { name: "Edit alias", exact: true }).first().click();
+	await page.getByRole("button", { name: "Rename", exact: true }).last().click();
 	const dialog = page.getByRole("dialog");
-	await dialog.getByLabel("Account alias (optional)").fill("office");
+	await expect(dialog.getByRole("heading", { name: "Rename account" })).toBeVisible();
+	await dialog.getByLabel("Name (optional)").fill("office");
 	try {
-		await dialog.getByRole("button", { name: "Save", exact: true }).click();
+		await dialog.getByRole("button", { name: "Rename", exact: true }).click();
 		await expect.poll(() => updates.length).toBe(1);
-		await expect(dialog.getByRole("button", { name: /Save/ })).toBeDisabled();
+		await expect(dialog.getByRole("button", { name: "Rename" })).toBeDisabled();
 		await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeDisabled();
 		await page.keyboard.press("Escape");
 		await expect(dialog).toBeVisible();
 	} finally {
 		release();
 	}
-	await expect(dialog.getByRole("alert")).toContainText("Couldn't save alias");
+	await expect(dialog.getByRole("alert")).toContainText("Couldn't rename account");
 	await expect(page.getByText("secret-upstream-error")).toHaveCount(0);
-	await dialog.getByRole("button", { name: "Save", exact: true }).click();
+	await dialog.getByRole("button", { name: "Rename", exact: true }).click();
 	await expect(dialog).toBeHidden();
 	await expect(page.getByText("office", { exact: true })).toBeVisible();
-	await expect(page.getByText("Account ca_work", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Edit alias", exact: true }).first().click();
-	await dialog.getByLabel("Account alias (optional)").fill("");
-	await dialog.getByRole("button", { name: "Save", exact: true }).click();
+	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Rename", exact: true }).last().click();
+	await dialog.getByLabel("Name (optional)").fill("");
+	await dialog.getByRole("button", { name: "Rename", exact: true }).click();
 	await expect(dialog).toBeHidden();
 	await expect(page.getByText("office", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1006,7 +1006,7 @@ test("connector cards complete each authentication flow in Agent scope", async (
 
 	const gmailCard = main.getByRole("link", { name: "Gmail" }).locator("..");
 	await gmailCard.getByRole("button", { name: "Connect", exact: true }).click();
-	await page.getByRole("dialog").getByLabel("Account alias (optional)").fill("work-gmail");
+	await page.getByRole("dialog").getByLabel("Name (optional)").fill("work-gmail");
 	const popupPromise = page.waitForEvent("popup");
 	await page.getByRole("dialog").getByRole("button", { name: "Continue", exact: true }).click();
 	const popup = await popupPromise;

--- a/apps/web/src/components/connectors/account-alias-dialog.tsx
+++ b/apps/web/src/components/connectors/account-alias-dialog.tsx
@@ -46,7 +46,7 @@ export function AccountAliasDialog({
 			if (mountedRef.current) onClose();
 		} catch {
 			if (mountedRef.current) {
-				setError("Couldn't save alias. Try again. If the problem persists, refresh the page.");
+				setError("Couldn't rename account. Try again. If the problem persists, refresh the page.");
 			}
 		} finally {
 			inflightRef.current = false;
@@ -62,7 +62,7 @@ export function AccountAliasDialog({
 		>
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>
-					<DialogTitle>Edit account alias</DialogTitle>
+					<DialogTitle>Rename account</DialogTitle>
 					<DialogDescription className="break-all">
 						{connection.account_display && connection.account_display !== connection.alias
 							? connection.account_display
@@ -91,7 +91,7 @@ export function AccountAliasDialog({
 							disabled={mutation.isPending || alias.trim() === (connection.alias ?? "")}
 						>
 							{mutation.isPending ? <Spinner className="size-3.5" /> : null}
-							Save
+							Rename
 						</Button>
 					</DialogFooter>
 				</form>

--- a/apps/web/src/components/connectors/account-alias-field.tsx
+++ b/apps/web/src/components/connectors/account-alias-field.tsx
@@ -14,20 +14,20 @@ export function AccountAliasField({
 	const id = useId();
 	return (
 		<div className="flex flex-col gap-1.5">
-			<Label htmlFor={id}>Account alias (optional)</Label>
+			<Label htmlFor={id}>Name (optional)</Label>
 			<Input
 				id={id}
 				value={value}
 				maxLength={256}
 				onChange={(event) => onChange(event.target.value)}
 				disabled={disabled}
-				placeholder="e.g. work-gmail"
+				placeholder="e.g. Work Gmail"
 				autoComplete="off"
 				spellCheck={false}
 				aria-describedby={`${id}-hint`}
 			/>
 			<p id={`${id}-hint`} className="text-xs text-muted-foreground">
-				Use a unique alias for each of your accounts in this connector. Leave blank for no alias.
+				Choose a unique name to help identify this account. Leave blank to use the account identity.
 			</p>
 		</div>
 	);

--- a/apps/web/src/components/connectors/connector-connect-action.tsx
+++ b/apps/web/src/components/connectors/connector-connect-action.tsx
@@ -148,7 +148,7 @@ export function ConnectorConnectAction({
 					<DialogHeader>
 						<DialogTitle>Connect {app.display_name}</DialogTitle>
 						<DialogDescription>
-							Add an optional alias, then authorize your account in a new window.
+							Add an optional name, then authorize your account in a new window.
 						</DialogDescription>
 					</DialogHeader>
 					<form

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { components } from "@clawdi/shared/api";
 import { AlertCircle, Check, Link2Off, Plug, Wrench } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { Suspense, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
@@ -158,9 +159,65 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 
 	const appConnections = connections?.filter((c) => c.app_name === name) ?? [];
 	const activeConnections = appConnections.filter(isActiveConnection);
+	const inactiveConnections = appConnections.filter((c) => !isActiveConnection(c));
 	const editingConnection = appConnections.find((connection) => connection.id === editingId);
 	const isConnected = activeConnections.length > 0;
 	const isLoading = isAppLoading || appQ.isPending;
+
+	const renderAccount = (c: components["schemas"]["ConnectorConnectionResponse"]) => (
+		<div key={c.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+			<div className="min-w-0">
+				<p className="truncate text-sm font-medium" title={c.alias || c.account_display || c.id}>
+					{c.alias || c.account_display || `Account ${c.id.slice(-6)}`}
+				</p>
+				{c.alias && c.account_display && c.account_display !== c.alias ? (
+					<p className="truncate text-xs text-muted-foreground" title={c.account_display}>
+						{c.account_display}
+					</p>
+				) : null}
+				<p className="mt-0.5 text-xs text-muted-foreground">
+					{c.is_disabled ? "Disabled" : connectionStatusLabel(c.status)}
+				</p>
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<Button
+					variant="ghost"
+					size="xs"
+					disabled={isDisconnecting(c.id)}
+					onClick={() => setEditingId(c.id)}
+				>
+					Rename
+				</Button>
+				<ConfirmAction
+					title={`${isActiveConnection(c) ? "Disconnect" : "Delete"} ${c.alias || c.account_display || "this account"}?`}
+					description={
+						<p>
+							{isActiveConnection(c)
+								? "All agents will lose access immediately. To restore access, sign in again."
+								: "This removes the saved account and its name for all agents."}
+						</p>
+					}
+					confirmLabel={isActiveConnection(c) ? "Disconnect" : "Delete"}
+					destructive
+					onConfirm={() => handleDisconnect(c.id)}
+				>
+					<Button
+						variant="ghost"
+						size="xs"
+						disabled={isDisconnecting(c.id)}
+						className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+					>
+						{isDisconnecting(c.id) ? (
+							<Spinner className="size-3.5" />
+						) : (
+							<Link2Off className="size-3.5" />
+						)}
+						{isActiveConnection(c) ? "Disconnect" : "Delete"}
+					</Button>
+				</ConfirmAction>
+			</div>
+		</div>
+	);
 
 	const displayName = app?.display_name || formatName(name);
 
@@ -218,7 +275,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 					<Plug />
 					<AlertTitle>Shared across all agents</AlertTitle>
 					<AlertDescription>
-						Connections and aliases belong to this account. Changes here affect all agents.
+						Connections and names belong to this account. Changes here affect all agents.
 					</AlertDescription>
 				</Alert>
 			) : null}
@@ -317,75 +374,15 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 						)
 					) : (
 						<div className="divide-y overflow-hidden rounded-lg border bg-card">
-							{appConnections.map((c) => (
-								<div
-									key={c.id}
-									className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
-								>
-									<div className="min-w-0">
-										<p
-											className="truncate text-sm font-medium"
-											title={c.alias || c.account_display || c.id}
-										>
-											{c.alias || c.account_display || `Account ${c.id.slice(-6)}`}
-										</p>
-										{c.alias ? (
-											<p
-												className="truncate text-xs text-muted-foreground"
-												title={
-													c.account_display && c.account_display !== c.alias
-														? c.account_display
-														: c.id
-												}
-											>
-												{c.account_display && c.account_display !== c.alias
-													? c.account_display
-													: `Account ${c.id}`}
-											</p>
-										) : null}
-										<p className="mt-0.5 text-xs text-muted-foreground">
-											{c.is_disabled ? "Disabled" : connectionStatusLabel(c.status)}
-										</p>
-									</div>
-									<div className="flex flex-wrap items-center gap-2">
-										<Button
-											variant="ghost"
-											size="xs"
-											disabled={isDisconnecting(c.id)}
-											onClick={() => setEditingId(c.id)}
-										>
-											Edit alias
-										</Button>
-										<ConfirmAction
-											title={`${isActiveConnection(c) ? "Disconnect" : "Delete"} ${c.alias || c.account_display || "this account"}?`}
-											description={
-												<p>
-													{isActiveConnection(c)
-														? "All agents will lose access immediately. To restore access, sign in again."
-														: "This removes the saved account and its alias for all agents."}
-												</p>
-											}
-											confirmLabel={isActiveConnection(c) ? "Disconnect" : "Delete"}
-											destructive
-											onConfirm={() => handleDisconnect(c.id)}
-										>
-											<Button
-												variant="ghost"
-												size="xs"
-												disabled={isDisconnecting(c.id)}
-												className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-											>
-												{isDisconnecting(c.id) ? (
-													<Spinner className="size-3.5" />
-												) : (
-													<Link2Off className="size-3.5" />
-												)}
-												{isActiveConnection(c) ? "Disconnect" : "Delete"}
-											</Button>
-										</ConfirmAction>
-									</div>
-								</div>
-							))}
+							{activeConnections.map(renderAccount)}
+							{inactiveConnections.length > 0 ? (
+								<details>
+									<summary className="cursor-pointer px-4 py-3 text-sm text-muted-foreground hover:text-foreground">
+										Inactive accounts ({inactiveConnections.length})
+									</summary>
+									<div className="divide-y border-t">{inactiveConnections.map(renderAccount)}</div>
+								</details>
+							) : null}
 						</div>
 					)}
 				</div>

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -929,18 +929,15 @@ def _serialize_connected_account_identity(account: _ConnectedAccount) -> Connect
 
 
 def _account_display_label(account: _ConnectedAccount) -> str | None:
-    """Best-effort user-facing label for a Composio connected account."""
+    """Return a known account identity, never a connection name or word ID."""
     state_value = _json_object(account.state.get("val"))
     authed_user = _json_object(state_value.get("authed_user") or state_value.get("authedUser"))
     containers = (account.data, state_value, authed_user)
-    for container in containers:
-        for key in ("connectionLabel", "connection_label", "label", "email", "username"):
+    for key in ("email", "username"):
+        for container in containers:
             value = container.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
-    for value in (account.word_id, account.alias):
-        if value is not None and value.strip():
-            return value.strip()
     return None
 
 

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -1578,6 +1578,38 @@ def test_composio_request_boundary_rejects_unknown_auth_scheme():
         )
 
 
+@pytest.mark.parametrize(
+    ("data", "state", "expected"),
+    [
+        ({"email": " work@example.test ", "label": "gmail_red-castle"}, {}, "work@example.test"),
+        ({"username": "octocat"}, {"val": {"email": "work@example.test"}}, "work@example.test"),
+        ({}, {"val": {"authed_user": {"username": " octocat "}}}, "octocat"),
+        ({}, {"val": {"authedUser": {"email": "work@example.test"}}}, "work@example.test"),
+        ({"email": " ", "username": 123}, {}, None),
+        (
+            {"connectionLabel": "gmail_red-castle", "connection_label": "Work", "label": "Work"},
+            {},
+            None,
+        ),
+    ],
+)
+def test_connected_account_display_uses_only_account_identity(data, state, expected):
+    account = composio._ConnectedAccount.model_validate(
+        {
+            "id": "ca_gmail",
+            "alias": "Work Gmail",
+            "word_id": "gmail_red-castle",
+            "created_at": "2026-09-03T00:00:00Z",
+            "status": "ACTIVE",
+            "toolkit": {"slug": "gmail"},
+            "data": data,
+            "state": state,
+        }
+    )
+
+    assert composio._account_display_label(account) == expected
+
+
 def test_connected_account_identity_exposes_only_allowlisted_labels() -> None:
     account = composio._ConnectedAccount.model_validate(
         {


### PR DESCRIPTION
Connector account rows showed a user-chosen name above Composio's generated word ID, making the identity look duplicated, while historical expired records filled the page. Use only actual email/username metadata as account_display, show a secondary identity only when distinct from the chosen name, and label the UI Name/Rename rather than alias.

Show active accounts first and put inactive/expired records in a collapsed native disclosure with a count. Expanded records retain rename and delete controls. Library and Agent views share the same renderer. API field alias is unchanged; no actual connections are deleted or renamed.

Validation in isolated Docker: four existing browser scenarios, seven focused backend display tests, frontend typecheck, Biome and Ruff passed. No new test files or dependency changes. This is independent of the pending Composio native MCP tool consolidation.
