### PR TITLE
perf(composio): reclaim idle sessions and coalesce bounded cold creation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,7 +76,7 @@ from app.routes.sync import router as sync_router
 from app.routes.vault import router as vault_router
 from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorruptError
 from app.services.channels import close_channel_provider_http_client
-from app.services.composio import close_composio_client
+from app.services.composio import close_composio_client, run_tool_router_mcp_session_reaper
 from app.services.embedding import LocalEmbedder, LocalServiceEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
 from app.services.metrics import db_control_lock_timeouts, db_pool_timeouts, observe_event_loop_lag
@@ -134,6 +134,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     lag_monitor = asyncio.create_task(observe_event_loop_lag(), name="event-loop-lag")
     background.add(lag_monitor)
     lag_monitor.add_done_callback(background.discard)
+
+    session_reaper = asyncio.create_task(
+        run_tool_router_mcp_session_reaper(), name="composio-session-reaper"
+    )
+    background.add(session_reaper)
+    session_reaper.add_done_callback(background.discard)
 
     if settings.memory_embedding_mode.lower() == "local":
 

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -26,6 +26,7 @@ from collections.abc import AsyncGenerator, Awaitable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from itertools import islice
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 import composio_client
@@ -38,6 +39,7 @@ from mcp.types import CallToolResult, ListToolsResult
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, ValidationError
 
 from app.core.config import settings
