### PR TITLE
chore(channels): attribute slow Telegram requests by stage

### DIFF
--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -2,15 +2,19 @@
 
 Adds a cheap per-request process-time response header and logs only slow
 requests or server errors. Logs intentionally include method/path/status/time
-and request id only; query strings, headers, bodies, and user identity stay out
-of application logs.
+and request id, plus fixed channel stage timings; query strings, headers, bodies,
+and user identity stay out of application logs.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Literal, cast
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -23,6 +27,44 @@ _TELEGRAM_BOT_API_PATH_RE = re.compile(
 )
 
 
+# Wall-clock stages include event-loop waits. Initially instrumented only on the
+# Telegram Bot API proxy. Provider time includes pool waits, TCP/TLS and RTT,
+# not just provider processing. Request body arrival/parsing, response parsing
+# and result reference writes remain unattributed: the stage sum is not the
+# whole request duration.
+type ChannelStage = Literal["channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms"]
+_CHANNEL_STAGES: tuple[ChannelStage, ...] = (
+    "channel_auth_ms",
+    "channel_url_validation_ms",
+    "channel_provider_ms",
+)
+_CHANNEL_TIMING_STATE = "_channel_stage_timings"
+
+
+@contextmanager
+def channel_stage(scope: Scope, stage: ChannelStage) -> Generator[None]:
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        scope.setdefault("state", {}).setdefault(_CHANNEL_TIMING_STATE, {})[stage] = _elapsed_ms(
+            started
+        )
+
+
+def _channel_stage_log_fields(scope: Scope) -> str:
+    timings: object = scope.get("state", {}).get(_CHANNEL_TIMING_STATE)
+    if not isinstance(timings, dict):
+        return ""
+    values = cast(dict[object, object], timings)
+    fields: list[str] = []
+    for stage in _CHANNEL_STAGES:
+        value = values.get(stage)
+        if isinstance(value, float) and math.isfinite(value) and value >= 0:
+            fields.append(f" {stage}={value:.1f}")
+    return "".join(fields)
+
+
 class RequestTimingMiddleware:
     def __init__(self, app: ASGIApp, *, slow_ms: float) -> None:
         self.app = app
@@ -33,6 +75,8 @@ class RequestTimingMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # ASGI lifespan state is shallow-copied; replace the nested dict per request.
+        scope.setdefault("state", {})[_CHANNEL_TIMING_STATE] = {}
         started = time.perf_counter()
         raw_method: object = scope.get("method", "GET")
         method = raw_method if isinstance(raw_method, str) else "GET"
