### PR TITLE
refactor(providers): remove unused catalogs and compatibility helper

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -12,7 +12,6 @@ import {
 	providerChoiceFromRef,
 	providerDisplayLabel,
 	providerPresentation,
-	providerRuntimeIncompatibility,
 	usableProviders,
 } from "@/hosted/v2/ai-providers/model-binding";
 
@@ -314,8 +313,6 @@ describe("model binding", () => {
 			},
 		} satisfies AiProvider;
 
-		expect(providerRuntimeIncompatibility(geminiProvider, "openclaw")).toBeNull();
-		expect(providerRuntimeIncompatibility(geminiProvider, "hermes")).toContain("Choose OpenClaw");
 		const issue = providerAvailabilityIssue(geminiProvider, {
 			runtime: "hermes",
 			environmentId: null,
@@ -339,8 +336,6 @@ describe("model binding", () => {
 			},
 		} satisfies AiProvider;
 
-		expect(providerRuntimeIncompatibility(provider, "openclaw")).toBeNull();
-		expect(providerRuntimeIncompatibility(provider, "hermes")).toContain("Hermes cannot use");
 		expect(
 			providerAvailabilityIssue(provider, { runtime: "hermes", environmentId: null })?.message,
 		).toBe("Hermes cannot use this provider's authentication or API protocol.");

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -5,7 +5,7 @@ import {
 	isFirstPartyManagedAiProvider,
 } from "@clawdi/shared";
 import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
-import { type HostedRuntime, runtimeDisplayName } from "@/hosted/runtimes";
+import type { HostedRuntime } from "@/hosted/runtimes";
 import {
 	type ProviderPreset,
 	providerPresetById,
@@ -73,21 +73,6 @@ export function primaryModelRef(providerId: string, model: string): PrimaryModel
 
 export function isManagedProviderId(providerId: string | null | undefined): boolean {
 	return typeof providerId === "string" && isClawdiManagedProviderId(providerId);
-}
-
-export function providerRuntimeIncompatibility(
-	provider: AiProvider,
-	runtime: HostedRuntime,
-): string | null {
-	const compatible = provider.readiness?.runtime_compatibility[runtime];
-	if (compatible === true) return null;
-	if (runtime === "hermes" && provider.api_mode === "google_generate_content") {
-		return "Hermes cannot use this Gemini connection yet. Choose OpenClaw, or use an OpenAI- or Anthropic-compatible provider.";
-	}
-	if (compatible === false) {
-		return `${runtimeDisplayName(runtime)} cannot use this provider's authentication or API protocol.`;
-	}
-	return null;
 }
 
 export function providerAvailabilityIssue(

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -5,19 +5,7 @@ import {
 } from "@clawdi/shared";
 import type { AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
-/**
- * The six AI provider types (backend `ProviderType`) with the defaults the
- * add flow prefills: base URL, allowed API modes, and runtime env var.
- */
-export const PROVIDER_TYPES = [
-	"openai",
-	"anthropic",
-	"openrouter",
-	"gemini",
-	"mistral",
-	"custom_openai_compatible",
-] as const;
-export type ProviderTypeId = (typeof PROVIDER_TYPES)[number];
+export type ProviderTypeId = AiProviderUpsert["type"];
 
 export type ApiMode = NonNullable<AiProviderUpsert["api_mode"]>;
 
@@ -31,8 +19,6 @@ export interface ProviderTypeMeta {
 	apiKeyUrl?: string;
 	/** base_url + api_mode are user-supplied / required. */
 	custom?: boolean;
-	/** Offers "Sign in with ChatGPT" (Codex OAuth). */
-	oauth?: boolean;
 }
 
 const CUSTOM_OPENAI_COMPATIBLE_RUNTIME_ENV = "CUSTOM_API_KEY";
@@ -46,7 +32,6 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		defaultApiMode: defaultAiProviderApiMode("openai") ?? "openai_responses",
 		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("openai") ?? "",
 		apiKeyUrl: "https://platform.openai.com/settings/organization/api-keys",
-		oauth: true,
 	},
 	anthropic: {
 		id: "anthropic",

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -3,10 +3,8 @@ import {
 	type AiProviderAuth,
 	type AiProviderCatalog,
 	CLAWDI_MANAGED_PROVIDER_ID,
-	CODEX_OAUTH_MODEL_CATALOG,
 	defaultAiProviderApiMode,
 	defaultAiProviderBaseUrl,
-	defaultAiProviderModels,
 	defaultAiProviderRuntimeEnvName,
 } from "@clawdi/shared";
 import { parse as parseYaml } from "yaml";
@@ -25,7 +23,7 @@ const byokOpenAiCatalog: AiProviderCatalog = {
 			auth: { type: "api_key", source: "managed" },
 			managed_by: "user",
 			runtime_env_name: defaultAiProviderRuntimeEnvName("openai") ?? "OPENAI_API_KEY",
-			models: defaultAiProviderModels("openai").map((model) => ({ ...model })),
+			models: [{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", context_window: 1_050_000 }],
 		},
 	],
 	defaults: { chat_provider_id: "openai-main" },
@@ -42,7 +40,7 @@ const codexOAuthCatalog: AiProviderCatalog = {
 			api_mode: "openai_responses",
 			auth: { type: "agent_profile", tool: "codex", profile: "default" },
 			managed_by: "user",
-			models: CODEX_OAUTH_MODEL_CATALOG.map((model) => ({ ...model })),
+			models: [{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" }],
 		},
 	],
 	defaults: { chat_provider_id: "openai-codex" },

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -9,8 +9,6 @@ import {
 	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
-	CODEX_OAUTH_MODEL_CATALOG,
-	defaultAiProviderModels,
 	defaultAiProviderRuntimeEnvName,
 	isClawdiManagedV2ProviderId,
 	isFirstPartyManagedAiProvider,
@@ -540,77 +538,5 @@ describe("known AI provider defaults", () => {
 		expect(defaultAiProviderRuntimeEnvName("gemini")).toBe("GEMINI_API_KEY");
 		expect(defaultAiProviderRuntimeEnvName("mistral")).toBe("MISTRAL_API_KEY");
 		expect(defaultAiProviderRuntimeEnvName("custom_openai_compatible")).toBeUndefined();
-	});
-
-	test("provides a non-empty model catalog for built-in providers and Codex OAuth", () => {
-		expect(defaultAiProviderModels("openai").map((model) => model.id)).toEqual([
-			"gpt-5.6-sol",
-			"gpt-5.6-terra",
-			"gpt-5.6-luna",
-			"gpt-5.5",
-			"gpt-5.4",
-			"gpt-5.4-mini",
-		]);
-		expect(defaultAiProviderModels("anthropic").map((model) => model.id)).toEqual([
-			"claude-sonnet-5",
-			"claude-opus-5",
-			"claude-opus-4-6",
-			"claude-haiku-4-5",
-		]);
-		expect(defaultAiProviderModels("openrouter").map((model) => model.id)).toEqual([
-			"openrouter/auto-beta",
-			"~openai/gpt-latest",
-			"anthropic/claude-sonnet-5",
-			"anthropic/claude-opus-4.6",
-			"openai/gpt-5.5",
-		]);
-		expect(defaultAiProviderModels("gemini").map((model) => model.id)).toEqual([
-			"gemini-3.6-flash",
-			"gemini-3.5-flash",
-			"gemini-3.5-flash-lite",
-		]);
-		expect(defaultAiProviderModels("mistral").map((model) => model.id)).toEqual([
-			"mistral-medium-latest",
-			"mistral-small-latest",
-			"mistral-large-latest",
-			"codestral-latest",
-		]);
-		expect(defaultAiProviderModels("custom_openai_compatible")).toEqual([]);
-		expect(CODEX_OAUTH_MODEL_CATALOG.map((model) => model.id)).toEqual([
-			"gpt-5.6-sol",
-			"gpt-5.6-terra",
-			"gpt-5.6-luna",
-			"gpt-5.5",
-		]);
-	});
-
-	test("keeps context metadata only when an exact durable value is documented", () => {
-		expect(defaultAiProviderModels("openai").map((model) => model.context_window)).toEqual([
-			1_050_000,
-			1_050_000,
-			1_050_000,
-			undefined,
-			undefined,
-			undefined,
-		]);
-		expect(
-			defaultAiProviderModels("anthropic").every((model) => model.context_window === undefined),
-		).toBe(true);
-		expect(defaultAiProviderModels("openrouter").map((model) => model.context_window)).toEqual([
-			undefined,
-			undefined,
-			1_000_000,
-			undefined,
-			undefined,
-		]);
-		expect(defaultAiProviderModels("gemini").map((model) => model.context_window)).toEqual([
-			1_048_576, 1_048_576, 1_048_576,
-		]);
-		expect(
-			defaultAiProviderModels("mistral").every((model) => model.context_window === undefined),
-		).toBe(true);
-		expect(CODEX_OAUTH_MODEL_CATALOG.every((model) => model.context_window === undefined)).toBe(
-			true,
-		);
 	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -169,56 +169,6 @@ const DEFAULT_RUNTIME_ENV_NAME: Partial<Record<AiProviderType, string>> = {
 	mistral: "MISTRAL_API_KEY",
 };
 
-const DEFAULT_MODEL_CATALOG: Partial<Record<AiProviderType, readonly AiProviderModel[]>> = {
-	openai: [
-		{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", context_window: 1_050_000 },
-		{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra", context_window: 1_050_000 },
-		{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna", context_window: 1_050_000 },
-		{ id: "gpt-5.5", label: "GPT-5.5" },
-		{ id: "gpt-5.4", label: "GPT-5.4" },
-		{ id: "gpt-5.4-mini", label: "GPT-5.4 mini" },
-	],
-	anthropic: [
-		{ id: "claude-sonnet-5", label: "Claude Sonnet 5" },
-		{ id: "claude-opus-5", label: "Claude Opus 5" },
-		{ id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-		{ id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
-	],
-	openrouter: [
-		{ id: "openrouter/auto-beta", label: "Auto Router" },
-		{ id: "~openai/gpt-latest", label: "OpenAI GPT Latest" },
-		{
-			id: "anthropic/claude-sonnet-5",
-			label: "Claude Sonnet 5",
-			context_window: 1_000_000,
-		},
-		{ id: "anthropic/claude-opus-4.6", label: "Claude Opus 4.6" },
-		{ id: "openai/gpt-5.5", label: "OpenAI GPT-5.5" },
-	],
-	gemini: [
-		{ id: "gemini-3.6-flash", label: "Gemini 3.6 Flash", context_window: 1_048_576 },
-		{ id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", context_window: 1_048_576 },
-		{
-			id: "gemini-3.5-flash-lite",
-			label: "Gemini 3.5 Flash-Lite",
-			context_window: 1_048_576,
-		},
-	],
-	mistral: [
-		{ id: "mistral-medium-latest", label: "Mistral Medium" },
-		{ id: "mistral-small-latest", label: "Mistral Small" },
-		{ id: "mistral-large-latest", label: "Mistral Large" },
-		{ id: "codestral-latest", label: "Codestral" },
-	],
-};
-
-export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
-	{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
-	{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
-	{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
-	{ id: "gpt-5.5", label: "GPT-5.5" },
-];
-
 export const CLAWDI_MANAGED_PROVIDER_ID = "clawdi";
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
@@ -331,10 +281,6 @@ export function defaultAiProviderBaseUrl(type: AiProviderType): string | undefin
 
 export function defaultAiProviderRuntimeEnvName(type: AiProviderType): string | undefined {
 	return DEFAULT_RUNTIME_ENV_NAME[type];
-}
-
-export function defaultAiProviderModels(type: AiProviderType): readonly AiProviderModel[] {
-	return DEFAULT_MODEL_CATALOG[type] ?? [];
 }
 
 export function aiProviderRuntimeCompatibility(


### PR DESCRIPTION
Remove retired provider setup data with no production callers: the static vendor/Codex model catalogs, their getter, and the duplicate Web runtime-compatibility helper. Delete the catalog-list assertions and use one explicit model per projection fixture.

Remove the unused OAuth metadata flag and derive the Web provider type from the generated API type. Existing provider availability checks, Managed projection, and historical configuration handling continue through their current callers.

Validation in sequential 4 CPU / 4 GiB Docker runners: Shared 81 tests, CLI projection 13 tests, Web provider 34 tests, all three typechecks, OSS build, and six production SSR checks passed. Biome and diff checks passed. References were checked across both Core and Hosted repositories; no tests added.