+from app.core.database import finish_cleanup
 from app.schemas.connector import (
     ConnectorAuthFieldResponse,
     ConnectorAuthFieldsResponse,
@@ -245,8 +247,10 @@ _client: AsyncComposio | None = None
 _sdk_client: Composio[OpenAITool, OpenAIToolCollection] | None = None
 _TOOL_ROUTER_SESSION_TIMEOUT_SECONDS = 10.0
 _TOOL_ROUTER_DISCOVERY_TIMEOUT_SECONDS = 25.0
+_TOOL_ROUTER_REAP_INTERVAL_SECONDS = 60.0
+_TOOL_ROUTER_REAP_BATCH_SIZE = 128
 _tool_router_session_cache: dict[str, ComposioMcpSession] = {}
-_tool_router_session_creations: dict[str, set[object]] = {}
+_tool_router_session_creations: dict[str, _ToolRouterSessionCreation] = {}
 _tool_router_tools_cache: dict[str, tuple[ComposioMcpSession, ListToolsResult]] = {}
 _tool_router_tools_inflight: dict[str, asyncio.Task[ListToolsResult]] = {}
 
@@ -434,6 +438,12 @@ def _bounded_scrubbed_message(
     return " ".join(safe.split())[:500]
 
 
+@dataclass(eq=False)
+class _ToolRouterSessionCreation:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    participants: int = 0
+
+
 class _ComposioMcpSessionRetired(RuntimeError):
     pass
 
@@ -476,7 +486,9 @@ class ComposioMcpSession:
         client = self._http_client
         self._http_client = None
         if client is not None:
-            await client.aclose()
+            # A reaper/request may be cancelled after detaching this session.
+            # Keep ownership of the removed client's close until it finishes.
+            await finish_cleanup(client.aclose)
 
 
 _MCP_OPERATION_ERRORS = (
@@ -597,28 +609,76 @@ async def get_tool_router_mcp_session(user_id: str) -> ComposioMcpSession:
     if cached and cached.expires_at > now:
         return cached
 
-    # Invalidation detaches this group; its in-flight requests cannot republish.
-    pending = _tool_router_session_creations.setdefault(user_id, set())
-    creation = object()
-    pending.add(creation)
+    # Invalidation detaches this generation, including its queued waiters.
+    pending = _tool_router_session_creations.get(user_id)
+    if pending is None:
+        pending = _ToolRouterSessionCreation()
+        _tool_router_session_creations[user_id] = pending
+    pending.participants += 1
     try:
-        if cached is not None:
-            await cached.retire()
-        session = await _create_tool_router_mcp_session(user_id, now=now)
-        if _tool_router_session_creations.get(user_id) is not pending:
-            await session.retire()
-            raise ComposioMcpUpstreamError("Composio session invalidated during creation")
-        current = _tool_router_session_cache.get(user_id)
-        if current is not None and current.expires_at > datetime.now(UTC):
-            if current is not session:
+        # Each caller's budget includes queueing and retirement, not just SDK
+        # creation. Owned client cleanup still drains before cancellation exits.
+        async with asyncio.timeout(_TOOL_ROUTER_SESSION_TIMEOUT_SECONDS), pending.lock:
+            if _tool_router_session_creations.get(user_id) is not pending:
+                raise ComposioMcpUpstreamError("Composio session invalidated during creation")
+            now = datetime.now(UTC)
+            cached = _tool_router_session_cache.get(user_id)
+            if cached is not None:
+                if cached.expires_at > now:
+                    return cached
+                _detach_tool_router_mcp_session(user_id, cached)
+                await cached.retire()
+                if _tool_router_session_creations.get(user_id) is not pending:
+                    raise ComposioMcpUpstreamError("Composio session invalidated during creation")
+            session = await _create_tool_router_mcp_session(user_id, now=now)
+            if _tool_router_session_creations.get(user_id) is not pending:
                 await session.retire()
-            return current
-        _tool_router_session_cache[user_id] = session
-        return session
+                raise ComposioMcpUpstreamError("Composio session invalidated during creation")
+            _tool_router_session_cache[user_id] = session
+            return session
+    except TimeoutError:
+        raise ComposioProviderError(ComposioFailure("timeout")) from None
     finally:
-        pending.discard(creation)
-        if not pending and _tool_router_session_creations.get(user_id) is pending:
+        pending.participants -= 1
+        if pending.participants == 0 and _tool_router_session_creations.get(user_id) is pending:
             _tool_router_session_creations.pop(user_id)
+
+
+def _detach_tool_router_mcp_session(user_id: str, session: ComposioMcpSession) -> None:
+    if _tool_router_session_cache.get(user_id) is session:
+        _tool_router_session_cache.pop(user_id)
+    tools = _tool_router_tools_cache.get(user_id)
+    if tools is not None and tools[0] is session:
+        _tool_router_tools_cache.pop(user_id)
+
+
+async def reap_expired_tool_router_mcp_sessions() -> None:
+    """Inspect one bounded batch, rotating retained entries for eventual reclamation."""
+    now = datetime.now(UTC)
+    batch = tuple(islice(_tool_router_session_cache.items(), _TOOL_ROUTER_REAP_BATCH_SIZE))
+    for user_id, session in batch:
+        if _tool_router_session_cache.get(user_id) is not session:
+            continue
+        if session.expires_at > now:
+            # Dict insertion order provides a bounded round-robin scan without
+            # a second index that would itself need invalidation and cleanup.
+            _tool_router_session_cache.pop(user_id)
+            _tool_router_session_cache[user_id] = session
+            continue
+        _detach_tool_router_mcp_session(user_id, session)
+        try:
+            await session.retire()
+        except Exception as exc:
+            logger.warning(
+                "Failed to close expired Composio MCP session: error_type=%s", type(exc).__name__
+            )
+
+
+async def run_tool_router_mcp_session_reaper() -> None:
+    """Reclaim idle sessions independently of requests; owned by ASGI lifespan."""
+    while True:
+        await asyncio.sleep(_TOOL_ROUTER_REAP_INTERVAL_SECONDS)
+        await reap_expired_tool_router_mcp_sessions()
 
 
 async def invalidate_tool_router_mcp_session(user_id: str) -> None:

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -911,7 +911,7 @@ async def test_composio_mcp_client_runs_lifecycle_and_parses_json_and_sse(monkey
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("invalidation", ["none", "account-change", "shutdown"])
+@pytest.mark.parametrize("invalidation", ["account-change", "shutdown"])
 async def test_session_creation_cannot_replace_a_newer_session(
     monkeypatch, tool_router_cache, invalidation
 ):
@@ -942,11 +942,8 @@ async def test_session_creation_cannot_replace_a_newer_session(
                 await composio.close_composio_client()
             assert await composio.get_tool_router_mcp_session("publication") is fresh
             release.set()
-            if invalidation != "none":
-                with pytest.raises(composio.ComposioMcpUpstreamError):
-                    await request
-            else:
-                assert await request is fresh
+            with pytest.raises(composio.ComposioMcpUpstreamError):
+                await request
         assert composio._tool_router_session_cache["publication"] is fresh
         assert stale._retired
         assert not fresh._retired
@@ -971,7 +968,7 @@ async def test_cancelled_session_creation_does_not_invalidate_another_creator(
     async def create(_user_id, *, now):
         nonlocal calls
         calls += 1
-        if calls == 2:
+        if calls == 1:
             started.set()
         await release.wait()
         return _mcp_session("survivor")
@@ -982,11 +979,14 @@ async def test_cancelled_session_creation_does_not_invalidate_another_creator(
     try:
         async with asyncio.timeout(3):
             await started.wait()
+            await asyncio.sleep(0)
+            assert calls == 1
             first.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await first
             release.set()
             surviving = await second
+        assert calls == 2
         assert composio._tool_router_session_cache["survivor"] is surviving
         assert not surviving._retired
         assert not composio._tool_router_session_creations
@@ -1672,3 +1672,301 @@ async def test_clawdi_mcp_session_get_share_url_respects_env_binding(
     assert not own_env.get("isError"), own_env
     assert cross_env["isError"] is True, cross_env
     assert not linked.get("isError"), linked
+
+
+@pytest.mark.asyncio
+async def test_session_cold_creation_is_single_flight(monkeypatch, tool_router_cache):
+    composio, _ = tool_router_cache
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def create(_user_id, *, now):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _mcp_session("cold")
+
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", create)
+    tasks = [asyncio.create_task(composio.get_tool_router_mcp_session("cold")) for _ in range(32)]
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            await asyncio.sleep(0)
+            assert calls == 1
+            release.set()
+            results = await asyncio.gather(*tasks)
+        assert all(result is results[0] for result in results)
+        assert not composio._tool_router_session_creations
+    finally:
+        release.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_queued_callers_have_one_acquisition_deadline(monkeypatch, tool_router_cache):
+    composio, _ = tool_router_cache
+    calls = 0
+    monkeypatch.setattr(composio, "_TOOL_ROUTER_SESSION_TIMEOUT_SECONDS", 0.05)
+
+    async def fail_create(_user_id, *, now):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.02)
+        raise composio.ComposioProviderError(composio.ComposioFailure("timeout"))
+
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", fail_create)
+    started = asyncio.get_running_loop().time()
+    async with asyncio.timeout(3):
+        results = await asyncio.gather(
+            *(composio.get_tool_router_mcp_session("deadline") for _ in range(32)),
+            return_exceptions=True,
+        )
+    elapsed = asyncio.get_running_loop().time() - started
+    assert not composio._tool_router_session_cache
+    assert not composio._tool_router_session_creations
+    assert all(
+        isinstance(result, composio.ComposioProviderError) and result.failure.kind == "timeout"
+        for result in results
+    )
+    # Allow scheduler headroom, but not 32 serial upstream waits (~0.64s).
+    assert elapsed < 0.3, f"{elapsed=:.3f}, {calls=}"
+    assert calls < 32
+
+
+@pytest.mark.asyncio
+async def test_session_acquisition_deadline_drains_retired_client_close(
+    monkeypatch, tool_router_cache
+):
+    composio, sessions = tool_router_cache
+    expired = _mcp_session("deadline")
+    expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    composio._tool_router_session_cache["deadline"] = expired
+    sessions["deadline"] = [_mcp_session("deadline", 2)]
+    async with expired.lease_http_client() as client:
+        real_close = client.aclose
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def close():
+        started.set()
+        await release.wait()
+        await real_close()
+
+    monkeypatch.setattr(client, "aclose", close)
+    monkeypatch.setattr(composio, "_TOOL_ROUTER_SESSION_TIMEOUT_SECONDS", 0.02)
+    request = asyncio.create_task(composio.get_tool_router_mcp_session("deadline"))
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            await asyncio.sleep(0.05)
+            assert request.cancelling()
+            assert not request.done()
+            assert not client.is_closed
+            release.set()
+            with pytest.raises(composio.ComposioProviderError) as error:
+                await request
+        assert error.value.failure.kind == "timeout"
+        assert client.is_closed
+        assert len(sessions["deadline"]) == 1
+        assert not composio._tool_router_session_cache
+        assert not composio._tool_router_session_creations
+    finally:
+        release.set()
+        request.cancel()
+        await asyncio.gather(request, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_invalidation_rejects_queued_generation(monkeypatch, tool_router_cache):
+    composio, _ = tool_router_cache
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def create(_user_id, *, now):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            await release.wait()
+        return _mcp_session("queued", calls)
+
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", create)
+    tasks = [asyncio.create_task(composio.get_tool_router_mcp_session("queued")) for _ in range(2)]
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            await asyncio.sleep(0)
+            assert composio._tool_router_session_creations["queued"].participants == 2
+            await composio.invalidate_tool_router_mcp_session("queued")
+            fresh = await composio.get_tool_router_mcp_session("queued")
+            release.set()
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+        assert all(isinstance(result, composio.ComposioMcpUpstreamError) for result in results)
+        assert calls == 2
+        assert composio._tool_router_session_cache["queued"] is fresh
+        assert not composio._tool_router_session_creations
+    finally:
+        release.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_reaper_rotates_bounded_batches_and_preserves_leases(
+    monkeypatch, tool_router_cache
+):
+    composio, _ = tool_router_cache
+    monkeypatch.setattr(composio, "_TOOL_ROUTER_REAP_BATCH_SIZE", 1)
+    fresh = _mcp_session("fresh")
+    expired = _mcp_session("expired")
+    expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    composio._tool_router_session_cache.update(fresh=fresh, expired=expired)
+    composio._tool_router_tools_cache["expired"] = (expired, _mcp_tools("expired"))
+    async with expired.lease_http_client() as client:
+        await composio.reap_expired_tool_router_mcp_sessions()
+        assert "expired" in composio._tool_router_session_cache
+        await composio.reap_expired_tool_router_mcp_sessions()
+        assert "expired" not in composio._tool_router_session_cache
+        assert "expired" not in composio._tool_router_tools_cache
+        assert expired._retired
+        assert not client.is_closed
+    assert client.is_closed
+    assert composio._tool_router_session_cache == {"fresh": fresh}
+
+
+@pytest.mark.asyncio
+async def test_session_reaper_preserves_replacement_and_active_creation(
+    monkeypatch, tool_router_cache
+):
+    composio, _ = tool_router_cache
+    expired = _mcp_session("race")
+    expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    fresh = _mcp_session("race", 2)
+    replaced = _mcp_session("replaced")
+    replaced.expires_at = expired.expires_at
+    replacement = _mcp_session("replaced", 2)
+    composio._tool_router_session_cache.update(race=expired, replaced=replaced)
+    composio._tool_router_tools_cache["race"] = (expired, _mcp_tools("old"))
+    close_started = asyncio.Event()
+    close_release = asyncio.Event()
+    create_started = asyncio.Event()
+    create_release = asyncio.Event()
+
+    async with expired.lease_http_client() as client:
+        real_close = client.aclose
+
+    async def close():
+        close_started.set()
+        await close_release.wait()
+        await real_close()
+
+    async def create(_user_id, *, now):
+        if _user_id == "replaced":
+            return replacement
+        create_started.set()
+        await create_release.wait()
+        return fresh
+
+    monkeypatch.setattr(client, "aclose", close)
+    monkeypatch.setattr(composio, "_create_tool_router_mcp_session", create)
+    reaper = asyncio.create_task(composio.reap_expired_tool_router_mcp_sessions())
+    creator = None
+    try:
+        async with asyncio.timeout(3):
+            await close_started.wait()
+            # The sweep already captured the old second entry before yielding.
+            await composio.invalidate_tool_router_mcp_session("replaced")
+            assert await composio.get_tool_router_mcp_session("replaced") is replacement
+            composio._tool_router_tools_cache["replaced"] = (replacement, _mcp_tools("new"))
+            creator = asyncio.create_task(composio.get_tool_router_mcp_session("race"))
+            await create_started.wait()
+            generation = composio._tool_router_session_creations["race"]
+            await composio.reap_expired_tool_router_mcp_sessions()
+            assert composio._tool_router_session_creations["race"] is generation
+            create_release.set()
+            assert await creator is fresh
+            composio._tool_router_tools_cache["race"] = (fresh, _mcp_tools("new"))
+            close_release.set()
+            await reaper
+        assert client.is_closed
+        assert composio._tool_router_session_cache["replaced"] is replacement
+        assert composio._tool_router_tools_cache["replaced"][0] is replacement
+        assert not replacement._retired
+        assert composio._tool_router_session_cache["race"] is fresh
+        assert composio._tool_router_tools_cache["race"][0] is fresh
+    finally:
+        close_release.set()
+        create_release.set()
+        tasks = [reaper] if creator is None else [reaper, creator]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_reaper_shutdown_waits_for_removed_client_close(
+    monkeypatch, tool_router_cache
+):
+    composio, _ = tool_router_cache
+    expired = _mcp_session("shutdown")
+    expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    composio._tool_router_session_cache["shutdown"] = expired
+    async with expired.lease_http_client() as client:
+        real_close = client.aclose
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def close():
+        started.set()
+        await release.wait()
+        await real_close()
+
+    monkeypatch.setattr(client, "aclose", close)
+    monkeypatch.setattr(composio, "_TOOL_ROUTER_REAP_INTERVAL_SECONDS", 0)
+    reaper = asyncio.create_task(composio.run_tool_router_mcp_session_reaper())
+    try:
+        async with asyncio.timeout(3):
+            await started.wait()
+            assert not composio._tool_router_session_cache
+            reaper.cancel()
+            await asyncio.sleep(0)
+            assert not reaper.done()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await reaper
+        assert client.is_closed
+    finally:
+        release.set()
+        reaper.cancel()
+        await asyncio.gather(reaper, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_reaper_close_failure_does_not_skip_remaining_sessions(
+    monkeypatch, tool_router_cache, caplog
+):
+    composio, _ = tool_router_cache
+    clients = []
+    for user_id in ("failure", "next"):
+        expired = _mcp_session(user_id)
+        expired.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        composio._tool_router_session_cache[user_id] = expired
+        async with expired.lease_http_client() as client:
+            clients.append(client)
+    real_close = clients[0].aclose
+
+    async def fail_close():
+        await real_close()
+        raise OSError("fixture close failure")
+
+    monkeypatch.setattr(clients[0], "aclose", fail_close)
+    await composio.reap_expired_tool_router_mcp_sessions()
+    assert not composio._tool_router_session_cache
+    assert all(client.is_closed for client in clients)
+    assert "Failed to close expired Composio MCP session" in caplog.text


### PR DESCRIPTION
Released: included in production Cloud ecc6441b2b32b592e7888bca150e7855534cb34b via https://github.com/Clawdi-AI/clawdi/actions/runs/34359326746. Final postflight confirmed three exact-version healthy roles, health/readiness 200, zero sampled pool-timeout metric and new-error markers, active SSE leases back to 589 with 123 historical expired rows after reconnect. This is bounded observation, not a production throughput claim.

Expired Tool Router sessions retained user-scoped HTTP clients and tool catalogs until the same user returned or the process shut down. Reclaim them through the existing ASGI-owned background lifecycle, inspecting at most 128 entries per sweep and rotating retained entries. Remove cached sessions/tools by identity and retire active clients only after their final lease; removed-client cleanup remains owned through cancellation.

Serialize same-user cold creation within the existing invalidation generation. Waiters recheck the cache and generation before creating, and the group disappears after its final participant exits. Each caller has one acquisition deadline covering lock queueing, retirement and creation, so repeated upstream failures cannot serialize callers into an unbounded wait. Late canceled results still cannot publish.

Isolated Python 3.14.7 measurements using imported production modules and locked dependencies: 1,000 expired session/tool/client entries were reclaimed in 8 bounded sweeps instead of retained; 32 successful concurrent cold calls created 1 session instead of 32. With shortened failure deadlines, a 32-call fixture changed from about 660 ms / 32 creates to 53 ms / 3 creates, with all callers receiving the existing timeout error and the registry emptied. These are fixture object/call/timing measurements, not production socket/RSS/throughput claims or an absolute cache-memory bound.

Verification: 32 focused SDK/MCP/cache/reaper tests passed, including replacement races, active leases, invalidation while queued, canceled creator with surviving waiter, late results, close failure, and shutdown/deadline cleanup ownership. Ruff and typing passed for both changed production files. Root reviewed the final runtime and regression diff. Final-head CI passed: 2735 passed, 12 skipped, 1 pre-existing upstream xfail, and all other applicable checks passed. https://github.com/Clawdi-AI/clawdi/actions/runs/34332129219

The existing 30-minute session TTL and authentication remain unchanged. The minute-based bounded reaper provides eventual idle reclamation; very large caches need multiple sweeps. Owned cleanup can outlast the nominal acquisition deadline. PR1364 owns grouped MCP error handling and is not included. No production changes have been executed.
