### PR TITLE
release(cli): publish 0.14.63 managed Hermes wait budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- CLI 0.14.63 lets Hermes wait up to 20 minutes for Clawdi AI Responses calls,
+  preserving explicit timeout settings and withdrawing the default when switching
+  to a self-managed provider.
 - Native Hermes API-key connections now support older credential-pool APIs while
   preserving personal credentials and native key-rotation behavior.
 

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.62",
+      "version": "0.14.63",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -343,6 +343,15 @@ all generated provider fields, so removed models do not survive. Generic and
 BYOK projection leaves Hermes' discovery default unchanged. Hermes has no
 OpenClaw-style global `models.mode` switch.
 
+This provider catalog behavior is verified against Hermes `0.19.1`, source commit
+[`cc4cab2f`](https://github.com/NousResearch/hermes-agent/tree/cc4cab2f592e60a197e796506de9168f74baf3ea):
+[`model_switch.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/model_switch.py#L2613-L2658)
+and its custom-provider path
+[`model_switch.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/model_switch.py#L2791-L2942)
+probe `/models` by default but honor `discover_models: false`;
+[`config.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/config.py#L1310-L1321)
+accepts that provider field.
+
 When the manifest selects an enabled Hermes runtime's Clawdi-managed Responses
 provider (`managed_by: clawdi`), the CLI defaults
 `HERMES_API_CALL_STALE_TIMEOUT=1200` in its generated gateway and dashboard
@@ -372,15 +381,6 @@ that namespace. The service environment avoids adding a bogus provider.
 
 Done: `scripts/test.sh cli src/runtime/manifest-services.test.ts` verifies managed
 selection, repeat convergence, explicit values and BYO withdrawal.
-
-The provider catalog behavior above is verified against Hermes `0.19.1`, source commit
-[`cc4cab2f`](https://github.com/NousResearch/hermes-agent/tree/cc4cab2f592e60a197e796506de9168f74baf3ea):
-[`model_switch.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/model_switch.py#L2613-L2658)
-and its custom-provider path
-[`model_switch.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/model_switch.py#L2791-L2942)
-probe `/models` by default but honor `discover_models: false`;
-[`config.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/config.py#L1310-L1321)
-accepts that provider field.
 
 For explicit catalog connections, OpenClaw Hosted provider convergence uses the public
 `openclaw/plugin-sdk/config-mutation` export. The mutation starts from authored

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -343,7 +343,37 @@ all generated provider fields, so removed models do not survive. Generic and
 BYOK projection leaves Hermes' discovery default unchanged. Hermes has no
 OpenClaw-style global `models.mode` switch.
 
-This behavior is verified against Hermes `0.19.1`, source commit
+When the manifest selects an enabled Hermes runtime's Clawdi-managed Responses
+provider (`managed_by: clawdi`), the CLI defaults
+`HERMES_API_CALL_STALE_TIMEOUT=1200` in its generated gateway and dashboard
+service environments. Explicit `run.env` / service `env` or `secretEnv` values
+win. Hermes also gives explicit provider/model timeout config and the user's
+`.hermes/.env` precedence. Generated run files and service environments retract
+the default on a manifest switch to BYO, without editing user config or `.env`.
+Provider names, gateway hostnames and merely running on hosted compute do not
+identify Clawdi AI; no additional manifest policy field is needed.
+
+The 1200-second scalar is the maximum native Codex context stale floor, not
+dynamic equivalence. Hermes
+[`9e6c4100` watchdogs](https://github.com/NousResearch/hermes-agent/blob/9e6c4100cbf5222fb473ecc2b51fd17874f6ee75/agent/chat_completion_helpers.py)
+use 600/900/1200 seconds above 10k/50k/100k context tokens for native Codex.
+The 1500-second native hard ceiling is not a stale baseline. The CLI leaves the
+normal 1800-second request budget, Responses TTFB/event-idle settings, auth,
+reasoning, retries, model capabilities and UI streaming defaults unchanged.
+The user dotenv precedence is verified in
+[`env_loader.py`](https://github.com/NousResearch/hermes-agent/blob/9e6c4100cbf5222fb473ecc2b51fd17874f6ee75/hermes_cli/env_loader.py#L349).
+
+This default follows the manifest-selected deployment: a local/session-only
+switch to another provider before authoritative manifest convergence shares
+the service default for all models. Hermes collapses named custom profiles to
+runtime provider `custom`; writing timeout-only `providers.custom` entries is
+unsafe because its model-selection and provider metadata readers also consume
+that namespace. The service environment avoids adding a bogus provider.
+
+Done: `scripts/test.sh cli src/runtime/manifest-services.test.ts` verifies managed
+selection, repeat convergence, explicit values and BYO withdrawal.
+
+The provider catalog behavior above is verified against Hermes `0.19.1`, source commit
 [`cc4cab2f`](https://github.com/NousResearch/hermes-agent/tree/cc4cab2f592e60a197e796506de9168f74baf3ea):
 [`model_switch.py`](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/model_switch.py#L2613-L2658)
 and its custom-provider path

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.62",
+	"version": "0.14.63",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -191,6 +191,7 @@ export function resolveRuntimeRunConfigs(input: {
 	const { placeholderEnv, configEnv, secretEnv: providerSecretEnv } = providerEnvironment;
 	const providerPlaceholderEnv = { ...placeholderEnv, ...configEnv };
 	const runtimeRunSettings = resolvedRuntimeSettings(
+		input.manifest,
 		runtimeName,
 		input.runtime.run,
 		providerPlaceholderEnv,

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -160,7 +160,6 @@ function withHermesManagedAiDefaults(
 		runtime !== "hermes" ||
 		!desired?.enabled ||
 		!providerId ||
-		!desired.provider_ids?.includes(providerId) ||
 		provider?.managed_by !== "clawdi" ||
 		provider.status === "error" ||
 		provider.apiMode !== "openai_responses" ||

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -125,17 +125,55 @@ export function resolvedRuntimeServiceSettings(
 	settings: RuntimeRunSettings,
 	providerEnv: Record<string, string>,
 ): RuntimeRunSettings {
-	const merged = mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv, service);
+	const merged = mergeRuntimeEnvWithProviderPlaceholders(
+		runtime,
+		withHermesManagedAiDefaults(manifest, runtime, settings) ?? settings,
+		providerEnv,
+		service,
+	);
 	return runtime === "hermes" && service === "dashboard"
 		? (withHermesDashboardAuthEnvironment(manifest, merged) ?? merged)
 		: merged;
 }
 export function resolvedRuntimeSettings(
+	manifest: RuntimeManifest,
 	runtime: string,
 	settings: RuntimeRunSettings | undefined,
 	providerEnv: Record<string, string>,
 ): RuntimeRunSettings | undefined {
-	return mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv);
+	return mergeRuntimeEnvWithProviderPlaceholders(
+		runtime,
+		withHermesManagedAiDefaults(manifest, runtime, settings),
+		providerEnv,
+	);
+}
+
+function withHermesManagedAiDefaults(
+	manifest: RuntimeManifest,
+	runtime: string,
+	settings: RuntimeRunSettings | undefined,
+): RuntimeRunSettings | undefined {
+	const desired = manifest.runtimes[runtime];
+	const providerId = desired?.primary_model?.provider_id;
+	const provider = providerId ? manifest.projection?.providers?.[providerId] : undefined;
+	if (
+		runtime !== "hermes" ||
+		!desired?.enabled ||
+		!providerId ||
+		!desired.provider_ids?.includes(providerId) ||
+		provider?.managed_by !== "clawdi" ||
+		provider.status === "error" ||
+		provider.apiMode !== "openai_responses" ||
+		settings?.secretEnv?.HERMES_API_CALL_STALE_TIMEOUT !== undefined
+	)
+		return settings;
+	return {
+		...settings,
+		prependPath: settings?.prependPath ?? [],
+		// Maximum native Codex context floor, not a dynamic-policy equivalent.
+		// Hermes provider/model config and its user .env still take precedence.
+		env: { HERMES_API_CALL_STALE_TIMEOUT: "1200", ...settings?.env },
+	};
 }
 export function mergeRuntimeSecretEnv(
 	runtimeName: string,

--- a/packages/cli/src/runtime/manifest-runtime-state.ts
+++ b/packages/cli/src/runtime/manifest-runtime-state.ts
@@ -135,12 +135,6 @@ export function runtimeProgramRevisionForManifest(
 	}
 	return runtimeProgramRevision({
 		renderedProjection: {
-			...(runtime === "hermes" &&
-			runtimeSettings?.env.HERMES_API_CALL_STALE_TIMEOUT !== undefined &&
-			runtimeSettings.env.HERMES_API_CALL_STALE_TIMEOUT !==
-				desiredRuntime?.run?.env.HERMES_API_CALL_STALE_TIMEOUT
-				? { hermesStaleTimeout: runtimeSettings.env.HERMES_API_CALL_STALE_TIMEOUT }
-				: {}),
 			channels: channelProjection,
 			gateway:
 				runtime === "openclaw"

--- a/packages/cli/src/runtime/manifest-runtime-state.ts
+++ b/packages/cli/src/runtime/manifest-runtime-state.ts
@@ -108,7 +108,12 @@ export function runtimeProgramRevisionForManifest(
 		? hostedProviderEnvironment(manifest, runtime)
 		: { placeholderEnv: {}, secretEnv: {} };
 	const runtimeSettings = desiredRuntime
-		? resolvedRuntimeSettings(runtime, desiredRuntime.run, providerEnvironment.placeholderEnv)
+		? resolvedRuntimeSettings(
+				manifest,
+				runtime,
+				desiredRuntime.run,
+				providerEnvironment.placeholderEnv,
+			)
 		: undefined;
 	const runtimeSecretRefs = desiredRuntime
 		? [
@@ -130,6 +135,12 @@ export function runtimeProgramRevisionForManifest(
 	}
 	return runtimeProgramRevision({
 		renderedProjection: {
+			...(runtime === "hermes" &&
+			runtimeSettings?.env.HERMES_API_CALL_STALE_TIMEOUT !== undefined &&
+			runtimeSettings.env.HERMES_API_CALL_STALE_TIMEOUT !==
+				desiredRuntime?.run?.env.HERMES_API_CALL_STALE_TIMEOUT
+				? { hermesStaleTimeout: runtimeSettings.env.HERMES_API_CALL_STALE_TIMEOUT }
+				: {}),
 			channels: channelProjection,
 			gateway:
 				runtime === "openclaw"

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1201,6 +1201,80 @@ esac
 		expect(sourceChangedWatchUnit).toBe(rotatedWatchUnit);
 		expect(sourceChangedWatchUnit).not.toContain("next-runtime-source-value");
 		expect(warnings.join("\n")).not.toContain("next-runtime-source-value");
+
+		// The existing service env owns managed defaults, including withdrawal on BYO.
+		const managed = structuredClone(manifest);
+		const hermes = managed.runtimes.hermes;
+		if (!hermes?.run || !hermes.services.dashboard) throw new Error("missing Hermes fixture");
+		hermes.provider_ids = ["selected-ai"];
+		hermes.primary_model = { provider_id: "selected-ai", model: "gpt-6-astra" };
+		managed.projection = {
+			providers: {
+				"selected-ai": {
+					type: "custom_openai_compatible",
+					managed_by: "clawdi",
+					baseUrl: "https://provider.example.test/v1",
+					apiMode: "openai_responses",
+					runtimeEnvName: "CLAWDI_AI_API_KEY",
+					apiKeySecretRef: "secret://provider.clawdi.apiKey",
+					models: [{ id: "gpt-6-astra" }],
+				},
+			},
+		};
+		const managedLoad: RuntimeManifestLoad = {
+			...load,
+			manifest: managed,
+			secretValues: { ...load.secretValues, "secret://provider.clawdi.apiKey": "managed-test-key" },
+		};
+		const applyManaged = () => {
+			expect(convergeRuntimeManifest(managedLoad, paths).installErrors).toEqual([]);
+			return readSystemdEnvironment(paths, "hermes-gateway");
+		};
+		const managedEnv = applyManaged();
+		expect(managedEnv.HERMES_API_CALL_STALE_TIMEOUT).toBe("1200");
+		expect(managedEnv).not.toHaveProperty("HERMES_API_TIMEOUT");
+		expect(
+			readSystemdEnvironment(paths, "clawdi-hermes-dashboard").HERMES_API_CALL_STALE_TIMEOUT,
+		).toBe("1200");
+		expect(applyManaged()).toEqual(managedEnv);
+		expect(readFileSync(join(paths.userHome, ".hermes", "config.yaml"), "utf8")).not.toContain(
+			"stale_timeout_seconds",
+		);
+		expect(readFileSync(watchEnvPath, "utf8")).not.toContain("HERMES_API_CALL_STALE_TIMEOUT");
+
+		hermes.run.env.HERMES_API_CALL_STALE_TIMEOUT = "777";
+		hermes.services.dashboard.secretEnv = {
+			HERMES_API_CALL_STALE_TIMEOUT: "secret://runtime/custom-timeout",
+		};
+		managedLoad.secretValues = {
+			...managedLoad.secretValues,
+			"secret://runtime/custom-timeout": "888",
+		};
+		const explicitEnv = applyManaged();
+		expect(explicitEnv.HERMES_API_CALL_STALE_TIMEOUT).toBe("777");
+		expect(explicitEnv.CLAWDI_MANAGED_CONTENT_DIGEST).not.toBe(
+			managedEnv.CLAWDI_MANAGED_CONTENT_DIGEST,
+		);
+		expect(
+			readSystemdEnvironment(paths, "clawdi-hermes-dashboard").HERMES_API_CALL_STALE_TIMEOUT,
+		).toBe("888");
+
+		// Same provider ID, URL and model, but authoritative ownership is BYO.
+		const provider = managed.projection.providers?.["selected-ai"];
+		if (!provider) throw new Error("missing managed provider fixture");
+		provider.managed_by = "user";
+		expect(applyManaged().HERMES_API_CALL_STALE_TIMEOUT).toBe("777");
+		delete hermes.run.env.HERMES_API_CALL_STALE_TIMEOUT;
+		delete hermes.services.dashboard.secretEnv.HERMES_API_CALL_STALE_TIMEOUT;
+		const byoEnv = applyManaged();
+		expect(byoEnv).not.toHaveProperty("HERMES_API_CALL_STALE_TIMEOUT");
+		expect(byoEnv.CLAWDI_MANAGED_CONTENT_DIGEST).not.toBe(managedEnv.CLAWDI_MANAGED_CONTENT_DIGEST);
+		expect(readSystemdEnvironment(paths, "clawdi-hermes-dashboard")).not.toHaveProperty(
+			"HERMES_API_CALL_STALE_TIMEOUT",
+		);
+		expect(
+			JSON.parse(readFileSync(runtimeRunConfigPath("hermes", paths), "utf8")).env,
+		).not.toHaveProperty("HERMES_API_CALL_STALE_TIMEOUT");
 	});
 
 	test("enumerates only enabled schema-known secret consumers", () => {

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1252,9 +1252,6 @@ esac
 		};
 		const explicitEnv = applyManaged();
 		expect(explicitEnv.HERMES_API_CALL_STALE_TIMEOUT).toBe("777");
-		expect(explicitEnv.CLAWDI_MANAGED_CONTENT_DIGEST).not.toBe(
-			managedEnv.CLAWDI_MANAGED_CONTENT_DIGEST,
-		);
 		expect(
 			readSystemdEnvironment(paths, "clawdi-hermes-dashboard").HERMES_API_CALL_STALE_TIMEOUT,
 		).toBe("888");
@@ -1268,7 +1265,6 @@ esac
 		delete hermes.services.dashboard.secretEnv.HERMES_API_CALL_STALE_TIMEOUT;
 		const byoEnv = applyManaged();
 		expect(byoEnv).not.toHaveProperty("HERMES_API_CALL_STALE_TIMEOUT");
-		expect(byoEnv.CLAWDI_MANAGED_CONTENT_DIGEST).not.toBe(managedEnv.CLAWDI_MANAGED_CONTENT_DIGEST);
 		expect(readSystemdEnvironment(paths, "clawdi-hermes-dashboard")).not.toHaveProperty(
 			"HERMES_API_CALL_STALE_TIMEOUT",
 		);

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -5,6 +5,7 @@ import { TRANSPARENT_EGRESS_TRANSPORT_VERSION } from "./transparent-egress";
 
 export interface RuntimeProgramRevisionInput {
 	renderedProjection: {
+		hermesStaleTimeout?: string;
 		channels: unknown;
 		gateway: unknown;
 		locale: unknown;

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -5,7 +5,6 @@ import { TRANSPARENT_EGRESS_TRANSPORT_VERSION } from "./transparent-egress";
 
 export interface RuntimeProgramRevisionInput {
 	renderedProjection: {
-		hermesStaleTimeout?: string;
 		channels: unknown;
 		gateway: unknown;
 		locale: unknown;


### PR DESCRIPTION
Release `clawdi@0.14.63`: Clawdi AI Hermes deployments can abort long Responses calls after 90 seconds. Default `HERMES_API_CALL_STALE_TIMEOUT` to 1200 seconds in generated gateway and dashboard environments only when the enabled runtime selects a Clawdi-managed Responses provider. Explicit environment/secret settings take precedence; a manifest switch to BYO removes the default. Existing systemd unit/environment fingerprints own restart and repeat-convergence behavior.

The existing manifest ownership and selected-provider fields are sufficient. There are no Hosted schema, database, provider registry, or runtime-image changes. The fixed budget uses Hermes's maximum native Codex context floor; native request/first-event/idle/reasoning/auth/retry/display settings keep their existing behavior. A local/session-only provider switch shares the service default until the manifest changes; provider/model timeout settings and the user's Hermes `.env` can override it.

Validation: Fable independently reviewed the implementation and found no blocking correctness issues; redundant revision/membership checks were removed. Docker CLI typechecking and all 28 service-convergence tests (312 assertions), Biome, and diff checks passed. The source is rebased onto main; package and lockfile versions are updated together. This PR triggers the protected CLI publish workflow on merge. Production promotion follows exact CLI/image qualification, a live canary, and the durable Hosted fleet rollout API. The local hook reports missing lefthook; checks were run explicitly.
