### PR TITLE
perf(auth): ignore oversized optional avatars before persistence

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -23,7 +23,7 @@ from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.session import AgentEnvironment
-from app.models.user import PRINCIPAL_KIND_CLERK, User
+from app.models.user import PRINCIPAL_KIND_CLERK, USER_AVATAR_URL_MAX_LENGTH, User
 from app.schemas.problem import ACCOUNT_SUSPENDED_DETAIL, AccountSuspendedProblem
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
@@ -641,7 +641,13 @@ async def auth_via_verified_clerk_jwt(
     raw_name = payload.get("name")
     name = raw_name if isinstance(raw_name, str) and raw_name else None
     raw_picture = payload.get("picture")
-    picture = raw_picture if isinstance(raw_picture, str) and raw_picture else None
+    # Optional profile metadata must fit PostgreSQL's character limit; a signed
+    # but oversized URL must not break bootstrap or retry a failed write on every request.
+    picture = (
+        raw_picture
+        if isinstance(raw_picture, str) and 0 < len(raw_picture) <= USER_AVATAR_URL_MAX_LENGTH
+        else None
+    )
 
     # Backfill email/name on rows that were lazy-created via the
     # admin path (`_resolve_or_create_user` in routes/admin.py) — that

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
 
+USER_AVATAR_URL_MAX_LENGTH = 512
+
 PRINCIPAL_KIND_CLERK = "clerk"
 PRINCIPAL_KIND_PARTNER_TENANT = "partner_tenant"
 
@@ -49,7 +51,7 @@ class User(Base, TimestampMixin):
     # the underlying signed URL periodically). Public session-share
     # pages render this so visitors see the owner's avatar in the
     # message stream.
-    avatar_url: Mapped[str | None] = mapped_column(String(512))
+    avatar_url: Mapped[str | None] = mapped_column(String(USER_AVATAR_URL_MAX_LENGTH))
     # Monotonic counter incremented on any skill insert / update /
     # soft-delete (`is_active=False`). Exposed as a collection-level
     # ETag on `GET /v1/skills` and embedded in SSE `skill_changed`

--- a/backend/tests/test_auth_transactions.py
+++ b/backend/tests/test_auth_transactions.py
@@ -8,7 +8,7 @@ import httpx
 import jwt
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import delete, event, text, update
+from sqlalchemy import delete, event, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -17,6 +17,7 @@ from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.models.principal_lifecycle import ClerkPrincipalSuspension, PrincipalLifecycle
+from app.models.project import Project
 from app.models.user import User
 from app.services.principal_lifecycle import (
     fence_clerk_user_deleted,
@@ -56,11 +57,16 @@ def capture_sql(engine) -> Iterator[list[str]]:
     def capture_commit(_connection):
         statements.append("COMMIT")
 
+    def capture_rollback(_connection):
+        statements.append("ROLLBACK")
+
+    event.listen(engine.sync_engine, "rollback", capture_rollback)
     event.listen(engine.sync_engine, "before_cursor_execute", capture)
     event.listen(engine.sync_engine, "commit", capture_commit)
     try:
         yield statements
     finally:
+        event.remove(engine.sync_engine, "rollback", capture_rollback)
         event.remove(engine.sync_engine, "before_cursor_execute", capture)
         event.remove(engine.sync_engine, "commit", capture_commit)
 
@@ -362,8 +368,14 @@ async def test_avatar_write_failure_reloads_persisted_identity_before_authorizat
                     await writer.commit()
 
             monkeypatch.setattr(session, "rollback", rollback_then_change_identity)
-            # A real PostgreSQL varchar(512) error; commit itself is not mocked.
-            token = sign_jwt(subject, picture="https://example.test/" + "a" * 512)
+
+            # Fail inside a real PostgreSQL transaction during the avatar flush.
+            # Commit/rollback still exercise ORM expiration and identity reloading.
+            def fail_avatar_flush(sync_session, _flush_context, _instances):
+                sync_session.connection().execute(text("SELECT 1 / 0"))
+
+            event.listen(session.sync_session, "before_flush", fail_avatar_flush, once=True)
+            token = sign_jwt(subject, picture="https://example.test/new-avatar.png")
             if winner == "unchanged":
                 auth = await _auth_via_clerk_jwt(token, session)
                 assert auth is not None and auth.user_id == user_id
@@ -372,7 +384,7 @@ async def test_avatar_write_failure_reloads_persisted_identity_before_authorizat
                 with pytest.raises(HTTPException) as failure:
                     await _auth_via_clerk_jwt(token, session)
                 assert failure.value.status_code == 401
-            assert postgres_errors == ["22001"]
+            assert postgres_errors == ["22012"]
             assert not session.dirty
     finally:
         event.remove(engine.sync_engine, "handle_error", record_error)
@@ -384,3 +396,58 @@ async def test_avatar_write_failure_reloads_persisted_identity_before_authorizat
                 )
             )
             await cleanup.commit()
