### PR TITLE
fix(channels): isolate webhook fallback retry backoff per binding

### DIFF
--- a/backend/alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py
+++ b/backend/alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py
@@ -1,0 +1,32 @@
+"""Persist Telegram webhook fallback backoff per Binding."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a6d9c2e4f7b1"
+down_revision = "9b3e2a71c640"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("channel_bindings", sa.Column("webhook_retry_at", sa.DateTime(timezone=True)))
+    op.add_column(
+        "channel_bindings",
+        sa.Column("webhook_retry_step", sa.SmallInteger(), nullable=False, server_default="0"),
+    )
+    op.create_check_constraint(
+        "ck_channel_bindings_webhook_retry_step_nonnegative",
+        "channel_bindings",
+        "webhook_retry_step >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_channel_bindings_webhook_retry_step_nonnegative",
+        "channel_bindings",
+        type_="check",
+    )
+    op.drop_column("channel_bindings", "webhook_retry_step")
+    op.drop_column("channel_bindings", "webhook_retry_at")

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Index,
     Integer,
     LargeBinary,
+    SmallInteger,
     String,
     Text,
     UniqueConstraint,
@@ -361,8 +362,16 @@ class ChannelBinding(Base, TimestampMixin):
         default=BINDING_STATUS_ACTIVE,
         server_default=BINDING_STATUS_ACTIVE,
     )
+    webhook_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    webhook_retry_step: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0, server_default="0"
+    )
 
     __table_args__ = (
+        CheckConstraint(
+            "webhook_retry_step >= 0",
+            name="ck_channel_bindings_webhook_retry_step_nonnegative",
+        ),
         Index(
             "uq_channel_bindings_account_external_chat_active",
             "account_id",

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -1067,7 +1067,11 @@ async def _deliver_telegram_agent_webhook_for_binding(
         link=current_link,
     ):
         return False
-    return await deliver_telegram_agent_webhook(current_link, payload)
+    delivered = await deliver_telegram_agent_webhook(current_link, payload)
+    if delivered:
+        current_binding.webhook_retry_at = None
+        current_binding.webhook_retry_step = 0
+    return delivered
 
 
 async def _validate_telegram_webhook_url(url: str) -> JSONResponse | None:

--- a/backend/app/services/channel_webhook_delivery_worker.py
+++ b/backend/app/services/channel_webhook_delivery_worker.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
@@ -49,10 +50,19 @@ class ChannelWebhookDeliveryWorker:
         backoff_cap_seconds: float = 60.0,
         ttl_seconds: int = int(TELEGRAM_UPDATE_RETENTION.total_seconds()),
     ) -> None:
+        if not (
+            math.isfinite(backoff_base_seconds)
+            and math.isfinite(backoff_cap_seconds)
+            and 0 < backoff_base_seconds <= backoff_cap_seconds
+        ):
+            raise ValueError("webhook backoff must be finite, positive, and capped above its base")
         self._sessionmaker = sessionmaker
         self._poll_interval_seconds = poll_interval_seconds
         self._backoff_base_seconds = backoff_base_seconds
         self._backoff_cap_seconds = backoff_cap_seconds
+        self._max_retry_step = (
+            math.ceil(math.log2(backoff_cap_seconds) - math.log2(backoff_base_seconds)) + 1
+        )
         self._ttl = timedelta(seconds=ttl_seconds)
 
     async def run_once(self) -> ChannelWebhookDeliveryResult | None:
@@ -61,14 +71,27 @@ class ChannelWebhookDeliveryWorker:
             if candidate is None:
                 await db.rollback()
                 return None
-            message, account, link = candidate
+            message, account, link, binding = candidate
             result = await self._deliver_message(db, message, account, link)
+            if result.delivered or result.expired:
+                binding.webhook_retry_at = None
+                binding.webhook_retry_step = 0
+            else:
+                binding.webhook_retry_step = min(
+                    binding.webhook_retry_step + 1, self._max_retry_step
+                )
+                delay = (
+                    self._backoff_cap_seconds
+                    if binding.webhook_retry_step == self._max_retry_step
+                    else math.ldexp(self._backoff_base_seconds, binding.webhook_retry_step - 1)
+                )
+                binding.webhook_retry_at = datetime.now(UTC) + timedelta(seconds=delay)
             await db.commit()
             return result
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
-        backoff = self._backoff_base_seconds
+        error_backoff = self._backoff_base_seconds
         while not stop_event.is_set():
             try:
                 result = await self.run_once()
@@ -76,23 +99,20 @@ class ChannelWebhookDeliveryWorker:
                 raise
             except Exception as exc:  # noqa: BLE001 - worker must survive one bad webhook.
                 log.exception("channel webhook delivery worker failed: %s", exc)
-                result = None
+                await _sleep_until_stop(stop_event, error_backoff)
+                error_backoff = min(error_backoff * 2, self._backoff_cap_seconds)
+                continue
 
+            error_backoff = self._backoff_base_seconds
             if result is None:
                 await _sleep_until_stop(stop_event, self._poll_interval_seconds)
-                continue
-            if result.delivered or result.expired:
-                backoff = self._backoff_base_seconds
-                continue
-            await _sleep_until_stop(stop_event, backoff)
-            backoff = min(backoff * 2, self._backoff_cap_seconds)
 
     async def _claim_next_telegram_webhook_message(
         self,
         db: AsyncSession,
-    ) -> tuple[ChannelMessage, ChannelAccount, ChannelBotAgentLink] | None:
+    ) -> tuple[ChannelMessage, ChannelAccount, ChannelBotAgentLink, ChannelBinding] | None:
         result = await db.execute(
-            select(ChannelMessage, ChannelAccount, ChannelBotAgentLink)
+            select(ChannelMessage, ChannelAccount, ChannelBotAgentLink, ChannelBinding)
             .join(
                 ChannelBinding,
                 ChannelBinding.id == ChannelMessage.binding_id,
@@ -112,6 +132,10 @@ class ChannelWebhookDeliveryWorker:
                 ChannelBinding.account_id == ChannelMessage.account_id,
                 ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
                 ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                or_(
+                    ChannelBinding.webhook_retry_at.is_(None),
+                    ChannelBinding.webhook_retry_at <= datetime.now(UTC),
+                ),
                 ChannelAccount.provider == CHANNEL_PROVIDER_TELEGRAM,
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
@@ -141,8 +165,8 @@ class ChannelWebhookDeliveryWorker:
         row = result.first()
         if row is None:
             return None
-        message, account, link = row
-        return message, account, link
+        message, account, link, binding = row
+        return message, account, link, binding
 
     async def _deliver_message(
         self,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1897,6 +1897,9 @@ async def get_or_create_binding(
         if candidate_name is not None and candidate_name != external_chat_id:
             binding.external_chat_name = candidate_name
         binding.paired_external_user_id = external_user_id
+        if binding.status != BINDING_STATUS_ACTIVE:
+            binding.webhook_retry_at = None
+            binding.webhook_retry_step = 0
         binding.status = BINDING_STATUS_ACTIVE
         await db.execute(
             update(ChannelBindingAlias)
@@ -3217,6 +3220,9 @@ async def consume_pending_inbound_messages_for_bindings(
     bindings: list[ChannelBinding],
 ) -> int:
     """Revoke queued adapter delivery when binding authority is archived."""
+    for binding in bindings:
+        binding.webhook_retry_at = None
+        binding.webhook_retry_step = 0
     binding_ids = {binding.id for binding in bindings}
     if not binding_ids:
         return 0

--- a/backend/tests/test_channel_webhook_retry.py
+++ b/backend/tests/test_channel_webhook_retry.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models.channel import ChannelBinding, ChannelMessage
+from app.models.hosted_runtime import HostedRuntimeState
+from app.services import channel_webhook_delivery_worker as worker_module
+from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
+from tests.test_channels import (
+    _create_paired_telegram_channel,
+    _pair_telegram_chat,
+    _telegram_agent_headers,
+    _telegram_bot_path,
+)
+
+pytestmark = pytest.mark.committed_db
+
+
+@pytest_asyncio.fixture
+async def webhook_queue(client, db_session, engine, channel_agent, second_channel_agent):
+    channels = []
+    bindings = []
+    for name, agent in (("a", channel_agent), ("b", second_channel_agent)):
+        channel = await _create_paired_telegram_channel(
+            client,
+            name=f"retry-{name}",
+            provider_token=None,
+            agent_id=agent.id,
+        )
+        # Enqueue before setWebhook so the fixture does not make inline HTTP calls.
+        for index in range(2 if name == "a" else 1):
+            response = await client.post(
+                f"/v1/channels/telegram/{channel['id']}/webhook",
+                headers={"x-telegram-bot-api-secret-token": channel["webhook_secret"]},
+                json={
+                    "update_id": 100 + index,
+                    "message": {
+                        "message_id": 100 + index,
+                        "text": f"{name}{index}",
+                        "chat": {"id": 42, "type": "private"},
+                    },
+                },
+            )
+            assert response.status_code == 200, response.text
+        response = await client.post(
+            _telegram_bot_path(channel, "setWebhook"),
+            headers=_telegram_agent_headers(channel),
+            json={"url": f"https://{name}.example/hook"},
+        )
+        assert response.status_code == 200, response.text
+        binding = await db_session.scalar(
+            select(ChannelBinding).where(ChannelBinding.account_id == UUID(channel["id"]))
+        )
+        bindings.append(binding.id)
+        channels.append(channel)
+    await db_session.rollback()
+    return async_sessionmaker(engine, expire_on_commit=False), bindings, channels
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    class Provider:
+        calls = []
+        fail_a = True
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        failed = asyncio.Event()
+        delivered_b = asyncio.Event()
+        block_a = False
+        failure_returned_at = None
+        b_called_at = None
+
+        def __init__(self, **_kwargs):
+            pass
+
+        async def post(self, url, **kwargs):
+            text = kwargs["json"]["message"]["text"]
+            self.calls.append((url, text))
+            if text.startswith("a"):
+                self.entered.set()
+                if self.block_a:
+                    await self.release.wait()
+                if self.fail_a:
+                    Provider.failure_returned_at = time.perf_counter()
+                    self.failed.set()
+                    return httpx.Response(503)
+            else:
+                Provider.b_called_at = time.perf_counter()
+                self.delivered_b.set()
+            return httpx.Response(200)
+
+    monkeypatch.setattr("app.services.channel_webhooks.SafePublicHttpClient", Provider)
+    return Provider
+
+
+async def make_due(factory, binding_id):
+    async with factory() as db:
+        await db.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == binding_id)
+            .values(webhook_retry_at=datetime.now(UTC) - timedelta(seconds=1))
+        )
+        await db.commit()
+
+
+async def test_failed_binding_does_not_sleep_before_healthy_binding(webhook_queue, provider):
+    factory, bindings, _ = webhook_queue
+    stop = asyncio.Event()
+    task = asyncio.create_task(ChannelWebhookDeliveryWorker(factory).run_forever(stop))
+    try:
+        await asyncio.wait_for(provider.failed.wait(), 2)
+        # Start the bound after A returns, not when B was enqueued. Serial HTTP
+        # can still block B for the entire duration of A's in-flight request.
+        await asyncio.wait_for(provider.delivered_b.wait(), 0.75)
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, 2)
+    assert [text for _, text in provider.calls] == ["a0", "b0"]
+    print(f"B called {provider.b_called_at - provider.failure_returned_at:.6f}s after A failure")
+    # A newly constructed worker respects the committed cooldown as well.
+    assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+    await make_due(factory, bindings[0])
+    provider.fail_a = False
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert (await worker.run_once()).delivered
+    assert (await worker.run_once()).delivered
+    assert [text for _, text in provider.calls] == ["a0", "b0", "a0", "a1"]
+    async with factory() as db:
+        binding = await db.get(ChannelBinding, bindings[0])
+        assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+
+
+async def test_retry_steps_persist_and_cap_without_retrying_early(
+    webhook_queue, provider, monkeypatch
+):
+    factory, bindings, _ = webhook_queue
+    now = datetime.now(UTC)
+
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    monkeypatch.setattr(worker_module, "datetime", Clock)
+    for index, seconds in enumerate((1, 2, 4, 8, 16, 32, 60, 60)):
+        worker = ChannelWebhookDeliveryWorker(factory)
+        assert not (await worker.run_once()).delivered
+        if index == 0:
+            assert (await worker.run_once()).delivered  # Drain independent B.
+        async with factory() as db:
+            binding = await db.get(ChannelBinding, bindings[0])
+            assert binding.webhook_retry_step == min(index + 1, 7)
+            assert binding.webhook_retry_at == now + timedelta(seconds=seconds)
+        now += timedelta(seconds=seconds, microseconds=-1)
+        assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+        now += timedelta(microseconds=1)
+    assert [text for _, text in provider.calls].count("a0") == 8
+    assert not any(text == "a1" for _, text in provider.calls)
+
+
+async def test_two_workers_skip_the_entire_locked_binding(webhook_queue, provider):
+    factory, _, _ = webhook_queue
+    provider.block_a = True
+    first = asyncio.create_task(ChannelWebhookDeliveryWorker(factory).run_once())
+    try:
+        await asyncio.wait_for(provider.entered.wait(), 2)
+        second = ChannelWebhookDeliveryWorker(factory)
+        assert (await asyncio.wait_for(second.run_once(), 1)).delivered
+        assert await asyncio.wait_for(second.run_once(), 1) is None
+        assert [text for _, text in provider.calls] == ["a0", "b0"]
+    finally:
+        provider.release.set()
+        assert not (await asyncio.wait_for(first, 2)).delivered
+
+
+@pytest.mark.parametrize("terminal", ["ttl", "authority", "inline", "retirement"])
+async def test_retry_state_clears_on_terminal_outcomes(
+    webhook_queue,
+    provider,
+    client,
+    terminal,
+    db_session,
+    seed_user,
+):
+    factory, bindings, channels = webhook_queue
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert not (await worker.run_once()).delivered
+    if terminal in {"ttl", "authority"}:
+        await make_due(factory, bindings[0])
+        async with factory() as db:
+            if terminal == "ttl":
+                await db.execute(
+                    update(ChannelMessage)
+                    .where(ChannelMessage.binding_id == bindings[0])
+                    .values(created_at=datetime.now(UTC) - timedelta(days=2))
+                )
+            else:
+                # A real persisted authority mismatch, not a mocked predicate.
+                state = await db.get(HostedRuntimeState, UUID(channels[0]["agent_id"]))
+                state.deployment_id = "retired-authority"
+            await db.commit()
+        assert (await worker.run_once()).expired
+        assert len(provider.calls) == 1
+    else:
+        provider.fail_a = False
+        response = await client.post(
+            f"/v1/channels/telegram/{channels[0]['id']}/webhook",
+            headers={"x-telegram-bot-api-secret-token": channels[0]["webhook_secret"]},
+            json={
+                "update_id": 200,
+                "message": {
+                    "message_id": 200,
+                    "text": "a-inline" if terminal == "inline" else "/clawdi_unpair",
+                    "chat": {"id": 42, "type": "private"},
+                    "from": {"id": 4242, "is_bot": False},
+                },
+            },
+        )
+        assert response.status_code == 200, response.text
+    async with factory() as db:
+        binding = await db.get(ChannelBinding, bindings[0])
+        assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+        if terminal == "retirement":
+            assert binding.status == "archived"
+            # Historical rows may still carry state. Reactivation must reset it.
+            binding.webhook_retry_at = datetime.now(UTC) + timedelta(seconds=60)
+            binding.webhook_retry_step = 7
+            await db.commit()
+    if terminal == "retirement":
+        await db_session.refresh(seed_user)
+        await _pair_telegram_chat(client, created=channels[0], chat_id="42", update_id=201)
+        async with factory() as db:
+            binding = await db.get(ChannelBinding, bindings[0])
+            assert binding.status == "active"
+            assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+
+
+async def test_webhook_reconfiguration_keeps_cooldown_without_waiting_for_binding(
+    webhook_queue,
+    provider,
+    client,
+):
+    factory, bindings, channels = webhook_queue
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert not (await worker.run_once()).delivered
+    assert (await worker.run_once()).delivered
+    channel = channels[0]
+    async with factory() as locked_db:
+        binding = await locked_db.scalar(
+            select(ChannelBinding).where(ChannelBinding.id == bindings[0]).with_for_update()
+        )
+        original_retry = binding.webhook_retry_at
+        for method, body in (
+            ("deleteWebhook", {}),
+            ("setWebhook", {"url": "https://new.example/hook"}),
+        ):
+            response = await asyncio.wait_for(
+                client.post(
+                    _telegram_bot_path(channel, method),
+                    headers=_telegram_agent_headers(channel),
+                    json=body,
+                ),
+                1,
+            )
+            assert response.status_code == 200, response.text
+        await locked_db.refresh(binding)
+        assert binding.webhook_retry_at == original_retry
+        assert binding.webhook_retry_step == 1
+    info = await client.get(
+        _telegram_bot_path(channel, "getWebhookInfo"), headers=_telegram_agent_headers(channel)
+    )
+    assert info.json()["result"]["url"] == "https://new.example/hook"
+    assert info.json()["result"]["pending_update_count"] == 2
+    assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+    await make_due(factory, bindings[0])
+    provider.fail_a = False
+    assert (await worker.run_once()).delivered
+    assert provider.calls[-1] == ("https://new.example/hook", "a0")
+
+
+async def test_infrastructure_errors_back_off_and_stop(monkeypatch):
+    worker = ChannelWebhookDeliveryWorker(None)
+    stop = asyncio.Event()
+    waits = []
+
+    async def unavailable():
+        raise RuntimeError("synthetic database outage")
+
+    async def wait(event, seconds):
+        waits.append(seconds)
+        if len(waits) == 8:
+            event.set()
+
+    monkeypatch.setattr(worker, "run_once", unavailable)
+    monkeypatch.setattr(worker_module, "_sleep_until_stop", wait)
+    await worker.run_forever(stop)
+    assert waits == [1, 2, 4, 8, 16, 32, 60, 60]

--- a/backend/tests/test_channel_webhook_retry_migration.py
+++ b/backend/tests/test_channel_webhook_retry_migration.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from app.models.channel import ChannelBinding
+
+
+def test_webhook_retry_migration_defaults_constraint_and_downgrade(engine):
+    path = (
+        Path(__file__).parents[1]
+        / "alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py"
+    )
+    spec = importlib.util.spec_from_file_location("webhook_retry_migration", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    sync_engine = sa.create_engine(engine.url.set(drivername="postgresql+psycopg2"))
+    schema = f"webhook_retry_{uuid4().hex}"
+    try:
+        with sync_engine.begin() as connection:
+            # Compare the migrated real application table to the ORM contract.
+            columns = {
+                column["name"]: column
+                for column in sa.inspect(connection).get_columns("channel_bindings")
+            }
+            for name in ("webhook_retry_at", "webhook_retry_step"):
+                assert columns[name]["nullable"] == ChannelBinding.__table__.c[name].nullable
+                assert columns[name]["type"].compile(
+                    dialect=connection.dialect
+                ) == ChannelBinding.__table__.c[name].type.compile(dialect=connection.dialect)
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET LOCAL search_path TO "{schema}"'))
+            connection.execute(sa.text("CREATE TABLE channel_bindings (id integer PRIMARY KEY)"))
+            connection.execute(sa.text("INSERT INTO channel_bindings VALUES (1)"))
+            migration.op = Operations(MigrationContext.configure(connection))
+            migration.upgrade()
+            assert connection.execute(
+                sa.text(
+                    "SELECT webhook_retry_at, webhook_retry_step FROM channel_bindings WHERE id = 1"
+                )
+            ).one() == (None, 0)
+            with pytest.raises(sa.exc.IntegrityError), connection.begin_nested():
+                connection.execute(sa.text("UPDATE channel_bindings SET webhook_retry_step = -1"))
+            connection.execute(
+                sa.text(
+                    "UPDATE channel_bindings SET webhook_retry_step = 7, webhook_retry_at = now()"
+                )
+            )
+            migration.downgrade()
+            assert [
+                column["name"]
+                for column in sa.inspect(connection).get_columns("channel_bindings", schema=schema)
+            ] == ["id"]
+            assert connection.scalar(sa.text("SELECT id FROM channel_bindings")) == 1
+            migration.upgrade()
+            assert connection.execute(
+                sa.text("SELECT webhook_retry_at, webhook_retry_step FROM channel_bindings")
+            ).one() == (None, 0)
+            connection.execute(sa.text(f'DROP SCHEMA "{schema}" CASCADE'))
+    finally:
+        sync_engine.dispose()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -9470,9 +9470,16 @@ async def test_telegram_webhook_worker_retries_failed_agent_delivery(
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     worker = ChannelWebhookDeliveryWorker(sessionmaker)
-    first_result = await worker.run_once()
-    second_result = await worker.run_once()
-    result = await worker.run_once()
+    results = []
+    for _ in range(3):
+        await db_session.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == message.binding_id)
+            .values(webhook_retry_at=None)
+        )
+        await db_session.commit()
+        results.append(await worker.run_once())
+    first_result, second_result, result = results
     await db_session.refresh(message)
 
     assert first_result is not None
@@ -9653,9 +9660,16 @@ async def test_telegram_webhook_worker_skips_non_webhook_queue_head(
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     worker = ChannelWebhookDeliveryWorker(sessionmaker)
-    first_result = await worker.run_once()
-    second_result = await worker.run_once()
-    result = await worker.run_once()
+    results = []
+    for _ in range(3):
+        await db_session.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == webhook_message.binding_id)
+            .values(webhook_retry_at=None)
+        )
+        await db_session.commit()
+        results.append(await worker.run_once())
+    first_result, second_result, result = results
     await db_session.refresh(webhook_message)
 
     assert first_result is not None

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -505,9 +505,18 @@ Required behavior:
   `.local`/`.localhost` names, private DNS results, and unresolved DNS names
   are rejected.
 - Telegram webhook delivery only acknowledges messages after a successful
-  `2xx` or `3xx` response. Telegram makes one inline delivery attempt and
+  `2xx` response. Telegram makes one inline delivery attempt and
   leaves `5xx`, network, `4xx`, and DNS failures pending for
-  `ChannelWebhookDeliveryWorker` retry or TTL drop.
+  `ChannelWebhookDeliveryWorker` retry or TTL drop. Fallback failures defer only
+  their Binding using persisted retry steps (1, 2, 4, 8, 16, 32, then 60 seconds).
+  Other due Bindings remain eligible after the failed HTTP attempt returns;
+  delivery remains serial, so an in-flight request can still delay them.
+  Success, TTL/authority consumption, retirement, and reactivation clear retry
+  state. Inline ingress still attempts
+  delivery separately; this does not guarantee ordering across both paths.
+  `setWebhook`/`deleteWebhook` do not reset Binding cooldowns: a replacement URL
+  may inherit up to 60 seconds of the previous cooldown, plus the worker's
+  polling interval. Configuration updates do not wait for Binding delivery locks.
 
 ## Message Routing Model
 


### PR DESCRIPTION
When one Telegram webhook keeps failing, the fallback worker repeatedly selects its oldest message and applies a global retry sleep, preventing healthy Bindings from making progress. Persist the retry deadline and capped backoff step on each Binding under its existing row lock, allowing other due Bindings to run after a failed attempt returns.

Success, expiry, authority consumption, retirement, reactivation, and successful inline delivery clear retry state. Infrastructure errors retain global bounded backoff. Delivery stays serial; this fixes fallback fairness, not current synchronous getMe latency or end-to-end ordering. Webhook reconfiguration retains cooldown without acquiring additional Binding locks. Includes an additive two-column migration and reversible downgrade.

Validation: 45 focused tests passed in isolated Python 3.14.7/PostgreSQL 18.4, covering independent progress, exact backoff saturation, restart persistence, concurrent workers, lifecycle resets, and migration roundtrip. The synthetic healthy destination was attempted 13.7 ms after the failing destination returned; before the fix it received no attempts during 3.509 seconds. This is a bounded fixture observation, not a production speedup claim. Ruff, scoped typing, dependency/outbound governance, and generated-client checks passed. Root and independent Fable reviewed the actual diff.

Integrated through #1458 at commit `69f7ad493693c11deead97d56c4747e10201edda`.
