### PR TITLE
fix(connectors): show only connected accounts in a flat list

### DIFF
--- a/apps/web/e2e/connector-alias.pw.ts
+++ b/apps/web/e2e/connector-alias.pw.ts
@@ -45,21 +45,33 @@ async function stub(page: Page, authType = "oauth2") {
 	});
 }
 
-test("expired accounts are absent from account rows and counts", async ({ page }) => {
+test("only active enabled accounts appear in flat account rows", async ({ page }) => {
 	await stub(page);
 	await page.route("**/v1/connectors", (route) =>
 		route.fulfill({
 			json: [
 				{ id: "ca_expired", app_name: "gmail", alias: "old-work", status: "EXPIRED" },
+				{ id: "ca_failed", app_name: "gmail", alias: "failed-work", status: "FAILED" },
+				{
+					id: "ca_disabled",
+					app_name: "gmail",
+					alias: "disabled-work",
+					status: "ACTIVE",
+					is_disabled: true,
+				},
 				{ id: "ca_active", app_name: "gmail", alias: "work", status: "ACTIVE" },
 			],
 		}),
 	);
 	await page.goto("/connectors/gmail");
-	await expect(page.getByText("1 active · 1 total", { exact: true })).toBeVisible();
+	await expect(page.getByText("1 connected", { exact: true })).toBeVisible();
 	await expect(page.getByText("work", { exact: true })).toBeVisible();
 	await expect(page.getByText("old-work", { exact: true })).toHaveCount(0);
-	await expect(page.getByText(/Inactive accounts/)).toHaveCount(0);
+	await expect(
+		page.getByText(/Inactive accounts|Needs attention|failed-work|disabled-work/),
+	).toHaveCount(0);
+	const row = page.getByText("work", { exact: true }).locator("../..");
+	await expect(row.locator("..")).toHaveClass("divide-y");
 });
 
 test("credentials connect includes alias without leaking failed response details", async ({
@@ -100,7 +112,7 @@ test("Agent account rename, retry and clear retain identity", async ({ page }) =
 			app_name: "gmail",
 			alias: "work",
 			account_display: "work@example.test",
-			status: "INACTIVE",
+			status: "ACTIVE",
 		},
 		{
 			id: "ca_personal",
@@ -140,14 +152,11 @@ test("Agent account rename, retry and clear retain identity", async ({ page }) =
 	await expect(page.getByText("gmail-marvin-phala", { exact: true })).toBeVisible();
 	await expect(page.getByText("Account ca_named", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Account 123456", { exact: true })).toBeVisible();
-	await expect(page.getByText("Inactive", { exact: true })).toBeHidden();
-	await page.getByText("Inactive accounts (1)", { exact: true }).click();
-	await expect(page.getByText("Inactive", { exact: true })).toBeVisible();
-	await expect(page.getByText("3 active · 4 total", { exact: true })).toBeVisible();
+	await expect(page.getByText("4 connected", { exact: true })).toBeVisible();
 	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();
 	await expect(page.getByText("personal@example.test", { exact: true })).toBeVisible();
 	await expect(page.getByText("Shared across all agents")).toBeVisible();
-	await page.getByRole("button", { name: "Rename", exact: true }).last().click();
+	await page.getByRole("button", { name: "Rename", exact: true }).first().click();
 	const dialog = page.getByRole("dialog");
 	await expect(dialog.getByRole("heading", { name: "Rename account" })).toBeVisible();
 	await dialog.getByLabel("Name (optional)").fill("office");
@@ -167,7 +176,7 @@ test("Agent account rename, retry and clear retain identity", async ({ page }) =
 	await expect(dialog).toBeHidden();
 	await expect(page.getByText("office", { exact: true })).toBeVisible();
 	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Rename", exact: true }).last().click();
+	await page.getByRole("button", { name: "Rename", exact: true }).first().click();
 	await dialog.getByLabel("Name (optional)").fill("");
 	await dialog.getByRole("button", { name: "Rename", exact: true }).click();
 	await expect(dialog).toBeHidden();

--- a/apps/web/e2e/connector-alias.pw.ts
+++ b/apps/web/e2e/connector-alias.pw.ts
@@ -45,29 +45,21 @@ async function stub(page: Page, authType = "oauth2") {
 	});
 }
 
-test("inactive accounts are collapsed and can be expanded and deleted", async ({ page }) => {
+test("expired accounts are absent from account rows and counts", async ({ page }) => {
 	await stub(page);
-	let accounts = [{ id: "ca_expired", app_name: "gmail", alias: "work", status: "EXPIRED" }];
-	await page.route("**/v1/connectors", (route) => route.fulfill({ json: accounts }));
-	await page.route("**/v1/connectors/ca_expired", async (route) => {
-		expect(route.request().method()).toBe("DELETE");
-		accounts = [];
-		await route.fulfill({ json: { status: "disconnected" } });
-	});
-	await page.goto("/connectors");
-	const rail = page
-		.locator("section")
-		.filter({ has: page.getByText("Your connections", { exact: true }) })
-		.last();
-	await expect(rail.getByText("Needs attention")).toBeVisible();
-	await rail.getByRole("link", { name: "Gmail", exact: true }).click();
-	await expect(page.getByText("Expired", { exact: true })).toBeHidden();
-	await page.getByText("Inactive accounts (1)", { exact: true }).click();
-	await expect(page.getByText("Expired", { exact: true })).toBeVisible();
-	await expect(page.getByRole("button", { name: "Connect account" })).toBeVisible();
-	await page.getByRole("button", { name: "Delete", exact: true }).click();
-	await page.getByRole("alertdialog").getByRole("button", { name: "Delete", exact: true }).click();
-	await expect(page.getByText("work", { exact: true })).toHaveCount(0);
+	await page.route("**/v1/connectors", (route) =>
+		route.fulfill({
+			json: [
+				{ id: "ca_expired", app_name: "gmail", alias: "old-work", status: "EXPIRED" },
+				{ id: "ca_active", app_name: "gmail", alias: "work", status: "ACTIVE" },
+			],
+		}),
+	);
+	await page.goto("/connectors/gmail");
+	await expect(page.getByText("1 active · 1 total", { exact: true })).toBeVisible();
+	await expect(page.getByText("work", { exact: true })).toBeVisible();
+	await expect(page.getByText("old-work", { exact: true })).toHaveCount(0);
+	await expect(page.getByText(/Inactive accounts/)).toHaveCount(0);
 });
 
 test("credentials connect includes alias without leaking failed response details", async ({
@@ -108,7 +100,7 @@ test("Agent account rename, retry and clear retain identity", async ({ page }) =
 			app_name: "gmail",
 			alias: "work",
 			account_display: "work@example.test",
-			status: "EXPIRED",
+			status: "INACTIVE",
 		},
 		{
 			id: "ca_personal",
@@ -148,9 +140,9 @@ test("Agent account rename, retry and clear retain identity", async ({ page }) =
 	await expect(page.getByText("gmail-marvin-phala", { exact: true })).toBeVisible();
 	await expect(page.getByText("Account ca_named", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Account 123456", { exact: true })).toBeVisible();
-	await expect(page.getByText("Expired", { exact: true })).toBeHidden();
+	await expect(page.getByText("Inactive", { exact: true })).toBeHidden();
 	await page.getByText("Inactive accounts (1)", { exact: true }).click();
-	await expect(page.getByText("Expired", { exact: true })).toBeVisible();
+	await expect(page.getByText("Inactive", { exact: true })).toBeVisible();
 	await expect(page.getByText("3 active · 4 total", { exact: true })).toBeVisible();
 	await expect(page.getByText("work@example.test", { exact: true })).toBeVisible();
 	await expect(page.getByText("personal@example.test", { exact: true })).toBeVisible();

--- a/apps/web/e2e/connector-loading.pw.ts
+++ b/apps/web/e2e/connector-loading.pw.ts
@@ -93,13 +93,10 @@ for (const width of [1440, 375]) {
 			const rail = page
 				.locator("section")
 				.filter({ has: page.getByText("Your connections", { exact: true }) });
-			const gamma = rail.getByRole("link", { name: "GAMMA", exact: true });
-			await expect(gamma).toBeVisible();
-			await expect(gamma.locator("..").getByLabel("Connected", { exact: true })).toHaveCount(0);
-			await expect(gamma.locator("..").getByText("Needs attention")).toBeVisible();
-			await expect(rail.getByText("4 apps", { exact: true })).toBeVisible();
+			await expect(rail.getByRole("link", { name: "GAMMA", exact: true })).toHaveCount(0);
+			await expect(rail.getByText("3 apps", { exact: true })).toBeVisible();
 			await expect(rail.getByRole("link", { name: "retired", exact: true })).toBeVisible();
-			expect(batches).toEqual([["alpha", "beta", "gamma", "retired"]]);
+			expect(batches).toEqual([["alpha", "beta", "retired"]]);
 			const alpha = rail.getByRole("link", { name: "ALPHA", exact: true }).locator("..");
 			await expect(alpha.getByText("A", { exact: true })).toBeVisible();
 			catalog.resolve();

--- a/apps/web/e2e/connector-loading.pw.ts
+++ b/apps/web/e2e/connector-loading.pw.ts
@@ -94,9 +94,9 @@ for (const width of [1440, 375]) {
 				.locator("section")
 				.filter({ has: page.getByText("Your connections", { exact: true }) });
 			await expect(rail.getByRole("link", { name: "GAMMA", exact: true })).toHaveCount(0);
-			await expect(rail.getByText("3 apps", { exact: true })).toBeVisible();
-			await expect(rail.getByRole("link", { name: "retired", exact: true })).toBeVisible();
-			expect(batches).toEqual([["alpha", "beta", "retired"]]);
+			await expect(rail.getByText("2 apps", { exact: true })).toBeVisible();
+			await expect(rail.getByRole("link", { name: "retired", exact: true })).toHaveCount(0);
+			expect(batches).toEqual([["alpha", "beta"]]);
 			const alpha = rail.getByRole("link", { name: "ALPHA", exact: true }).locator("..");
 			await expect(alpha.getByText("A", { exact: true })).toBeVisible();
 			catalog.resolve();

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -7,7 +7,6 @@ import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { connectorSearchSupportingText } from "@/components/connectors/connector-search";
 import { ENTITY_GRID_CLASS, EntityCardSkeleton, EntityRow } from "@/components/entity-card";
 import { SearchHighlightedText } from "@/components/search-highlighted-text";
-import { Badge } from "@/components/ui/badge";
 import { useOpenApi } from "@/lib/api";
 import {
 	availableAppQueryOptions,
@@ -29,14 +28,12 @@ import {
 export function ConnectorCard({
 	app,
 	isConnected = false,
-	needsAttention = false,
 	scope = LIBRARY_RESOURCE_SCOPE,
 	searchQuery,
 	actions,
 }: {
 	app: ConnectorMetadata;
 	isConnected?: boolean;
-	needsAttention?: boolean;
 	scope?: ResourceNavigationScope;
 	searchQuery?: string;
 	actions?: ReactNode;
@@ -63,8 +60,6 @@ export function ConnectorCard({
 			titleAdornment={
 				isConnected ? (
 					<Check className="size-3.5 shrink-0 text-success" aria-label="Connected" />
-				) : needsAttention ? (
-					<Badge variant="outline">Needs attention</Badge>
 				) : undefined
 			}
 			meta={

--- a/apps/web/src/components/connectors/connectors-surface.tsx
+++ b/apps/web/src/components/connectors/connectors-surface.tsx
@@ -151,11 +151,6 @@ function ConnectorsList({
 		[connected.activeConnections],
 	);
 
-	const managedNames = useMemo(
-		() => new Set(connected.connections.flatMap((c) => (c.app_name ? [c.app_name] : []))),
-		[connected.connections],
-	);
-
 	const items = pageData?.items ?? [];
 	const total = pageData?.total ?? 0;
 	const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -221,8 +216,7 @@ function ConnectorsList({
 			{showConnectedRail ? (
 				<ConnectedRail
 					apps={connected.data}
-					appNames={[...managedNames]}
-					activeNames={connectedNames}
+					appNames={[...connectedNames]}
 					isLoading={connected.isLoading}
 					error={connectedError}
 					onRetry={connected.refetch}
@@ -236,7 +230,6 @@ function ConnectorsList({
 				page={page}
 				totalPages={totalPages}
 				connectedNames={connectedNames}
-				managedNames={managedNames}
 				isLoading={isCatalogLoading}
 				error={catalogError}
 				query={debouncedQuery}
@@ -252,12 +245,11 @@ function ConnectorsList({
 }
 
 /**
- * Account management stays discoverable regardless of account status or catalog page.
+ * Connected accounts stay discoverable regardless of catalog page.
  */
 function ConnectedRail({
 	apps,
 	appNames,
-	activeNames,
 	isLoading,
 	error,
 	onRetry,
@@ -265,7 +257,6 @@ function ConnectedRail({
 }: {
 	apps: ConnectorMetadata[];
 	appNames: readonly string[];
-	activeNames: Set<string>;
 	isLoading: boolean;
 	error: Error | null;
 	onRetry: () => void;
@@ -296,13 +287,7 @@ function ConnectedRail({
 					{appNames.map((name) => {
 						const app = byName.get(name);
 						return app ? (
-							<ConnectorCard
-								key={name}
-								app={app}
-								isConnected={activeNames.has(name)}
-								scope={scope}
-								needsAttention={!activeNames.has(name)}
-							/>
+							<ConnectorCard key={name} app={app} isConnected scope={scope} />
 						) : (
 							<ConnectorCardSkeleton key={name} />
 						);
@@ -319,7 +304,6 @@ function CatalogSection({
 	page,
 	totalPages,
 	connectedNames,
-	managedNames,
 	isLoading,
 	error,
 	query,
@@ -333,7 +317,6 @@ function CatalogSection({
 	page: number;
 	totalPages: number;
 	connectedNames: Set<string>;
-	managedNames: Set<string>;
 	isLoading: boolean;
 	error: Error | null;
 	query: string;
@@ -375,11 +358,10 @@ function CatalogSection({
 							key={app.name}
 							app={app}
 							isConnected={connectedNames.has(app.name)}
-							needsAttention={managedNames.has(app.name) && !connectedNames.has(app.name)}
 							scope={scope}
 							searchQuery={query.trim() || undefined}
 							actions={
-								!managedNames.has(app.name) ? (
+								!connectedNames.has(app.name) ? (
 									<ConnectorConnectAction
 										app={app}
 										redirectHref={connectorDetailHrefForScope(scope, app.name)}

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -111,6 +111,8 @@ export function connectionsQueryOptions(api: OpenApiClient) {
 		{},
 		{
 			refetchOnWindowFocus: "always" as const,
+			select: (connections) =>
+				connections.filter((connection) => connection.status.trim().toUpperCase() !== "EXPIRED"),
 		},
 	);
 }

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -111,8 +111,7 @@ export function connectionsQueryOptions(api: OpenApiClient) {
 		{},
 		{
 			refetchOnWindowFocus: "always" as const,
-			select: (connections) =>
-				connections.filter((connection) => connection.status.trim().toUpperCase() !== "EXPIRED"),
+			select: (connections) => connections.filter(isActiveConnection),
 		},
 	);
 }

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -26,7 +26,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import type { ConnectorTool } from "@/lib/api-schemas";
 import {
-	isActiveConnection,
 	useAvailableApp,
 	useConnections,
 	useConnectorTools,
@@ -46,19 +45,6 @@ function formatName(raw: string): string {
 		.replace(/^[_-]+/, "")
 		.replace(/[_-]/g, " ")
 		.replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function connectionStatusLabel(status: string): string {
-	const normalized = status.trim().toLowerCase();
-	if (normalized === "active") return "Connected";
-	if (["pending", "initializing", "initiated", "connecting"].includes(normalized))
-		return "Awaiting authorization";
-	if (normalized === "expired") return "Expired";
-	if (normalized === "inactive") return "Inactive";
-	if (normalized === "disconnected") return "Disconnected";
-	if (normalized === "revoked") return "Access revoked";
-	if (["failed", "error"].includes(normalized)) return "Connection failed";
-	return "Status unavailable";
 }
 
 /**
@@ -158,14 +144,12 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 	const isDisconnecting = (connectionId: string) => disconnectingIds.has(connectionId);
 
 	const appConnections = connections?.filter((c) => c.app_name === name) ?? [];
-	const activeConnections = appConnections.filter(isActiveConnection);
-	const inactiveConnections = appConnections.filter((c) => !isActiveConnection(c));
 	const editingConnection = appConnections.find((connection) => connection.id === editingId);
-	const isConnected = activeConnections.length > 0;
+	const isConnected = appConnections.length > 0;
 	const isLoading = isAppLoading || appQ.isPending;
 
 	const renderAccount = (c: components["schemas"]["ConnectorConnectionResponse"]) => (
-		<div key={c.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+		<div key={c.id} className="flex flex-wrap items-center justify-between gap-3 px-3 py-2.5">
 			<div className="min-w-0">
 				<p className="truncate text-sm font-medium" title={c.alias || c.account_display || c.id}>
 					{c.alias || c.account_display || `Account ${c.id.slice(-6)}`}
@@ -175,9 +159,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 						{c.account_display}
 					</p>
 				) : null}
-				<p className="mt-0.5 text-xs text-muted-foreground">
-					{c.is_disabled ? "Disabled" : connectionStatusLabel(c.status)}
-				</p>
+				<p className="mt-0.5 text-xs text-muted-foreground">Connected</p>
 			</div>
 			<div className="flex flex-wrap items-center gap-2">
 				<Button
@@ -189,15 +171,11 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 					Rename
 				</Button>
 				<ConfirmAction
-					title={`${isActiveConnection(c) ? "Disconnect" : "Delete"} ${c.alias || c.account_display || "this account"}?`}
+					title={`Disconnect ${c.alias || c.account_display || "this account"}?`}
 					description={
-						<p>
-							{isActiveConnection(c)
-								? "All agents will lose access immediately. To restore access, sign in again."
-								: "This removes the saved account and its name for all agents."}
-						</p>
+						<p>All agents will lose access immediately. To restore access, sign in again.</p>
 					}
-					confirmLabel={isActiveConnection(c) ? "Disconnect" : "Delete"}
+					confirmLabel="Disconnect"
 					destructive
 					onConfirm={() => handleDisconnect(c.id)}
 				>
@@ -212,7 +190,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 						) : (
 							<Link2Off className="size-3.5" />
 						)}
-						{isActiveConnection(c) ? "Disconnect" : "Delete"}
+						Disconnect
 					</Button>
 				</ConfirmAction>
 			</div>
@@ -302,7 +280,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 							? "No account required"
 							: isConnectionsLoading
 								? "Checking accounts"
-								: `${activeConnections.length} active · ${appConnections.length} total`
+								: `${appConnections.length} connected`
 					}
 					description={
 						usesNoAuth
@@ -319,7 +297,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 						) : null
 					}
 				/>
-				<div className="p-4">
+				<div className={isConnected ? undefined : "p-4"}>
 					{!usesNoAuth && shouldBlockQueryError(connectionsQ.error, connectionsQ.data) ? (
 						// Without this, a failed connections fetch silently renders
 						// the "No connected accounts yet" empty state — the user
@@ -333,7 +311,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 							title="Couldn't load connections"
 						/>
 					) : !usesNoAuth && isConnectionsLoading ? (
-						<div className="rounded-lg border bg-card p-4">
+						<div className="p-4">
 							<div className="flex items-center gap-3">
 								<Skeleton className="size-9 shrink-0 rounded-lg" />
 								<div className="min-w-0 flex-1 space-y-2">
@@ -373,17 +351,7 @@ function ConnectorDetail({ name, scope }: { name: string; scope: ResourceNavigat
 							/>
 						)
 					) : (
-						<div className="divide-y overflow-hidden rounded-lg border bg-card">
-							{activeConnections.map(renderAccount)}
-							{inactiveConnections.length > 0 ? (
-								<details>
-									<summary className="cursor-pointer px-4 py-3 text-sm text-muted-foreground hover:text-foreground">
-										Inactive accounts ({inactiveConnections.length})
-									</summary>
-									<div className="divide-y border-t">{inactiveConnections.map(renderAccount)}</div>
-								</details>
-							) : null}
-						</div>
+						<div className="divide-y">{appConnections.map(renderAccount)}</div>
 					)}
 				</div>
 			</DashboardSection>

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -135,9 +135,8 @@ through that system instead of adding another hardcoded string layer.
 ## Connector account management
 
 Connector management uses the same account-wide API in the library and Agent
-detail views. Hide expired accounts from UI rows and counts without deleting them.
-Other non-active accounts remain manageable; only active, enabled accounts count
-as connected. Display aliases alongside provider identity
+detail views. Show only active, enabled accounts in rows, counts, and connected-app
+lists without deleting other provider records. Accounts use flat divided rows. Display aliases alongside provider identity
 or a connection ID, and allow an empty alias to clear it. Alias input is bounded
 to 256 characters by Clawdi, not by a documented Composio format restriction.
 

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -135,8 +135,9 @@ through that system instead of adding another hardcoded string layer.
 ## Connector account management
 
 Connector management uses the same account-wide API in the library and Agent
-detail views. Keep non-active accounts discoverable for management; only active,
-enabled accounts count as connected. Display aliases alongside provider identity
+detail views. Hide expired accounts from UI rows and counts without deleting them.
+Other non-active accounts remain manageable; only active, enabled accounts count
+as connected. Display aliases alongside provider identity
 or a connection ID, and allow an empty alias to clear it. Alias input is bounded
 to 256 characters by Clawdi, not by a documented Composio format restriction.
 


### PR DESCRIPTION
Show only ACTIVE, enabled connector accounts across the dashboard. Filter at the shared query boundary so rows, counts and connected-app metadata requests agree. Remove Needs attention badges and inactive-account sections; no underlying connections are deleted.

Render Accounts as flat divided rows matching Available tools, removing the nested bordered card and normal-list outer padding. Retain Rename and Disconnect actions. Remove the unused status helpers and managed/active duplicate name sets.

Validation: isolated Docker frontend typecheck and Biome passed; five existing connector browser tests passed, covering mixed statuses/disabled accounts, counts, flat rows, Agent rename, credentials, and desktop/mobile loading. The final spacing-only adjustment removes outer list padding. No backend or API change.
