### PR TITLE
perf(sync): reuse SSE revocation waiter and close owned streams

### DIFF
--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -88,15 +88,27 @@ OAUTH_ACCESS_EXPIRY_SKEW = timedelta(seconds=1)
 
 
 class _SyncStreamingResponse(StreamingResponse):
-    def __init__(self, content: AsyncGenerator[bytes, None], *, headers: dict[str, str]) -> None:
+    def __init__(
+        self,
+        content: AsyncGenerator[bytes, None],
+        *,
+        cleanup: Callable[[], Awaitable[None]],
+        headers: dict[str, str],
+    ) -> None:
         super().__init__(content, media_type="text/event-stream", headers=headers)
         self._content = content
+        self._cleanup = cleanup
 
     async def stream_response(self, send: Send) -> None:
         # Starlette does not close an iterator suspended at yield when send
         # fails or is cancelled by disconnect/backpressure.
-        async with aclosing(self._content):
-            await super().stream_response(send)
+        try:
+            async with aclosing(self._content):
+                await super().stream_response(send)
+        finally:
+            # Header send can fail before iteration: closing an unstarted
+            # generator does not run its finally block.
+            await self._cleanup()
 
 
 def _oauth_cli_access_expired(
@@ -418,6 +430,28 @@ async def events(
                 )
                 subscriber.visible_project_ids = fresh
 
+    cleaned_up = False
+
+    async def cleanup() -> None:
+        nonlocal cleaned_up
+        # The generator closes first; response cleanup also covers a stream
+        # that never started. A started body_iterator also owns direct aclose().
+        if cleaned_up:
+            return
+        cleaned_up = True
+        try:
+            sync_events.sync_subscriptions_changed.unsubscribe(refresh_key, refresh_requested)
+        finally:
+            try:
+                sync_events.unsubscribe(user_id, queue)
+                log.info(
+                    "sync events: unsubscribed user=%s remaining=%s",
+                    user_id,
+                    sync_events.connection_count(user_id),
+                )
+            finally:
+                await _release_subscription_lease_safely(lease_id)
+
     async def gen() -> AsyncGenerator[bytes, None]:
         refresh_task = asyncio.create_task(refresh_visibility())
         expiry_task = asyncio.create_task(_close_on_oauth_access_expiry(auth, revoked))
@@ -430,21 +464,7 @@ async def events(
             try:
                 await _cancel_and_wait(refresh_task, expiry_task, lease_task)
             finally:
-                try:
-                    sync_events.sync_subscriptions_changed.unsubscribe(
-                        refresh_key,
-                        refresh_requested,
-                    )
-                finally:
-                    try:
-                        sync_events.unsubscribe(user_id, queue)
-                        log.info(
-                            "sync events: unsubscribed user=%s remaining=%s",
-                            user_id,
-                            sync_events.connection_count(user_id),
-                        )
-                    finally:
-                        await _release_subscription_lease_safely(lease_id)
+                await cleanup()
 
     # `text/event-stream` is the SSE content type. `X-Accel-Buffering:
     # no` disables nginx response buffering on the off chance an
@@ -452,6 +472,7 @@ async def events(
     # nginx's buffer and the daemon never sees the heartbeat.
     return _SyncStreamingResponse(
         gen(),
+        cleanup=cleanup,
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -37,7 +37,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import aclosing
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -45,6 +46,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.types import Send
 
 from app.core.auth import AuthContext, require_scope_short_session
 from app.core.database import async_session_factory, finish_cleanup
@@ -83,6 +85,18 @@ PER_BOUND_KEY_CONNECTION_CAP = 3
 HEARTBEAT_INTERVAL_S = 25.0
 SUBSCRIPTION_LEASE_TTL = timedelta(seconds=90)
 OAUTH_ACCESS_EXPIRY_SKEW = timedelta(seconds=1)
+
+
+class _SyncStreamingResponse(StreamingResponse):
+    def __init__(self, content: AsyncGenerator[bytes, None], *, headers: dict[str, str]) -> None:
+        super().__init__(content, media_type="text/event-stream", headers=headers)
+        self._content = content
+
+    async def stream_response(self, send: Send) -> None:
+        # Starlette does not close an iterator suspended at yield when send
+        # fails or is cancelled by disconnect/backpressure.
+        async with aclosing(self._content):
+            await super().stream_response(send)
 
 
 def _oauth_cli_access_expired(
@@ -178,7 +192,7 @@ async def _stream(
     queue: sync_events.SyncEventQueue,
     request: Request,
     revoked: asyncio.Event,
-) -> AsyncIterator[bytes]:
+) -> AsyncGenerator[bytes, None]:
     """SSE event source. Drains `queue` (events from
     `bump_skills_revision`, already broker-filtered to the
     subscriber's visible projects) and emits heartbeats so proxies
@@ -187,46 +201,34 @@ async def _stream(
     revocation noticed by the subscription refresher), or whichever
     happens first."""
     yield b": connected\n\n"
-    while True:
-        if await request.is_disconnected() or revoked.is_set():
-            return
-        event_task = asyncio.create_task(queue.get())
-        revoked_task = asyncio.create_task(revoked.wait())
-        child_tasks = (event_task, revoked_task)
-        try:
+    revoked_task = asyncio.create_task(revoked.wait())
+    event_task = None
+    try:
+        while True:
+            if await request.is_disconnected() or revoked.is_set():
+                return
+            event_task = asyncio.create_task(queue.get())
             done, _pending = await asyncio.wait(
-                child_tasks,
+                (event_task, revoked_task),
                 timeout=HEARTBEAT_INTERVAL_S,
                 return_when=asyncio.FIRST_COMPLETED,
             )
-        finally:
-            # A client disconnect cancels the async generator while it may be
-            # parked inside ``asyncio.wait``. Cleanup after a normal wait is
-            # therefore insufficient: Queue.get/Event.wait tasks survive and
-            # asyncio later reports "Task was destroyed but it is pending".
-            # Own both child tasks on every exit, including generator
-            # cancellation and server shutdown.
-            await _cancel_and_wait(*child_tasks)
-        if revoked_task in done or revoked.is_set():
-            return
-        if event_task not in done:
-            # No event in 25s; emit heartbeat comment and loop.
-            yield b": ping\n\n"
-            continue
-        event_payload = event_task.result()
-        # Re-check revocation BEFORE emitting. The refresher can
-        # set `revoked` while `wait_for` is parked on `queue.get()`;
-        # an event landing in the queue right after revocation
-        # would otherwise be emitted (one final `skill_changed`
-        # / `skill_deleted` slipping past). Skill events wake an
-        # Agent-authoritative local rescan, so this is
-        # not cosmetic — without the re-check, a freshly-revoked token could
-        # still trigger client work after its authorization was revoked.
-        if revoked.is_set():
-            return
-        # Real event: write SSE record.
-        payload = json.dumps(event_payload)
-        yield f"event: {event_payload['type']}\ndata: {payload}\n\n".encode()
+            # Revocation wins even when an event completes in the same turn.
+            if revoked_task in done or revoked.is_set():
+                return
+            if event_task not in done:
+                await _cancel_and_wait(event_task)
+                yield b": ping\n\n"
+                continue
+            # The event task has finished; only pending or exiting work needs
+            # shielded collection. Keep the revocation waiter across records.
+            event_payload = event_task.result()
+            payload = json.dumps(event_payload)
+            yield f"event: {event_payload['type']}\ndata: {payload}\n\n".encode()
+    finally:
+        # Own both waiters through disconnect, cancellation, and generator close.
+        child_tasks = (revoked_task,) if event_task is None else (event_task, revoked_task)
+        await _cancel_and_wait(*child_tasks)
 
 
 # Notifications drive normal refreshes. This slow poll only catches a lost
@@ -416,13 +418,14 @@ async def events(
                 )
                 subscriber.visible_project_ids = fresh
 
-    async def gen() -> AsyncIterator[bytes]:
+    async def gen() -> AsyncGenerator[bytes, None]:
         refresh_task = asyncio.create_task(refresh_visibility())
         expiry_task = asyncio.create_task(_close_on_oauth_access_expiry(auth, revoked))
         lease_task = asyncio.create_task(_refresh_subscription_lease(lease_id, revoked))
         try:
-            async for chunk in _stream(queue, request, revoked):
-                yield chunk
+            async with aclosing(_stream(queue, request, revoked)) as stream:
+                async for chunk in stream:
+                    yield chunk
         finally:
             try:
                 await _cancel_and_wait(refresh_task, expiry_task, lease_task)
@@ -447,9 +450,8 @@ async def events(
     # no` disables nginx response buffering on the off chance an
     # operator runs us behind one — without it the bytes pile up in
     # nginx's buffer and the daemon never sees the heartbeat.
-    return StreamingResponse(
+    return _SyncStreamingResponse(
         gen(),
-        media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -438,6 +438,94 @@ async def test_stream_cancellation_awaits_internal_wait_tasks(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("heartbeat", [False, True])
+@pytest.mark.parametrize("close_mode", ["aclose", "send_failure", "backpressure"])
+async def test_response_close_collects_stream_suspended_at_yield(
+    db_session: AsyncSession,
+    seed_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+    heartbeat: bool,
+    close_mode: str,
+):
+    """Closing the response must close its inner stream without relying on GC."""
+    from app.routes import sync as sync_route
+
+    original_stream = sync_route._stream
+    streams = []
+    queues = []
+
+    def retain_stream(queue, request, revoked):
+        stream = original_stream(queue, request, revoked)
+        streams.append(stream)
+        queues.append(queue)
+        return stream
+
+    monkeypatch.setattr(sync_route, "_stream", retain_stream)
+    if heartbeat:
+        monkeypatch.setattr(sync_route, "HEARTBEAT_INTERVAL_S", 0.01)
+    await db_session.commit()
+    response = await sync_route.events(_connected_request(), AuthContext(user=seed_user), None)
+    iterator = response.body_iterator
+    tasks_before = asyncio.all_tasks()
+    sending = asyncio.Event()
+    disconnected = asyncio.Event()
+    request_task = None
+
+    async def send(message):
+        if message.get("body"):
+            sending.set()
+            if close_mode == "send_failure":
+                raise OSError("peer send failed")
+            await asyncio.Event().wait()
+
+    async def receive():
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    try:
+        assert await iterator.__anext__() == b": connected\n\n"
+        if heartbeat:
+            assert await asyncio.wait_for(iterator.__anext__(), 1) == b": ping\n\n"
+        else:
+            for revision in (1, 2):
+                queues[0].put_nowait({"type": "skill_changed", "skills_revision": revision})
+            for revision in (1, 2):
+                chunk = await asyncio.wait_for(iterator.__anext__(), 1)
+                assert f'"skills_revision": {revision}'.encode() in chunk
+            assert queues[0].empty()
+        if close_mode != "aclose":
+            if not heartbeat:
+                queues[0].put_nowait({"type": "skill_changed", "skills_revision": 3})
+            request_task = asyncio.create_task(
+                response({"type": "http", "asgi": {"spec_version": "2.3"}}, receive, send)
+            )
+            await asyncio.wait_for(sending.wait(), 1)
+            if close_mode == "send_failure":
+                with pytest.raises(OSError, match="peer send failed"):
+                    await asyncio.wait_for(request_task, 2)
+            else:
+                disconnected.set()
+                await asyncio.wait_for(request_task, 2)
+        else:
+            await iterator.aclose()
+        assert streams[0].ag_frame is None
+        assert asyncio.all_tasks() <= tasks_before
+    finally:
+        if request_task is not None and not request_task.done():
+            request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+        await iterator.aclose()
+
+    assert sync_events.connection_count(seed_user.id) == 0
+    assert (
+        await db_session.scalar(
+            select(SyncSubscriptionLease.id).where(SyncSubscriptionLease.user_id == seed_user.id)
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_stream_cancellation_waits_for_lease_release_transaction(
     db_session: AsyncSession,
     seed_user: User,
@@ -585,15 +673,8 @@ async def test_cancel_and_wait_preserves_failure_when_parent_is_cancelled(caplog
 
 
 @pytest.mark.asyncio
-async def test_stream_drops_event_queued_before_revoke():
-    """Race: event lands in the queue right before / during the
-    25s `wait_for(queue.get())`. The refresher fires `revoked`
-    while wait_for is parked. wait_for resolves the event without
-    re-checking the flag — pre-fix the daemon got one extra
-    `skill_changed` / `skill_deleted` past revocation. Skill events now wake
-    an Agent-authoritative local rescan rather than mutating local files, but
-    work must still stop at revocation. Verify the second `__anext__` returns
-    (closes the generator) instead of yielding the event."""
+async def test_stream_drops_event_queued_before_revoke(monkeypatch: pytest.MonkeyPatch):
+    """An event and revocation arriving in the same turn must close a parked stream."""
     from app.routes.sync import _stream
 
     queue: asyncio.Queue = asyncio.Queue()
@@ -604,20 +685,33 @@ async def test_stream_drops_event_queued_before_revoke():
     first = await gen.__anext__()
     assert first == b": connected\n\n"
 
-    # Queue an event AND fire revocation in the same tick. The
-    # generator's next iteration sees the revoked flag (via the
-    # post-get re-check) and returns instead of emitting.
-    await queue.put(
-        {
-            "type": "skill_deleted",
-            "skill_key": "x",
-            "project_id": "00000000-0000-0000-0000-000000000099",
-            "skills_revision": 1,
-        }
-    )
-    revoked.set()
-    with pytest.raises(StopAsyncIteration):
-        await gen.__anext__()
+    waiting = asyncio.Event()
+    original_get = queue.get
+
+    async def get():
+        waiting.set()
+        return await original_get()
+
+    monkeypatch.setattr(queue, "get", get)
+    next_chunk = asyncio.create_task(gen.__anext__())
+    try:
+        await asyncio.wait_for(waiting.wait(), 1)
+        queue.put_nowait(
+            {
+                "type": "skill_deleted",
+                "skill_key": "x",
+                "project_id": "00000000-0000-0000-0000-000000000099",
+                "skills_revision": 1,
+            }
+        )
+        revoked.set()
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(next_chunk, 1)
+    finally:
+        if not next_chunk.done():
+            next_chunk.cancel()
+        await asyncio.gather(next_chunk, return_exceptions=True)
+        await gen.aclose()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -1526,3 +1526,161 @@ async def test_real_sse_disconnect_drains_database_refresh(
         invalidation_errors.clear()
         await refresh_engine.dispose()
     assert not [record for record in caplog.records if record.name.startswith("sqlalchemy.pool")]
+
+
+@pytest.mark.parametrize(
+    "ending", ["header_error", "header_cancel", "header_peer", "body_error", "exhausted"]
+)
+async def test_real_sse_response_releases_admission_once(
+    db_session: AsyncSession,
+    seed_user: User,
+    ending: str,
+):
+    """Admission survives header backpressure and ends with the ASGI request."""
+    from app.main import app
+    from app.services.api_key import mint_api_key
+
+    minted = await mint_api_key(db_session, user_id=seed_user.id, label="sse-headers")
+    await db_session.commit()
+    headers_started = asyncio.Event()
+    disconnected = asyncio.Event()
+    release_started = asyncio.Event()
+    releases = []
+    bodies = []
+    first_request = True
+    tasks_before = asyncio.all_tasks()
+    refresh_key = str(seed_user.id)
+
+    async def receive():
+        nonlocal first_request
+        if first_request:
+            first_request = False
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await disconnected.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            assert message["status"] == 200
+            headers_started.set()
+            if ending == "header_error":
+                raise OSError("header send failed")
+            if ending in {"header_cancel", "header_peer"}:
+                await asyncio.Event().wait()
+        elif message["type"] == "http.response.body":
+            bodies.append(message["body"])
+            if ending == "body_error":
+                raise OSError("body send failed")
+            if message["body"] == b": connected\n\n":
+                await db_session.execute(
+                    update(ApiKey)
+                    .where(ApiKey.id == minted.api_key.id)
+                    .values(revoked_at=datetime.now(UTC))
+                )
+                await db_session.commit()
+                sync_events.sync_subscriptions_changed.signal(refresh_key)
+
+    def capture_release(_connection, _cursor, statement, *_args):
+        if statement.lstrip().startswith(
+            "DELETE FROM sync_subscription_leases WHERE sync_subscription_leases.id ="
+        ):
+            releases.append(statement)
+            release_started.set()
+
+    event.listen(app_engine.sync_engine, "before_cursor_execute", capture_release)
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/v1/sync/events",
+        "raw_path": b"/v1/sync/events",
+        "query_string": b"",
+        "headers": [(b"authorization", f"Bearer {minted.raw_key}".encode())],
+        "client": ("127.0.0.1", 1),
+        "server": ("test", 80),
+    }
+    request_task = asyncio.create_task(app(scope, receive, send))
+    try:
+        async with asyncio.timeout(8):
+            await headers_started.wait()
+            if ending in {"header_cancel", "header_peer"}:
+                assert sync_events.connection_count(seed_user.id) == 1
+                assert len(sync_events.sync_subscriptions_changed._waiters[refresh_key]) == 1
+                # Hold the real lease DELETE across repeated request cancellation.
+                await db_session.execute(
+                    select(SyncSubscriptionLease.id)
+                    .where(SyncSubscriptionLease.user_id == seed_user.id)
+                    .with_for_update()
+                )
+                if ending == "header_peer":
+                    disconnected.set()
+                else:
+                    assert request_task.cancel("header-backpressure")
+                await release_started.wait()
+                if ending == "header_cancel":
+                    assert request_task.cancel("header-backpressure-again")
+                await asyncio.sleep(0)
+                assert not request_task.done()
+                await db_session.commit()
+            if ending.endswith("error"):
+                with pytest.raises(OSError, match="send failed"):
+                    await request_task
+            elif ending == "header_cancel":
+                with pytest.raises(asyncio.CancelledError):
+                    await request_task
+            else:
+                await request_task
+            assert sync_events.connection_count(seed_user.id) == 0
+            assert refresh_key not in sync_events.sync_subscriptions_changed._waiters
+            assert len(releases) == 1
+            assert not await db_session.scalar(
+                select(SyncSubscriptionLease.id).where(
+                    SyncSubscriptionLease.user_id == seed_user.id
+                )
+            )
+            assert asyncio.all_tasks() <= tasks_before
+            if ending.startswith("header"):
+                assert bodies == []
+            elif ending == "exhausted":
+                assert bodies[-1] == b""
+    finally:
+        await db_session.rollback()
+        disconnected.set()
+        if not request_task.done():
+            request_task.cancel()
+        await asyncio.gather(request_task, return_exceptions=True)
+        event.remove(app_engine.sync_engine, "before_cursor_execute", capture_release)
+
+
+async def test_real_sse_admission_rejects_before_success_headers(
+    db_session: AsyncSession,
+    seed_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import app
+    from app.routes import sync as sync_route
+    from app.services.api_key import mint_api_key
+
+    monkeypatch.setattr(sync_route, "PER_USER_CONNECTION_CAP", 1)
+    _, _, iterator = await _open_api_key_stream(db_session, seed_user)
+    try:
+        minted = await mint_api_key(db_session, user_id=seed_user.id, label="sse-over-cap")
+        await db_session.commit()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/v1/sync/events", headers={"Authorization": f"Bearer {minted.raw_key}"}
+            )
+        assert response.status_code == 429
+        assert response.headers["Retry-After"] == "30"
+        assert sync_events.connection_count(seed_user.id) == 1
+        assert len(sync_events.sync_subscriptions_changed._waiters[str(seed_user.id)]) == 1
+        leases = await db_session.scalars(
+            select(SyncSubscriptionLease.id).where(SyncSubscriptionLease.user_id == seed_user.id)
+        )
+        assert len(leases.all()) == 1
+    finally:
+        await iterator.aclose()

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -649,6 +649,15 @@ during sends, and `gen()` owns `_stream()` across its yields. Starlette 1.6.0's
 cancelled while blocked. The route-local response subclass wraps that method
 without changing Starlette's ASGI-version or disconnect handling.
 
+The response and a started generator share once-only admission cleanup. If
+header sending fails before the generator is first iterated, its `aclose()`
+cannot execute a `finally` block; response cleanup still removes the broker and
+refresh registrations and releases the database lease through owned cleanup.
+The real ASGI regression verifies header failure, cancellation during header
+backpressure, peer disconnect, body failure and exhaustion, with exactly one
+lease release and no remaining registrations or child tasks. Admission still
+rejects with HTTP 429 before successful SSE headers are sent.
+
 MCP's outbound transport also has AnyIO scopes, but its transport bodies do not
 execute Clawdi database queries. `tools/list` loads in a separate cached task;
 `tools/call` exits its transport context before request-dependency cleanup.

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -640,11 +640,103 @@ releases the blocking table lock; the lease is deleted, the local slot is
 returned, and no request-owned tasks survive. This reproduces a real route
 mechanism, not the proven causal ordering of a historical production incident.
 
+The revocation waiter lives for the stream lifetime; completed event tasks do
+not need shielded collection on every record. Pending event waits still use
+owned cleanup on heartbeat timeout, and both waiters are collected on exit.
+Two explicit `aclosing` boundaries are necessary: the SSE response owns `gen()`
+during sends, and `gen()` owns `_stream()` across its yields. Starlette 1.6.0's
+`stream_response()` does not close an iterator when `send()` fails or is
+cancelled while blocked. The route-local response subclass wraps that method
+without changing Starlette's ASGI-version or disconnect handling.
+
 MCP's outbound transport also has AnyIO scopes, but its transport bodies do not
 execute Clawdi database queries. `tools/list` loads in a separate cached task;
 `tools/call` exits its transport context before request-dependency cleanup.
 The MCP dependency session is lazy and its close already has owned cleanup.
 No MCP-specific cancellation change is justified by the inspected lifecycle.
+
+### SSE scheduling microbenchmark
+
+Against merged baseline `ccf7be8d1ab59645d8964859d6cc9ef569b08ca9`, the
+imported final `_stream` was measured in Docker (2 CPU limit, 3 GiB), Python
+3.14.7, AnyIO 4.14.2, Starlette 1.6.0 and uvloop 0.22.1. Seven alternating
+10,000-record batches followed a 1,000-record warmup. Each record was queued
+immediately before consumption; the request receive callable blocked. CPU
+uses `process_time_ns`, with tracing disabled; allocation instrumentation ran
+separately. Each batch includes explicit generator close.
+
+| Per-stream measurement | Baseline | Final |
+| --- | ---: | ---: |
+| asyncio median CPU, microseconds/record | 134.16 | 82.56 |
+| uvloop median CPU, microseconds/record | 85.95 | 48.97 |
+| Tasks created per 10,000 records, either loop | 30,000 | 10,002 |
+| asyncio traced peak bytes | 17,390 | 15,710 |
+| uvloop traced peak bytes | 16,883 | 15,398 |
+
+These are scheduling/serialization microbenchmarks, **not end-to-end throughput**
+or total allocation counts. They exclude database queries, sockets and send
+backpressure. Idle 25-second heartbeats offer negligible CPU savings.
+
+To reproduce the CPU comparison, export the baseline with
+`git show ccf7be8d1ab59645d8964859d6cc9ef569b08ca9:backend/app/routes/sync.py`
+and mount it read-only as `/baseline-sync.py` in a disposable Docker backend
+environment with the locked dependencies. Run from its `backend/` directory:
+
+```bash
+uv run python - <<'PY'
+from __future__ import annotations
+
+import ast
+import asyncio
+import statistics
+import time
+from pathlib import Path
+import uvloop
+from starlette.requests import Request
+from app.routes import sync
+
+tree = ast.parse(Path('/baseline-sync.py').read_text())
+node = next(n for n in tree.body if isinstance(n, ast.AsyncFunctionDef) and n.name == '_stream')
+namespace = dict(vars(sync))
+exec(compile(ast.Module(body=[node], type_ignores=[]), '<baseline>', 'exec'), namespace)
+variants = {'baseline': namespace['_stream'], 'final': sync._stream}
+
+async def batch(fn, count):
+    async def receive():
+        await asyncio.Event().wait()
+    queue = asyncio.Queue(maxsize=64)
+    stream = fn(queue, Request({'type': 'http'}, receive), asyncio.Event())
+    await anext(stream)
+    try:
+        for _ in range(count):
+            queue.put_nowait({'type': 'runtime_manifest_changed', 'environment_id': 'test'})
+            await anext(stream)
+    finally:
+        await stream.aclose()
+
+async def measure():
+    samples = {name: [] for name in variants}
+    for fn in variants.values():
+        await batch(fn, 1000)
+    for repetition in range(7):
+        order = list(variants) if repetition % 2 == 0 else list(reversed(variants))
+        for name in order:
+            started = time.process_time_ns()
+            await batch(variants[name], 10000)
+            samples[name].append((time.process_time_ns() - started) / 10000 / 1000)
+    print(type(asyncio.get_running_loop()).__name__,
+          {name: statistics.median(values) for name, values in samples.items()})
+
+for factory in (asyncio.new_event_loop, uvloop.new_event_loop):
+    with asyncio.Runner(loop_factory=factory) as runner:
+        runner.run(measure())
+PY
+```
+
+Done: both event loops print baseline/final median CPU microseconds per record.
+Absolute times depend on the host. To reproduce task counts, count creations
+with a loop task factory during a separate batch; use `tracemalloc` in that
+separate pass for peak live traced memory rather than timing traced execution.
 
 ### Remaining stalled-network requirement
 


### PR DESCRIPTION
Released: included in production Cloud ecc6441b2b32b592e7888bca150e7855534cb34b via https://github.com/Clawdi-AI/clawdi/actions/runs/34359326746. Final postflight confirmed three exact-version healthy roles, health/readiness 200, zero sampled pool-timeout metric and new-error markers, active SSE leases back to 589 with 123 historical expired rows after reconnect. This is bounded observation, not a production throughput claim.

SSE recreated a revocation waiter and a cleanup task for every record, while request cancellation could leave generator-owned cleanup vulnerable at send boundaries. Reuse one revocation waiter for the stream and consume completed event tasks directly; pending waits and exits retain owned cancellation-safe cleanup.

The response explicitly closes the outer generator, which closes the inner event stream. Response and started generator share once-only admission cleanup: if header sending fails or is cancelled before the first iteration, broker/refresh registrations and the pre-acquired database lease are still released. Admission remains before successful headers so connection-cap rejection is still HTTP429. Normal close, body failure and exhaustion release once; active child cleanup finishes before admission release.

Validation of the header follow-up: Python3.14.7 / Starlette1.6.0 / real app + APIkey + PostgreSQL18.4, 68 passed and 1 pre-existing strict upstream xfail, including four ASGI database cancellation regressions, header error/cancellation/peer disconnect, normal exhaustion and429. Lease release was blocked during repeated cancellation to verify cleanup ownership and exactly-one release. Ruff, strict typing, compilation and lock checks passed. Root reviewed the final runtime/test diff. Final head10193767cd033d0a8babc473133a62f0cdb7420b includes current main23e08c53; fresh CI passed with 2740 passed, 12 skipped and 1 pre-existing upstream xfail; all other applicable checks passed (https://github.com/Clawdi-AI/clawdi/actions/runs/34348008626). Combined qualification with auth aaa3e231 and Composio d7e401a1 passed on Python3.14.7: 170 focused tests and 2774 full-backend tests (12 skipped, 1 existing xfail); actual uvloop.Loop cleanup/admission lane: 10 passed. Generated API, configured production/strict typing, Ruff, format and compilation passed. Combined SHA 98a14333439fd3fb8e42f392bfb44d581e58784d; no remaining runtime blocker from the header cleanup defect.

Original scheduling microbenchmark versus ccf7be8: CPU median134.16→82.56 μs/record on asyncio and85.95→48.97 on uvloop; task creations30,000→10,002 per10,000 records. This excludes DB/network/backpressure and is not an end-to-end production throughput claim. Idle heartbeat savings are negligible; reproduction is documented.

No schema/dependency/API/CLI publication changes. finish_cleanup and the driver remain unchanged. Existing asyncpg stalled-network cleanup remains a strict xfail. Header backpressure retains admission until failure/cancellation; protected cleanup may outlast a nominal cancellation deadline. A response that is never executed is not asynchronously cleaned by GC. No merge or production deployment has been performed.
