### PR TITLE
fix(web): respect Custom model ownership in Agent settings

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -280,6 +280,18 @@ jobs:
         run: bun run --cwd apps/web e2e --config=playwright.auth.config.ts
       - name: OSS web e2e
         run: bun run --cwd apps/web e2e
+      - name: Set up Hosted browser fixture dependencies
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.5"
+          python-version: "3.12"
+      - name: Install Hosted browser fixture dependencies
+        run: uv sync --project backend --frozen
+      - name: Hosted provider flows
+        run: >-
+          bun run --cwd apps/web e2e --config=playwright.hosted.config.ts
+          e2e/hosted-deploy-flow.pw.ts e2e/hosted-smoke.pw.ts e2e/hosted-channels-providers.pw.ts
+          --grep "deploy wizard creates|Clawdi AI model selection|provider creation stays|Custom model ownership|renaming a native|editing and rotating an agent-owned"
 
   whatsapp-native-e2e:
     needs: changes

--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -55,7 +55,7 @@ test("editing and rotating an agent-owned connection sends one atomic patch with
 		provider_id: "saved-connection",
 		label: "Saved connection",
 		type: "custom_openai_compatible",
-		configuration_mode: "connection",
+		configuration_mode: "custom",
 		base_url: "https://custom.example/v1",
 		api_mode: "openai_responses",
 		runtime_env_name: "SAVED_CONNECTION_KEY",

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2992,6 +2992,48 @@ for (const projectionFailure of [
 	});
 }
 
+test("Custom model ownership is preserved in agent settings", async ({ page }) => {
+	const id = "existing-provider";
+	const provider = {
+		...userProvider(id, "Existing provider", [{ id: "legacy-first" }, { id: "legacy-second" }]),
+		configuration_mode: "custom" as const,
+	};
+	const deployment: DeploymentMutationFixture = {
+		...railHostedDeployment,
+		config_info: {
+			...railHostedDeployment.config_info,
+			ai_provider_auth_kind: "api_key",
+			runtime_configuration: {
+				providers: [
+					{
+						provider_id: id,
+						auth_kind: "secret_reference",
+						models: ["legacy-first", "legacy-second"],
+					},
+				],
+				primary_model: { provider_id: id, model: "legacy-first" },
+				features: [],
+			},
+		},
+	};
+	const updates: Array<{ body: string; idempotencyKey: string | null; ifMatch: string | null }> =
+		[];
+	await stubHostedApi(page, {
+		deployments: [deployment],
+		cloudAgents: [railHostedCloudAgent],
+		aiProviders: [provider],
+		updateDeploymentRequests: updates,
+	});
+	await page.goto(`/agents/${railHostedEnvironmentId}`);
+	await expect(page.locator('[data-overview-module="model-provider"]')).toContainText(
+		"Managed in agent",
+	);
+	await page.goto(`/agents/${railHostedEnvironmentId}/model-provider`);
+	await expect(page.getByTestId("managed-model-controls")).toHaveCount(0);
+	await expect(page.locator("main").getByRole("button", { name: "Save changes" })).toBeDisabled();
+	expect(updates).toEqual([]);
+});
+
 test("Clawdi AI model selection saves the chosen managed model", async ({ page }, testInfo) => {
 	const updateDeploymentRequests: Array<{
 		body: string;
@@ -3014,7 +3056,7 @@ test("Clawdi AI model selection saves the chosen managed model", async ({ page }
 		"true",
 	);
 	await models.getByRole("combobox", { name: "More managed models" }).click();
-	await page.getByRole("option", { name: /^GPT-5.6 Sol/ }).click();
+	await page.getByRole("option", { name: /GPT-5.6 Sol/ }).click();
 	await expect(models.getByRole("combobox")).toContainText("GPT-5.6 Sol");
 	await expect(page.getByText("Add, validate, or remove providers on")).toHaveCount(0);
 	await page.screenshot({ path: testInfo.outputPath("managed-model-picker.png") });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1284,12 +1284,14 @@ function OverviewTab({
 	const managedProvider = !providerId || isManagedProviderId(providerId);
 	const providers = useUserAiProviders({ enabled: !managedProvider });
 	const managedModelCatalog = useManagedModelCatalog({ enabled: managedProvider });
-	const nativeConnection = providers.data?.some(
+	const agentOwnsModels = providers.data?.some(
 		(provider) =>
 			provider.provider_id === providerId &&
-			(provider.configuration_mode === "native" || provider.configuration_mode === "connection"),
+			(provider.configuration_mode === "native" ||
+				provider.configuration_mode === "connection" ||
+				provider.configuration_mode === "custom"),
 	);
-	const model = nativeConnection
+	const model = agentOwnsModels
 		? "Managed in agent"
 		: modelBindingDisplayName(
 				primaryModel,
@@ -2467,7 +2469,9 @@ function AiProviderTab({
 	const agentOwnsModels = list.some(
 		(provider) =>
 			provider.provider_id === primaryProviderRef &&
-			(provider.configuration_mode === "connection" || provider.configuration_mode === "native"),
+			(provider.configuration_mode === "connection" ||
+				provider.configuration_mode === "native" ||
+				provider.configuration_mode === "custom"),
 	);
 	const bindingModelIdentity =
 		currentAuthKind === "unmanaged" || agentOwnsModels
@@ -2511,7 +2515,8 @@ function AiProviderTab({
 	const dirty =
 		bindingMode !== initialMode ||
 		(bindingMode === "configured" &&
-			(primaryProviderChoice !== initialPrimaryChoice || primaryModel !== currentModel));
+			(primaryProviderChoice !== initialPrimaryChoice ||
+				(!agentOwnsModels && primaryModel !== currentModel)));
 	function applyProviderSettings() {
 		let update: DeploymentUpdateRequest;
 		try {


### PR DESCRIPTION
Custom connections were missing from the Agent UI's agent-owned model checks. Historical model metadata could therefore appear as the current model and mark an unchanged Custom binding dirty. Treat Custom consistently with native connections in the overview, initial binding state, and dirty check.

Keep the existing Managed model picker and credential-only Custom/native UI. Route the focused Hosted provider browser flows into Client CI, which previously ran OSS browser coverage only. Correct the Managed overflow locator to include its accessible provider-icon prefix, and exercise key rotation using the current Custom mode.

Validation: 8 Chromium flows passed in a disposable 4 CPU / 4 GiB Docker runner, covering Managed create/edit model selection, Custom/native creation, Native API-key/OAuth label changes, Custom atomic edit/key rotation, and Custom historical metadata handling. Web typecheck, existing focused unit tests, OSS build, production SSR, and Biome passed.
