### PR TITLE
fix(cli): support older Hermes native credential writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Native Hermes API-key connections now support older credential-pool APIs while
+  preserving personal credentials and native key-rotation behavior.
+
 - CLI 0.14.53 ships only the Python egress addon source in npm and native packages,
   rejecting generated Python caches and bytecode before publication.
 - CLI 0.14.52 avoids redundant managed service restarts when the watcher inherits

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.61",
+      "version": "0.14.62",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.61",
+	"version": "0.14.62",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hermes-native-credentials.test.ts
+++ b/packages/cli/src/runtime/hermes-native-credentials.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-function fixture() {
+function fixture(legacyWriter = false) {
 	const home = mkdtempSync(join(tmpdir(), "clawdi-native-auth-"));
 	roots.push(home);
 	const app = join(home, ".hermes", "hermes-agent");
@@ -42,13 +42,13 @@ def resolve_provider(provider):
 def read_credential_pool(provider_id=None):
     pool = json.loads(path.read_text()) if path.exists() else {}
     return pool if provider_id is None else pool.get(provider_id, [])
-def write_credential_pool(provider_id, entries, *, removed_ids=(), status_cleared_ids=()):
+def write_credential_pool(provider_id, entries, *, removed_ids=()${legacyWriter ? "" : ", status_cleared_ids=()"}):
     assert all(e["id"] == "clawdi-native-api-key" for e in entries)
     pool = read_credential_pool()
     prior = {e["id"]: e for e in pool.get(provider_id, []) if e["id"] not in removed_ids}
     for entry in entries:
         old = prior.get(entry["id"], {})
-        if old.get("last_status") == "exhausted" and entry["id"] not in status_cleared_ids:
+        if old.get("last_status") == "exhausted" and ${legacyWriter ? 'old.get("access_token") == entry.get("access_token")' : 'entry["id"] not in status_cleared_ids'}:
             entry = {**entry, "last_status": old["last_status"]}
         prior[entry["id"]] = entry
     pool[provider_id] = list(prior.values())
@@ -143,43 +143,50 @@ test("native credentials use the official managed Hermes interpreter", () => {
 	).toBe(true);
 });
 
-test("native credentials take priority, rotate only their row, and retain cooldown until rotation", () => {
-	const f = fixture();
-	const initial = f.run([credential], { anthropic: "random" });
-	expect(initial.status).toBe(0);
-	expect(JSON.parse(initial.stdout)).toEqual({
-		changed: true,
-		selectedProvider: null,
-		strategyUpdates: { anthropic: { exists: true, value: "fill_first" } },
-	});
-	const connected = f.pool();
-	expect(connected.anthropic.find((row: { id: string }) => row.id === "personal")).toEqual(
-		f.userEntry,
-	);
-	const own = connected.anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key");
-	expect(own.priority).toBeLessThan(f.userEntry.priority);
-	own.last_status = "exhausted";
-	writeFileSync(f.auth, JSON.stringify(connected));
-	const repeat = f.run([credential], { anthropic: "fill_first" });
-	expect(repeat.status).toBe(0);
-	expect(JSON.parse(repeat.stdout).changed).toBe(false);
-	expect(
-		f.pool().anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key")
-			.last_status,
-	).toBe("exhausted");
-	const rotated = f.run([{ ...credential, apiKey: "rotated-key" }], { anthropic: "fill_first" });
-	expect(rotated.status).toBe(0);
-	const pool = f.pool();
-	expect(
-		pool.anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key"),
-	).toMatchObject({ access_token: "rotated-key", base_url: credential.baseUrl });
-	expect(
-		pool.anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key").last_status,
-	).toBeUndefined();
-	expect(pool.anthropic.find((row: { id: string }) => row.id === "personal")).toEqual(f.userEntry);
-	expect(pool.openai).toEqual(connected.openai);
-	expect(readFileSync(f.journal, "utf8")).not.toContain("key");
-});
+test.each([false, true])(
+	"native credentials rotate only their row and preserve other cooldowns (legacy writer: %s)",
+	(legacyWriter) => {
+		const f = fixture(legacyWriter);
+		const initial = f.run([credential], { anthropic: "random" });
+		expect(initial.status).toBe(0);
+		expect(JSON.parse(initial.stdout)).toEqual({
+			changed: true,
+			selectedProvider: null,
+			strategyUpdates: { anthropic: { exists: true, value: "fill_first" } },
+		});
+		const connected = f.pool();
+		expect(connected.anthropic.find((row: { id: string }) => row.id === "personal")).toEqual(
+			f.userEntry,
+		);
+		const own = connected.anthropic.find(
+			(row: { id: string }) => row.id === "clawdi-native-api-key",
+		);
+		expect(own.priority).toBeLessThan(f.userEntry.priority);
+		own.last_status = "exhausted";
+		writeFileSync(f.auth, JSON.stringify(connected));
+		const repeat = f.run([credential], { anthropic: "fill_first" });
+		expect(repeat.status).toBe(0);
+		expect(JSON.parse(repeat.stdout).changed).toBe(false);
+		expect(
+			f.pool().anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key")
+				.last_status,
+		).toBe("exhausted");
+		const rotated = f.run([{ ...credential, apiKey: "rotated-key" }], { anthropic: "fill_first" });
+		expect(rotated.status).toBe(0);
+		const pool = f.pool();
+		expect(
+			pool.anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key"),
+		).toMatchObject({ access_token: "rotated-key", base_url: credential.baseUrl });
+		expect(
+			pool.anthropic.find((row: { id: string }) => row.id === "clawdi-native-api-key").last_status,
+		).toBeUndefined();
+		expect(pool.anthropic.find((row: { id: string }) => row.id === "personal")).toEqual(
+			f.userEntry,
+		);
+		expect(pool.openai).toEqual(connected.openai);
+		expect(readFileSync(f.journal, "utf8")).not.toContain("key");
+	},
+);
 
 test("uses the native auth identity for selected aliases and rejects alias pool keys", () => {
 	const f = fixture();

--- a/packages/cli/src/runtime/hermes_native_credentials.py
+++ b/packages/cli/src/runtime/hermes_native_credentials.py
@@ -8,6 +8,7 @@ credential-free write-ahead journal preserving strategy ownership across retries
 
 import contextlib
 import fcntl
+import inspect
 import io
 import json
 import os
@@ -89,7 +90,11 @@ def write_journal(path, records):
 
 def reconcile(payload):
     from agent.credential_pool import PooledCredential
-    from hermes_cli.auth import read_credential_pool, resolve_provider, write_credential_pool
+    from hermes_cli.auth import (
+        read_credential_pool,
+        resolve_provider,
+        write_credential_pool,
+    )
 
     desired = {}
     for item in payload["providers"]:
@@ -187,9 +192,14 @@ def reconcile(payload):
                 if entry != existing:
                     # Omitted siblings are merged from disk, including concurrent
                     # key rotations; no snapshot of another credential is replayed.
-                    write_credential_pool(
-                        provider, [entry], status_cleared_ids=[ENTRY_ID] if rotated else []
+                    # Older Hermes writers clear cooldown when the token changes
+                    # but do not expose the explicit status-reset keyword.
+                    options = (
+                        {"status_cleared_ids": [ENTRY_ID] if rotated else []}
+                        if "status_cleared_ids" in inspect.signature(write_credential_pool).parameters
+                        else {}
                     )
+                    write_credential_pool(provider, [entry], **options)
                     changed = True
                 if strategies.get(provider) != "fill_first":
                     updates[provider] = {"exists": True, "value": "fill_first"}


### PR DESCRIPTION
Older Hermes installations reject the credential writer’s newer `status_cleared_ids` keyword, preventing native API-key convergence and CLI upgrades. Detect support for that optional native parameter and retain the older writer’s built-in token-change behavior. Personal credentials and normal cooldowns remain owned by Hermes.

Release CLI 0.14.62. Reuse the existing lifecycle test for both API signatures; no new reconciliation path or direct auth-file writer.

Validation: Docker CLI typecheck and eight focused tests passed. Unmodified official Hermes sources at `4323c67dcc6048fc8e311cdff7600d3d6a17807f` and `966637323e6f90864e069dbc12755934c2c86387` passed handoff, rotation, cooldown preservation, personal-row preservation, and unbind with fake keys. The released helper reproduced the failure against the older API.

The complete runtime, manifest-reconciliation, and Hermes credential suites also passed: 308 tests, 1,958 assertions, plus CLI typecheck in the disposable Docker runner.
