### PR TITLE
perf(auth): persist issuer bootstrap and reuse transaction authority

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -839,14 +839,25 @@ async def auth_via_verified_clerk_jwt(
     # clobbered by Clerk on subsequent logins.
     new_avatar = picture
     if new_avatar and user.avatar_url != new_avatar:
+        avatar_user_id = user.id
         user.avatar_url = new_avatar
         try:
             await db.commit()
         except SQLAlchemyError:
-            # Non-fatal — auth still proceeds with the in-memory user.
-            # Narrow to SQLAlchemyError so coding bugs surface instead
-            # of being silently swallowed.
+            # Rollback expires ORM state even with expire_on_commit=False.
+            # Reload the persisted identity before any synchronous attribute
+            # access; a concurrent identity change must fail closed.
             await db.rollback()
+            user = await db.get(User, avatar_user_id, populate_existing=True)
+            if (
+                user is None
+                or user.principal_kind != PRINCIPAL_KIND_CLERK
+                or user.clerk_id != clerk_id
+                or (issuer and user.clerk_issuer != issuer)
+            ):
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED, "Invalid account identity"
+                ) from None
 
     oauth_cli = oauth_setting is not None
     oauth_access_expires_at: datetime | None = None

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from sqlalchemy import and_, bindparam, or_, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import get_history
 
 from app.core.config import canonical_clerk_issuer, settings
 from app.core.database import get_session