@@ -57,35 +101,38 @@ class RequestTimingMiddleware:
         except Exception:
             duration_ms = _elapsed_ms(started)
             logger.exception(
-                "request_failed method=%s path=%s status=500 duration_ms=%.1f request_id=%s",
+                "request_failed method=%s path=%s status=500 duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
             raise
 
         duration_ms = _elapsed_ms(started)
         if status_code >= 500:
             logger.warning(
-                "request_error method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                "request_error method=%s path=%s status=%d duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 status_code,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
         elif not _is_expected_long_request(raw_path) and _is_slow(
             duration_ms=duration_ms,
             slow_ms=self.slow_ms,
         ):
             logger.warning(
-                "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 status_code,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
 
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -29,6 +29,7 @@ from starlette.datastructures import UploadFile
 
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
+from app.middleware.request_timing import channel_stage
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
@@ -387,11 +388,12 @@ async def telegram_bot_api(
     # Read the bounded request body before checking out an auth connection.
     raw_body = await request.body()
     params = await _telegram_request_params(request)
-    agent, _agent_token = await _resolve_telegram_agent(
-        db,
-        routing_id=routing_id,
-        authorization=authorization,
-    )
+    with channel_stage(request.scope, "channel_auth_ms"):
+        agent, _agent_token = await _resolve_telegram_agent(
+            db,
+            routing_id=routing_id,
+            authorization=authorization,
+        )
     account = agent.account
     duplicate_parameter = await _telegram_duplicate_security_parameter(request, raw_body, params)
     if duplicate_parameter is not None:
@@ -2653,7 +2655,8 @@ async def _telegram_provider_response(
     translate_direct_topic: bool = False,
 ) -> httpx.Response:
     base_url = settings.channel_telegram_api_base_url.strip()
-    await _validate_telegram_provider_base_url(base_url)
+    with channel_stage(request.scope, "channel_url_validation_ms"):
+        await _validate_telegram_provider_base_url(base_url)
     url = httpx.URL(f"{base_url.rstrip('/')}/bot{provider_token}/{method}")
     headers: dict[str, str] = {}
     content_type = request.headers.get("content-type")
@@ -2670,7 +2673,10 @@ async def _telegram_provider_response(
     if query_string:
         url = url.copy_with(query=query_string)
     try:
-        with track_proxy_latency("telegram", method):
+        with (
+            track_proxy_latency("telegram", method),
+            channel_stage(request.scope, "channel_provider_ms"),
+        ):
             response = await get_channel_provider_http_client().request(
                 request.method,
                 url,

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -137,3 +137,138 @@ async def test_request_timing_does_not_warn_for_successful_long_request(
     )
 
     assert caplog.text == ""
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_event", "expected_stages"),
+    [
+        ("slow", "request_slow", (11, 23, 37)),
+        ("fast", None, (11, 23, 37)),
+        ("auth_error", "request_error", (11, None, None)),
+        ("validation_failure", "request_failed", (11, 23, None)),
+        ("provider_error", "request_error", (11, 23, 37)),
+        ("cancel", None, (11, 23, 37)),
+    ],
+)
+async def test_telegram_route_stage_timings(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    outcome: str,
+    expected_event: str | None,
+    expected_stages: tuple[int | None, ...],
+):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    import httpx
+    from fastapi import FastAPI, HTTPException
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.core.database import get_session
+    from app.middleware import request_timing
+    from app.routes.channel_routers import telegram
+
+    elapsed = 0.0
+    monkeypatch.setattr(request_timing.time, "perf_counter", lambda: elapsed)
+    db = AsyncMock(spec=AsyncSession)
+    account = SimpleNamespace(
+        id=uuid4(), encrypted_provider_token="encrypted", provider_token_nonce="nonce"
+    )
+
+    async def resolve(*_args, **_kwargs):
+        nonlocal elapsed
+        elapsed += 0.011
+        if outcome == "auth_error":
+            raise HTTPException(500, "test auth failure")
+        return SimpleNamespace(account=account, link=SimpleNamespace(id=uuid4())), "token"
+
+    async def validate(_url):
+        nonlocal elapsed
+        elapsed += 0.023
+        if outcome == "validation_failure":
+            raise RuntimeError("test validation failure")
+
+    async def provider(request: httpx.Request) -> httpx.Response:
+        nonlocal elapsed
+        db.rollback.assert_awaited_once()
+        elapsed += 0.037
+        if outcome == "provider_error":
+            raise httpx.ConnectError("test connection failure")
+        if outcome == "cancel":
+            raise asyncio.CancelledError
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    monkeypatch.setattr(telegram, "_resolve_telegram_agent", resolve)
+    monkeypatch.setattr(telegram, "_validate_telegram_provider_base_url", validate)
+    monkeypatch.setattr(telegram, "decrypt_provider_token", lambda _account: "provider-secret")
+    app = FastAPI()
+    app.include_router(telegram.router, prefix="/v1")
+    app.dependency_overrides[get_session] = lambda: db
+    scope = _scope(path="/v1/channels/telegram/botrouting-secret/getMe")
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(provider)) as upstream:
+        monkeypatch.setattr(telegram, "get_channel_provider_http_client", lambda: upstream)
+        timed = RequestTimingMiddleware(app, slow_ms=100 if outcome == "fast" else 50)
+        if outcome == "validation_failure":
+            with pytest.raises(RuntimeError, match="test validation failure"):
+                await _collect(timed, scope)
+        elif outcome == "cancel":
+            with pytest.raises(asyncio.CancelledError):
+                await _collect(timed, scope)
+        else:
+            messages = await _collect(timed, scope)
+            assert messages[0]["status"] == (
+                500 if outcome == "auth_error" else 502 if outcome == "provider_error" else 200
+            )
+
+    stages = ("channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms")
+    timings = scope["state"]["_channel_stage_timings"]
+    assert timings == pytest.approx(
+        {stage: value for stage, value in zip(stages, expected_stages) if value is not None}
+    )
+    records = [r.getMessage() for r in caplog.records if r.name == request_timing.__name__]
+    if expected_event is None:
+        assert records == []
+    else:
+        assert len(records) == 1
+        assert records[0].startswith(expected_event + " ")
+        for stage, value in zip(stages, expected_stages):
+            if value is None:
+                assert stage not in records[0]
+            else:
+                assert f"{stage}={value:.1f}" in records[0]
+        assert "bot[redacted]/getMe" in records[0]
+    assert "routing-secret" not in caplog.text
+    assert "provider-secret" not in caplog.text
+    assert "secret=value" not in caplog.text
+
+
+async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
+    from app.middleware.request_timing import _CHANNEL_TIMING_STATE
+
+    inherited = {"channel_auth_ms": 999.0}
+    scope = _scope()
+    scope["state"][_CHANNEL_TIMING_STATE] = inherited
+
+    async def inner(scope: Scope, _receive: Receive, send: Send) -> None:
+        timings = scope["state"][_CHANNEL_TIMING_STATE]
+        assert timings == {}
+        assert timings is not inherited
+        timings.update(
+            channel_auth_ms=float("nan"),
+            channel_url_validation_ms=float("inf"),
+            channel_provider_ms="secret",
+            unknown="secret",
+        )
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    await _collect(RequestTimingMiddleware(inner, slow_ms=750), scope)
+    assert "request_error" in caplog.text
+    assert "channel_" not in caplog.text
+    assert "unknown" not in caplog.text
+    assert "secret" not in caplog.text
+    assert inherited == {"channel_auth_ms": 999.0}


### PR DESCRIPTION
Slow Telegram Bot API requests currently expose only total duration, so individual slow samples cannot distinguish authorization, URL validation, and upstream HTTP time. Append three fixed wall-clock stage durations to existing slow/error logs, including stages that fail; retain request isolation, token redaction, and successful long-poll suppression.

This adds attribution, not a claimed speedup. The provider stage includes connection-pool waits and network time; body reading, parsing, and response processing are outside these stages. No new success logs, payload fields, headers, dependencies, or security shortcuts.

Validation: isolated Python 3.14.7/PostgreSQL runner, 147 passed (306 deselected); Ruff lint/format passed; owned typing checked 216 files with zero errors or warnings. Real router/middleware tests cover fast/slow requests, partial failures, cancellation, redaction, and request-state isolation. Root and independent Fable review passed. Rebased onto current main; the tested backend tree is unchanged.

Integrated through #1458 at commit `69f7ad493693c11deead97d56c4747e10201edda`.
