### PR TITLE
feat(web): compact provider chooser with brand grouping

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -291,7 +291,7 @@ jobs:
         run: >-
           bun run --cwd apps/web e2e --config=playwright.hosted.config.ts
           e2e/hosted-deploy-flow.pw.ts e2e/hosted-smoke.pw.ts e2e/hosted-channels-providers.pw.ts
-          --grep "deploy wizard creates|Clawdi AI model selection|provider creation stays|Custom model ownership|renaming a native|editing and rotating an agent-owned"
+          --grep "deploy wizard creates|Clawdi AI model selection|provider creation stays|Custom model ownership|renaming a native|editing and rotating an agent-owned|popular BYOK|native BYOK saves"
 
   whatsapp-native-e2e:
     needs: changes

--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -123,6 +123,7 @@ test("native BYOK saves credentials without a model catalog or inference probe",
 
 	// The chooser gates the fields: pick a provider first.
 	await page.getByRole("button", { name: /^OpenAI/ }).click();
+	await page.getByRole("button", { name: "OpenAI API", exact: true }).click();
 	await page.getByRole("textbox", { name: "API key" }).fill("sk-e2e-test-key");
 	await expect(page.getByLabel("Model catalog")).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Test connection", exact: true })).toHaveCount(0);
@@ -210,7 +211,7 @@ test("channels connect dialog opens without browser errors", async ({ page }) =>
 	expect(errors, `connect dialog: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("popular BYOK providers support credential-only product setup", async ({ page }) => {
+test("popular BYOK providers support credential-only product setup", async ({ page }, testInfo) => {
 	const errors = collectBrowserErrors(page);
 	const inferenceRequests: string[] = [];
 	page.on("request", (request) => {
@@ -221,6 +222,25 @@ test("popular BYOK providers support credential-only product setup", async ({ pa
 	await page.goto("/ai-providers");
 	await page.getByRole("button", { name: "Add provider", exact: true }).first().click();
 	const dialog = page.getByRole("dialog");
+	await expect(dialog.getByRole("button", { name: "Kimi", exact: true })).toHaveCount(1);
+	await expect(
+		dialog.getByRole("button", { name: "Qwen (Model Studio)", exact: true }),
+	).toHaveCount(1);
+	const bounds = await dialog.boundingBox();
+	expect(bounds?.height).toBeLessThanOrEqual(576);
+	await page.screenshot({ path: testInfo.outputPath("provider-brands.png") });
+	await page.setViewportSize({ width: 390, height: 844 });
+	const mobileBounds = await dialog.boundingBox();
+	expect(mobileBounds?.height).toBeLessThanOrEqual(576);
+	expect(mobileBounds?.width).toBeLessThanOrEqual(390);
+	await expect(dialog.getByTestId("provider-dialog-body")).toHaveJSProperty("scrollLeft", 0);
+	await page.screenshot({ path: testInfo.outputPath("provider-mobile.png") });
+	await page.setViewportSize({ width: 1000, height: 1000 });
+	await dialog.getByRole("button", { name: "Kimi", exact: true }).click();
+	await expect(dialog.getByRole("button", { name: "Kimi Code", exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "API · Global", exact: true })).toBeVisible();
+	await page.screenshot({ path: testInfo.outputPath("provider-variants.png") });
+	await dialog.getByRole("button", { name: "Back to providers", exact: true }).click();
 	for (const choice of [
 		{
 			query: "Hugging Face",
@@ -250,9 +270,12 @@ test("popular BYOK providers support credential-only product setup", async ({ pa
 		await dialog.getByRole("textbox", { name: "Search providers" }).fill(choice.query);
 		await dialog
 			.getByRole("button", {
-				name: new RegExp(`^${choice.name}${choice.product ? ` · ${choice.product}` : ""}`),
+				name: choice.name,
+				exact: true,
 			})
 			.click();
+		if (choice.product)
+			await dialog.getByRole("button", { name: choice.product, exact: true }).click();
 		const credentialInput = dialog.getByLabel(choice.credential, { exact: true });
 		await expect(credentialInput).toHaveAttribute(
 			"placeholder",

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3119,6 +3119,8 @@ for (const kind of ["native", "custom"] as const) {
 		await dialog
 			.getByRole("button", { name: kind === "native" ? /^OpenAI/ : /^Custom endpoint/ })
 			.click();
+		if (kind === "native")
+			await dialog.getByRole("button", { name: "OpenAI API", exact: true }).click();
 		if (kind === "custom") {
 			await dialog.getByLabel("Name", { exact: true }).fill(providerName);
 			await dialog.getByLabel("Endpoint").fill("https://custom.example/v1");

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -6,7 +6,6 @@ import {
 	providerListAllowsSubmit,
 	providerSettingsPatch,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
-import { providerPresetSummary } from "@/hosted/v2/ai-providers/model-binding";
 import {
 	providerPresetById,
 	providerPresetForSavedProvider,
@@ -220,7 +219,6 @@ describe("native provider form defaults", () => {
 		const region = providerPresetRegion(preset, "coding-global");
 		expect(region?.id).toBe("coding-global");
 		expect(region?.base_url.startsWith("https://")).toBe(true);
-		expect(providerPresetSummary(preset)).toBe("API key · region / plan options");
 		expect(providerPresetForSavedProvider({ baseUrl: preset.base_url })?.id).toBe(preset.id);
 	});
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -477,7 +477,7 @@ export function AddProviderDialog({
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="flex max-h-[min(92vh,calc(100dvh-1rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
+				className="flex max-h-[min(36rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
 			>
 				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
 					<DialogTitle className="flex min-w-0 items-center gap-3">

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -230,16 +230,6 @@ export function providerCatalogDescription(provider: AiProvider): string {
 	return providerPresentation(provider).summary;
 }
 
-export function providerPresetSummary(preset: ProviderPreset): string {
-	if (preset.variant_label === "Product")
-		return preset.region_variants?.map((variant) => variant.label).join(" / ") || "API key";
-	if (preset.credential_label) return `Connect using an ${preset.credential_label.toLowerCase()}`;
-	if (preset.id === "xiaomi") return "Pay-as-you-go API access";
-	return preset.region_variants?.length
-		? "API key · region / plan options"
-		: "Connect with an API key";
-}
-
 function providerModelSummary(provider: AiProvider, preset: ProviderPreset | null): string {
 	if (
 		provider.configuration_mode === "native" ||

--- a/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { EntityChoiceCard } from "@/components/entity-card";
+import { ArrowLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
 import { EntityIcon } from "@/components/entity-icon";
+import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
-import { providerPresetSummary } from "@/hosted/v2/ai-providers/model-binding";
 import { PROVIDER_PRESETS, type ProviderPreset } from "@/hosted/v2/ai-providers/provider-presets";
 import { type ProviderTypeId, providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 
@@ -16,148 +16,149 @@ export type ProviderChoice =
 interface ChoiceEntry {
 	id: string;
 	label: string;
-	description: string;
-	iconId: string;
-	searchText: string;
 	choice: ProviderChoice;
 }
-
-const FIRST_CLASS_TYPES: readonly ProviderTypeId[] = ["openai", "anthropic", "gemini"];
-function typeDescription(type: ProviderTypeId): string {
-	if (type === "openai") return "API key";
-	if (type === "anthropic") return "Claude model access";
-	if (type === "gemini") return "Gemini model access";
-	return "Connect your own API endpoint";
+interface ProviderGroup {
+	id: string;
+	label: string;
+	iconId: string;
+	entries: ChoiceEntry[];
 }
 
-function typeEntry(type: ProviderTypeId): ChoiceEntry {
-	const meta = providerTypeMeta(type);
+function typeGroup(type: ProviderTypeId): ProviderGroup {
+	const label =
+		type === "custom_openai_compatible" ? "Custom endpoint" : providerTypeMeta(type).label;
 	return {
-		id: `type:${type}`,
-		label: type === "custom_openai_compatible" ? "Custom endpoint" : meta.label,
-		description: typeDescription(type),
+		id: type,
+		label,
 		iconId: type,
-		searchText: `${meta.label} ${type} ${typeDescription(type)}`.toLowerCase(),
-		choice: { kind: "type", type },
+		entries: [{ id: type, label, choice: { kind: "type", type } }],
 	};
 }
 
-function presetEntry(
-	preset: ProviderPreset,
-	region?: NonNullable<ProviderPreset["region_variants"]>[number],
-): ChoiceEntry {
-	const description = region
-		? (preset.credential_label ?? "API key")
-		: providerPresetSummary(preset);
-	return {
-		id: `preset:${preset.id}:${region?.id ?? "default"}`,
-		label: region ? `${preset.label} · ${region.label}` : preset.label,
-		description,
-		iconId: preset.id,
-		searchText: [
-			preset.label,
-			preset.id,
-			description,
-			...(preset.region_variants ?? []).map((variant) => variant.label),
-		]
-			.join(" ")
-			.toLowerCase(),
-		choice: { kind: "preset", preset, ...(region ? { regionId: region.id } : {}) },
-	};
-}
-
-const ALL_ENTRIES: readonly ChoiceEntry[] = [
-	...FIRST_CLASS_TYPES.map(typeEntry),
-	...PROVIDER_PRESETS.flatMap((preset) =>
-		preset.region_variants?.length
-			? preset.region_variants.map((region) => presetEntry(preset, region))
-			: [presetEntry(preset)],
-	),
+const GROUPS: ProviderGroup[] = [
 	{
-		id: "oauth:codex",
-		label: "ChatGPT (Codex)",
-		description: "Sign in with ChatGPT",
+		id: "openai",
+		label: "OpenAI",
 		iconId: "openai",
-		searchText: "chatgpt codex openai subscription oauth",
-		choice: { kind: "oauth" },
+		entries: [
+			{ id: "openai-api", label: "OpenAI API", choice: { kind: "type", type: "openai" } },
+			{ id: "chatgpt-codex", label: "ChatGPT (Codex)", choice: { kind: "oauth" } },
+		],
 	},
-	typeEntry("custom_openai_compatible"),
+	typeGroup("anthropic"),
+	typeGroup("gemini"),
 ];
-
-function ChoiceGrid({
-	entries,
-	onSelect,
-}: {
-	entries: readonly ChoiceEntry[];
-	onSelect: (choice: ProviderChoice) => void;
-}) {
-	return (
-		<div data-testid="provider-choice-grid" className="grid gap-1.5 sm:grid-cols-2">
-			{entries.map((entry) => (
-				<EntityChoiceCard
-					key={entry.id}
-					onClick={() => onSelect(entry.choice)}
-					icon={<EntityIcon kind="provider" id={entry.iconId} label={entry.label} size="sm" />}
-					title={entry.label}
-					description={entry.description}
-					variant="compact"
-				/>
-			))}
-		</div>
+for (const preset of PROVIDER_PRESETS) {
+	const isKimi = preset.id === "moonshot" || preset.id === "kimi-coding";
+	const id = isKimi ? "kimi" : preset.id;
+	let group = GROUPS.find((item) => item.id === id);
+	if (!group) {
+		group = { id, label: isKimi ? "Kimi" : preset.label, iconId: preset.id, entries: [] };
+		GROUPS.push(group);
+	}
+	const regions = preset.region_variants ?? [];
+	group.entries.push(
+		...(regions.length
+			? regions.map((region) => ({
+					id: `${preset.id}:${region.id}`,
+					label: isKimi ? `API · ${region.label}` : region.label,
+					choice: { kind: "preset" as const, preset, regionId: region.id },
+				}))
+			: [
+					{
+						id: preset.id,
+						label: isKimi ? "Kimi Code" : preset.label,
+						choice: { kind: "preset" as const, preset },
+					},
+				]),
 	);
 }
+GROUPS.push(typeGroup("custom_openai_compatible"));
 
 export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoice) => void }) {
 	const [query, setQuery] = useState("");
-	const normalizedQuery = query.trim().toLowerCase();
-	const searchResults = useMemo(
-		() =>
-			normalizedQuery
-				? ALL_ENTRIES.filter((entry) => entry.searchText.includes(normalizedQuery))
-				: [],
-		[normalizedQuery],
+	const [selected, setSelected] = useState<ProviderGroup | null>(null);
+	const normalized = query.trim().toLowerCase();
+	const groups = GROUPS.filter((group) =>
+		[group.id, group.label, ...group.entries.map((entry) => `${entry.id} ${entry.label}`)]
+			.join(" ")
+			.toLowerCase()
+			.includes(normalized),
 	);
 	return (
 		<div data-hosted="true" data-v2="true" className="flex flex-col gap-3">
-			<SearchInput
-				name="provider-search"
-				ariaLabel="Search providers"
-				value={query}
-				onChange={setQuery}
-				placeholder="OpenAI, DeepSeek, Moonshot…"
-			/>
-
-			{normalizedQuery ? (
-				<div className="flex flex-col gap-2">
-					<p className="text-xs font-medium text-muted-foreground">
-						{searchResults.length > 0 ? `${searchResults.length} matches` : "No providers found"}
-					</p>
-					{searchResults.length > 0 ? (
-						<ChoiceGrid entries={searchResults} onSelect={onSelect} />
-					) : (
-						<div data-testid="provider-choice-grid" className="grid gap-1.5 sm:grid-cols-2">
-							<EntityChoiceCard
-								onClick={() => onSelect({ kind: "type", type: "custom_openai_compatible" })}
-								icon={
-									<EntityIcon
-										kind="provider"
-										id="custom_openai_compatible"
-										label="Custom endpoint"
-										size="sm"
-									/>
-								}
-								title="Use a custom endpoint"
-								description={`No matches for “${query.trim()}”. Configure it manually.`}
-								variant="compact"
-							/>
-						</div>
-					)}
-				</div>
+			{selected ? (
+				<>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							aria-label="Back to providers"
+							onClick={() => setSelected(null)}
+						>
+							<ArrowLeft />
+						</Button>
+						<EntityIcon kind="provider" id={selected.iconId} size="sm" />
+						<span className="text-sm font-medium">{selected.label}</span>
+					</div>
+					<div className="grid gap-2 sm:grid-cols-2" data-testid="provider-variant-grid">
+						{selected.entries.map((entry) => (
+							<Button
+								key={entry.id}
+								variant="outline"
+								className="h-auto min-h-11 justify-between whitespace-normal px-3 py-2 text-left"
+								onClick={() => onSelect(entry.choice)}
+							>
+								{entry.label}
+								<ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+							</Button>
+						))}
+					</div>
+				</>
 			) : (
-				<div className="flex flex-col gap-2">
-					<p className="text-xs font-medium text-muted-foreground">Providers</p>
-					<ChoiceGrid entries={ALL_ENTRIES} onSelect={onSelect} />
-				</div>
+				<>
+					<SearchInput
+						name="provider-search"
+						ariaLabel="Search providers"
+						value={query}
+						onChange={setQuery}
+						placeholder="Search providers…"
+					/>
+					<div data-testid="provider-choice-grid" className="grid grid-cols-2 gap-2">
+						{groups.map((group) => (
+							<Button
+								key={group.id}
+								variant="outline"
+								className="h-11 min-w-0 justify-start gap-2 px-3 text-left"
+								onClick={() => {
+									const first = group.entries[0];
+									if (group.entries.length === 1 && first) onSelect(first.choice);
+									else setSelected(group);
+								}}
+							>
+								<span aria-hidden="true" className="shrink-0">
+									<EntityIcon kind="provider" id={group.iconId} size="sm" />
+								</span>
+								<span className="min-w-0 flex-1 truncate">{group.label}</span>
+								{group.entries.length > 1 ? (
+									<ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+								) : null}
+							</Button>
+						))}
+					</div>
+					{!groups.length ? (
+						<div className="flex flex-col items-start gap-2">
+							<p className="text-sm text-muted-foreground">No providers found</p>
+							<Button
+								variant="outline"
+								onClick={() => onSelect({ kind: "type", type: "custom_openai_compatible" })}
+							>
+								Use a custom endpoint
+							</Button>
+						</div>
+					) : null}
+				</>
 			)}
 		</div>
 	);

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -20,7 +20,8 @@ The product has three provider kinds:
 | Custom provider | Name, Endpoint, API format, API key | The agent owns models and selection |
 | Native provider | Choose a supported provider, Name, key/token or supported sign-in | The agent owns models and selection |
 
-Native region/plan variants are distinct chooser entries, not extra form settings.
+The provider chooser groups brands; a second step selects native region, plan,
+or product variants before credential setup.
 ChatGPT sign-in remains a native credential option. Every Name is only a Clawdi
 `label`; renaming does not change stable IDs, credential identity, or runtime intent.
 Provider credential forms have no model catalog editor or inference test.


### PR DESCRIPTION
Group the provider chooser by brand instead of displaying every region and plan on the first screen. Brands with multiple options open a second selection step before the existing credential form; Kimi API/Code and OpenAI API/ChatGPT share their brand entry. Search includes variant names and native IDs.

Use compact 44px rows without repetitive credential descriptions and cap the dialog at 576px or the available viewport height. Keep existing routing, credential submission, and Managed model selection unchanged. Remove the unused description helper.

Validation: isolated Docker Web typecheck, provider unit tests, OSS build, production SSR, and Chromium provider creation flows. Existing browser coverage now checks brand grouping, second-level selection, dialog height, and mobile sizing, with screenshots reviewed.