@@ -627,8 +628,13 @@ async def auth_via_verified_clerk_jwt(
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     except PrincipalIdentityConflictError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid account identity") from None
+    # The user-authority read can autoflush the legacy issuer assignment.
+    # Capture its persistence obligation before that clears attribute history.
+    issuer_binding_pending = user is not None and get_history(user, "clerk_issuer").has_changes()
     if user is not None:
         await _assert_active_user_or_401(db, user.id)
+    authorized_user_id = user.id if user is not None else None
+    authorized_transaction = db.get_nested_transaction() or db.get_transaction()
 
     raw_email = payload.get("email") or payload.get("email_address")
     email = raw_email if isinstance(raw_email, str) and raw_email else None
@@ -648,7 +654,10 @@ async def auth_via_verified_clerk_jwt(
     # NEVER overwrite an existing email/name because that would let
     # a Clerk-side display-name change silently rewrite our row
     # (Clerk is the source of truth for identity, not display).
-    if user is not None and ((user.email is None and email) or (user.name is None and name)):
+    needs_profile_backfill = user is not None and (
+        (user.email is None and email is not None) or (user.name is None and name is not None)
+    )
+    if user is not None and (issuer_binding_pending or needs_profile_backfill):
         if user.email is None and email:
             user.email = email
         if user.name is None and name:
@@ -662,19 +671,33 @@ async def auth_via_verified_clerk_jwt(
             # and is the one whose log line should claim the backfill.
             # Logging here both ways would lie about who wrote what
             # and corrupt audit / debugging trails.
-            logger.info("user_backfill clerk_id=%s user_id=%s", clerk_id, user.id)
+            if needs_profile_backfill:
+                logger.info("user_backfill clerk_id=%s user_id=%s", clerk_id, user.id)
         except IntegrityError:
-            # Concurrent backfill — another request won. Re-read the
-            # row (which now carries the winner's values) instead of
-            # 500-ing the user out of their session.
+            # Accept only a compatible persisted winner. Retrying the binding
+            # here could leave it uncommitted again in a read-only request.
             await db.rollback()
-            result = await db.execute(
-                select(User).where(
-                    User.principal_kind == PRINCIPAL_KIND_CLERK,
-                    User.clerk_id == clerk_id,
+            if issuer:
+                user = await load_clerk_user_for_issuer(
+                    db,
+                    issuer=issuer,
+                    subject=clerk_id,
+                    bind_legacy=False,
+                    allow_issuer_mismatch=True,
                 )
-            )
-            user = result.scalar_one()
+            else:
+                user = (
+                    await db.execute(
+                        select(User).where(
+                            User.principal_kind == PRINCIPAL_KIND_CLERK,
+                            User.clerk_id == clerk_id,
+                        )
+                    )
+                ).scalar_one_or_none()
+            if user is None or (issuer and user.clerk_issuer != issuer):
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED, "Invalid account identity"
+                ) from None
 
     # Sub miss + snapshot-rebind opted in: try to attach to an existing
     # snapshot row by verified email. We deliberately fail closed if any
@@ -839,17 +862,28 @@ async def auth_via_verified_clerk_jwt(
             # timestamps as invalid auth instead of turning them into a 500.
             return None
 
-    try:
-        await assert_clerk_principal_active(
-            db,
-            subject=clerk_id,
-            issuer=issuer or None,
-        )
-    except PrincipalSuspendedError:
-        raise AccountSuspendedHTTPException() from None
-    except PrincipalTerminatedError:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
-    await _assert_active_user_or_401(db, user.id)
+    # Only the same live transaction retains the principal and user fences.
+    # Commits, rollbacks (including inside helpers), and user replacement must
+    # reauthorize. Include savepoints because their rollback releases locks too.
+    if not (
+        authorized_user_id == user.id
+        and authorized_transaction is not None
+        and authorized_transaction.is_active
+        and authorized_transaction is (db.get_nested_transaction() or db.get_transaction())
+    ):
+        try:
+            await assert_clerk_principal_active(
+                db,
+                subject=clerk_id,
+                issuer=issuer or None,
+            )
+        except PrincipalSuspendedError:
+            raise AccountSuspendedHTTPException() from None
+        except PrincipalTerminatedError:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED, "Account has been terminated"
+            ) from None
+        await _assert_active_user_or_401(db, user.id)
     return AuthContext(
         user=user,
         oauth_cli=oauth_cli,

--- a/backend/tests/test_auth_transactions.py
+++ b/backend/tests/test_auth_transactions.py
@@ -1,0 +1,320 @@
+"""Clerk authentication owns bootstrap commits and retains transaction fences."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import httpx
+import jwt
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import delete, event, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.auth import _auth_via_clerk_jwt
+from app.core.config import settings
+from app.core.database import get_session
+from app.main import app
+from app.models.principal_lifecycle import ClerkPrincipalSuspension, PrincipalLifecycle
+from app.models.user import User
+from app.services.principal_lifecycle import (
+    fence_clerk_user_deleted,
+    load_clerk_user_for_issuer,
+    set_clerk_principal_suspension,
+)
+from tests.test_auth_jwt_backfill import _rsa_keypair
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.committed_db]
+_ISSUER = "https://auth-transactions.clerk.example.test"
+
+
+@pytest.fixture
+def sign_jwt(monkeypatch):
+    private_key, public_key = _rsa_keypair()
+    monkeypatch.setattr(settings, "clerk_pem_public_key", public_key)
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", _ISSUER)
+    monkeypatch.setattr(settings, "dev_auth_bypass", False)
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", False)
+
+    def sign(subject, *, issuer=_ISSUER, **claims):
+        payload = {"sub": subject, **claims}
+        if issuer is not None:
+            payload["iss"] = issuer
+        return jwt.encode(payload, private_key, algorithm="RS256")
+
+    return sign
+
+
+@contextmanager
+def capture_sql(engine) -> Iterator[list[str]]:
+    statements = []
+
+    def capture(_connection, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    def capture_commit(_connection):
+        statements.append("COMMIT")
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture)
+    event.listen(engine.sync_engine, "commit", capture_commit)
+    try:
+        yield statements
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture)
+        event.remove(engine.sync_engine, "commit", capture_commit)
+
+
+@pytest.mark.parametrize("backfill", [False, True])
+async def test_projects_read_persists_issuer_without_repeated_writes(
+    engine, db_session, seed_user, sign_jwt, backfill
+):
+    user_id = seed_user.id
+    claims = {}
+    if backfill:
+        seed_user.email = None
+        seed_user.name = None
+        claims = {"email": "backfill@example.test", "name": "Backfilled"}
+    await db_session.commit()
+    token = sign_jwt(seed_user.clerk_id, **claims)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def request_session():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = request_session
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        for first_request in (True, False):
+            with capture_sql(engine) as statements:
+                response = await client.get(
+                    "/v1/projects", headers={"Authorization": f"Bearer {token}"}
+                )
+            assert response.status_code == 200, response.text
+            assert any(project["slug"] == "personal" for project in response.json())
+            updates = [sql for sql in statements if sql.startswith("UPDATE users ")]
+            assert sum("clerk_issuer=" in sql for sql in updates) == int(first_request)
+            assert statements.count("COMMIT") == int(first_request)
+            if not first_request:
+                assert not updates
+                assert not any("FOR UPDATE" in sql for sql in statements)
+            async with factory() as observer:
+                persisted = await observer.get(User, user_id)
+                assert persisted.clerk_issuer == _ISSUER
+                if backfill:
+                    assert persisted.email == claims["email"]
+                    assert persisted.name == claims["name"]
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+async def test_auth_retains_both_fences_without_redundant_unchanged_reads(
+    engine, db_session, seed_user, sign_jwt, legacy
+):
+    seed_user.clerk_issuer = None if legacy else _ISSUER
+    await db_session.commit()
+    token = sign_jwt(seed_user.clerk_id)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        with capture_sql(engine) as statements:
+            auth = await _auth_via_clerk_jwt(token, session)
+        assert auth is not None and auth.user_id == seed_user.id
+        if legacy:
+            assert statements.count("COMMIT") == 1
+        else:
+            # Count only established-user auth, excluding request/fixture SQL.
+            assert len(statements) == 7
+            assert all(sql.startswith("SELECT ") for sql in statements)
+            assert sum("pg_advisory_xact_lock_shared" in sql for sql in statements) == 2
+        pid = await session.scalar(text("SELECT pg_backend_pid()"))
+        async with factory() as observer:
+            assert (
+                await observer.scalar(
+                    text(
+                        "SELECT count(*) FROM pg_locks WHERE pid=:pid AND locktype='advisory' "
+                        "AND mode='ShareLock' AND granted"
+                    ),
+                    {"pid": pid},
+                )
+                == 2
+            )
+    async with factory() as observer:
+        assert (
+            await observer.scalar(
+                text("SELECT count(*) FROM pg_locks WHERE pid=:pid AND locktype='advisory'"),
+                {"pid": pid},
+            )
+            == 0
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation", ["issuer", "backfill", "avatar", "rebind", "create", "rollback"]
+)
+@pytest.mark.parametrize("fence", ["suspension", "termination"])
+async def test_auth_rechecks_fences_after_mutation_transaction_ends(
+    engine, db_session, seed_user, sign_jwt, monkeypatch, mutation, fence
+):
+    original_subject = seed_user.clerk_id
+    subject = original_subject
+    seed_user.clerk_issuer = None if mutation == "issuer" else _ISSUER
+    claims = {}
+    if mutation in {"backfill", "rollback"}:
+        seed_user.email = None
+        claims["email"] = "backfill@example.test"
+    elif mutation == "avatar":
+        claims["picture"] = "https://example.test/new-avatar.png"
+    elif mutation in {"rebind", "create"}:
+        subject = f"{original_subject}-new"
+        if mutation == "rebind":
+            monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+            claims["email"] = seed_user.email
+    await db_session.commit()
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    fenced = False
+
+    async def install_fence():
+        nonlocal fenced
+        async with factory() as writer:
+            # These real lifecycle mutations need exclusive principal/user locks.
+            # A timeout would expose a retained pre-commit authentication fence.
+            await writer.execute(text("SET LOCAL lock_timeout='1s'"))
+            if fence == "suspension":
+                await set_clerk_principal_suspension(
+                    writer,
+                    issuer=_ISSUER,
+                    subject=subject,
+                    suspended=True,
+                    reason="auth_transaction_test",
+                )
+            else:
+                await fence_clerk_user_deleted(
+                    writer,
+                    issuer=_ISSUER,
+                    subject=subject,
+                    message_id=f"auth-transaction-{subject}",
+                    payload_sha256="a" * 64,
+                    event_occurred_at=datetime.now(UTC),
+                )
+            await writer.commit()
+        fenced = True
+
+    try:
+        async with factory() as session:
+            original_commit = session.commit
+            original_rollback = session.rollback
+
+            async def commit_then_fence():
+                if mutation == "rollback":
+                    raise IntegrityError("test concurrent backfill", {}, Exception("conflict"))
+                await original_commit()
+                await install_fence()
+
+            async def rollback_then_fence():
+                await original_rollback()
+                await install_fence()
+
+            monkeypatch.setattr(session, "commit", commit_then_fence)
+            if mutation == "rollback":
+                monkeypatch.setattr(session, "rollback", rollback_then_fence)
+            with pytest.raises(HTTPException) as failure:
+                await _auth_via_clerk_jwt(sign_jwt(subject, **claims), session)
+            assert failure.value.status_code == 401
+            assert fenced
+    finally:
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(ClerkPrincipalSuspension).where(
+                    ClerkPrincipalSuspension.issuer == _ISSUER,
+                    ClerkPrincipalSuspension.subject == subject,
+                )
+            )
+            await cleanup.execute(
+                delete(PrincipalLifecycle).where(
+                    PrincipalLifecycle.issuer == _ISSUER,
+                    PrincipalLifecycle.subject == subject,
+                )
+            )
+            if mutation == "create":
+                await cleanup.execute(delete(User).where(User.clerk_id == subject))
+            await cleanup.commit()
+
+
+@pytest.mark.parametrize(
+    ("mode", "winner", "accepted"),
+    [
+        ("bootstrap", "different", False),
+        ("bootstrap", "unbound", False),
+        ("bootstrap", "matching", True),
+        ("bootstrap", "deleted", False),
+        ("backfill", "matching", True),
+        ("legacy", "unbound", True),
+        ("legacy", "deleted", False),
+    ],
+)
+async def test_auth_rollback_accepts_only_a_compatible_persisted_winner(
+    engine, db_session, seed_user, sign_jwt, monkeypatch, mode, winner, accepted
+):
+    subject, user_id = seed_user.clerk_id, seed_user.id
+    seed_user.clerk_issuer = _ISSUER if mode == "backfill" else None
+    seed_user.email = None
+    await db_session.commit()
+    if mode == "legacy":
+        monkeypatch.setattr(settings, "clerk_jwt_issuer", "")
+    token = sign_jwt(
+        subject, issuer=None if mode == "legacy" else _ISSUER, email="loser@example.test"
+    )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    winner_issuer = (
+        "https://other.clerk.example.test"
+        if winner == "different"
+        else _ISSUER
+        if winner == "matching"
+        else None
+    )
+    async with factory() as session:
+        original_rollback = session.rollback
+
+        async def fail_commit():
+            raise IntegrityError("test competing bootstrap", {}, Exception("conflict"))
+
+        async def rollback_then_persist_winner():
+            await original_rollback()
+            async with factory() as writer:
+                await writer.execute(text("SET LOCAL lock_timeout='1s'"))
+                if winner == "deleted":
+                    await writer.execute(delete(User).where(User.id == user_id))
+                else:
+                    winning_user = (
+                        await load_clerk_user_for_issuer(
+                            writer, issuer=winner_issuer, subject=subject, bind_legacy=True
+                        )
+                        if winner_issuer is not None
+                        else await writer.get(User, user_id)
+                    )
+                    assert winning_user is not None
+                    winning_user.email = "winner@example.test"
+                await writer.commit()
+
+        monkeypatch.setattr(session, "commit", fail_commit)
+        monkeypatch.setattr(session, "rollback", rollback_then_persist_winner)
+        if accepted:
+            auth = await _auth_via_clerk_jwt(token, session)
+            assert auth is not None and auth.user_id == user_id
+            assert auth.user.email == "winner@example.test"
+            assert auth.user.clerk_issuer == winner_issuer
+        else:
+            with pytest.raises(HTTPException) as failure:
+                await _auth_via_clerk_jwt(token, session)
+            assert failure.value.status_code == 401
+            assert failure.value.detail == "Invalid account identity"
+        assert not session.dirty
+    async with factory() as observer:
+        persisted = await observer.get(User, user_id)
+        if winner == "deleted":
+            assert persisted is None
+        else:
+            assert persisted is not None
+            assert persisted.clerk_issuer == winner_issuer
+            assert persisted.email == "winner@example.test"

--- a/backend/tests/test_auth_transactions.py
+++ b/backend/tests/test_auth_transactions.py
@@ -8,7 +8,7 @@ import httpx
 import jwt
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import delete, event, text
+from sqlalchemy import delete, event, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -318,3 +318,69 @@ async def test_auth_rollback_accepts_only_a_compatible_persisted_winner(
             assert persisted is not None
             assert persisted.clerk_issuer == winner_issuer
             assert persisted.email == "winner@example.test"
+
+
+@pytest.mark.parametrize("winner", ["unchanged", "deleted", "mismatched", "suspended"])
+async def test_avatar_write_failure_reloads_persisted_identity_before_authorization(
+    engine, db_session, seed_user, sign_jwt, monkeypatch, winner
+):
+    user_id, subject = seed_user.id, seed_user.clerk_id
+    seed_user.clerk_issuer = _ISSUER
+    seed_user.avatar_url = "https://example.test/previous.png"
+    await db_session.commit()
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    postgres_errors = []
+
+    def record_error(context):
+        postgres_errors.append(getattr(context.original_exception, "sqlstate", None))
+
+    event.listen(engine.sync_engine, "handle_error", record_error)
+    try:
+        async with factory() as session:
+            original_rollback = session.rollback
+
+            async def rollback_then_change_identity():
+                await original_rollback()
+                async with factory() as writer:
+                    await writer.execute(text("SET LOCAL lock_timeout='1s'"))
+                    if winner == "deleted":
+                        await writer.execute(delete(User).where(User.id == user_id))
+                    elif winner == "mismatched":
+                        await writer.execute(
+                            update(User)
+                            .where(User.id == user_id)
+                            .values(clerk_issuer="https://other.clerk.example.test")
+                        )
+                    elif winner == "suspended":
+                        await set_clerk_principal_suspension(
+                            writer,
+                            issuer=_ISSUER,
+                            subject=subject,
+                            suspended=True,
+                            reason="avatar_rollback_test",
+                        )
+                    await writer.commit()
+
+            monkeypatch.setattr(session, "rollback", rollback_then_change_identity)
+            # A real PostgreSQL varchar(512) error; commit itself is not mocked.
+            token = sign_jwt(subject, picture="https://example.test/" + "a" * 512)
+            if winner == "unchanged":
+                auth = await _auth_via_clerk_jwt(token, session)
+                assert auth is not None and auth.user_id == user_id
+                assert auth.user.avatar_url == "https://example.test/previous.png"
+            else:
+                with pytest.raises(HTTPException) as failure:
+                    await _auth_via_clerk_jwt(token, session)
+                assert failure.value.status_code == 401
+            assert postgres_errors == ["22001"]
+            assert not session.dirty
+    finally:
+        event.remove(engine.sync_engine, "handle_error", record_error)
+        async with factory() as cleanup:
+            await cleanup.execute(
+                delete(ClerkPrincipalSuspension).where(
+                    ClerkPrincipalSuspension.issuer == _ISSUER,
+                    ClerkPrincipalSuspension.subject == subject,
+                )
+            )
+            await cleanup.commit()


### PR DESCRIPTION
Released: included in production Cloud ecc6441b2b32b592e7888bca150e7855534cb34b via https://github.com/Clawdi-AI/clawdi/actions/runs/34359326746. Final postflight confirmed three exact-version healthy roles, health/readiness 200, zero sampled pool-timeout metric and new-error markers, active SSE leases back to 589 with 123 historical expired rows after reconnect. This is bounded observation, not a production throughput claim.

Clerk users migrated with a null issuer could bind on every read-only request and then roll the binding back, retaining an update lock until request completion. Persist the first issuer binding with authentication profile backfill. If that commit loses a race, accept only a compatible persisted winner; mismatched, unbound, or deleted users return 401.

Established users retain their verified principal/user authority only while the same user and active transaction remain in place. Commits, rollbacks, savepoint replacement, creation, and rebind require final authorization. Unchanged authentication drops from 13 to 7 SELECTs without caching authorization across requests or transactions.

An opportunistic avatar update can fail with PostgreSQL 22001 for an oversized URL. Rollback expires ORM state even with expire_on_commit=False; explicitly reload and validate the persisted user before final authorization, preserving the previous avatar instead of raising MissingGreenlet. Concurrent deletion, identity changes, or suspension fail closed.

Validation: final-head CI passed on refreshed head aaa3e23148eb1dfb9ee3680b3c6d5d104bea166a: 2755 passed, 12 skipped, 1 strict pre-existing upstream xfail; all other applicable checks passed. https://github.com/Clawdi-AI/clawdi/actions/runs/34341945615. Focused Docker verification used Python 3.14.7 and PostgreSQL 18.4 and covered the real /v1/projects read path, persisted binding and zero subsequent writes, shared lock ownership, six mutation transaction boundaries, rollback winners, and a real avatar write error. Root reviewed the actual final runtime and test diffs.

No schema, dependency or API changes. Shared principal helpers and LISTEN remain unchanged. This PR has not been merged or deployed.