+
+
+@pytest.mark.parametrize("picture_length", [512, 513])
+@pytest.mark.parametrize("new_user", [False, True])
+async def test_avatar_character_bounds_preserve_auth_without_repeated_writes(
+    engine, db_session, seed_user, sign_jwt, picture_length, new_user
+):
+    subject = seed_user.clerk_id
+    previous_avatar = "https://example.test/previous.png"
+    seed_user.clerk_issuer = _ISSUER
+    seed_user.avatar_url = previous_avatar
+    if new_user:
+        await db_session.delete(seed_user)
+    await db_session.commit()
+    # Multibyte code points count as one character in PostgreSQL varchar.
+    prefix = "https://example.test/"
+    picture = prefix + "😀" * (picture_length - len(prefix))
+    token = sign_jwt(subject, picture=picture)
+    expected_avatar = picture if picture_length == 512 else None if new_user else previous_avatar
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    measurements = []
+    try:
+        for _ in range(2):
+            async with factory() as session:
+                with capture_sql(engine) as statements:
+                    auth = await _auth_via_clerk_jwt(token, session)
+                assert auth is not None
+                assert auth.user.avatar_url == expected_avatar
+                assert not session.dirty
+                measurements.append(statements)
+            async with factory() as observer:
+                persisted = await observer.scalar(select(User).where(User.clerk_id == subject))
+                assert persisted is not None
+                assert persisted.clerk_issuer == _ISSUER
+                assert persisted.avatar_url == expected_avatar
+                personal = await observer.scalar(
+                    select(Project).where(Project.user_id == persisted.id)
+                )
+                assert personal is not None and personal.slug == "personal"
+        for first_request, statements in zip((True, False), measurements, strict=True):
+            writes = [sql for sql in statements if sql.startswith("UPDATE users ")]
+            expected_updates = int(first_request and not new_user and picture_length == 512)
+            assert len(writes) == expected_updates
+            assert "ROLLBACK" not in statements
+            assert statements.count("COMMIT") == int(
+                first_request and (new_user or picture_length == 512)
+            )
+            if not first_request or (not new_user and picture_length == 513):
+                assert len(statements) == 7
+                assert all(sql.startswith("SELECT ") for sql in statements)
+    finally:
+        if new_user:
+            async with factory() as cleanup:
+                await cleanup.execute(delete(User).where(User.clerk_id == subject))
+                await cleanup.commit()


### PR DESCRIPTION
Released: included in production Cloud ecc6441b2b32b592e7888bca150e7855534cb34b via https://github.com/Clawdi-AI/clawdi/actions/runs/34359326746. Final postflight confirmed three exact-version healthy roles, health/readiness 200, zero sampled pool-timeout metric and new-error markers, active SSE leases back to 589 with 123 historical expired rows after reconnect. This is bounded observation, not a production throughput claim.

The former stacked base #1441 was merged first; this PR was rebased to main with its avatar-only delta unchanged before release.

Built on #1441 (base branch perf/deep-api-db-20260909); this PR contains only the optional-avatar boundary change and its regressions. Retarget to main after #1441 merges.

A signed Clerk picture URL longer than the existing varchar(512) field caused a failed database write on every established-user authentication and could break first-user bootstrap. Validate optional avatar length before persistence, using one constant shared with the model. Oversized values retain the existing avatar, or leave it null for a new user; URLs are never truncated and schema size is unchanged.

Real PostgreSQL 18.4 measurements on two repeated oversized-avatar authentications: each changed from 14 SELECTs + a failed UPDATE + ROLLBACK to 7 SELECTs with no writes/rollback inside the authentication span. First login now creates the user and Personal project successfully. These are isolated SQL counts, not end-to-end production latency claims.

Python 3.14.7 / locked-dependency Docker verification: 58 authentication tests passed; final avatar-focused set 10 passed. Unicode 512/513-character boundaries and normal updates are covered. Generic database rollback/identity fencing remains tested using a real PostgreSQL 22012 failure with a valid picture. Ruff, typing, dependency checks and compilation passed. Root reviewed the actual runtime/test diff; Final CI passed on 3fd6e73ee46daf3e9c63799a4aa1c05414f9795e: 2759 passed, 12 skipped, 1 pre-existing upstream xfail, with all other applicable checks passing. https://github.com/Clawdi-AI/clawdi/actions/runs/34343324726. No merge or production deployment has been performed.
