### PR TITLE
fix(web): put provider dialog Back in the header

### DIFF
--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -237,10 +237,19 @@ test("popular BYOK providers support credential-only product setup", async ({ pa
 	await page.screenshot({ path: testInfo.outputPath("provider-mobile.png") });
 	await page.setViewportSize({ width: 1000, height: 1000 });
 	await dialog.getByRole("button", { name: "Kimi", exact: true }).click();
+	const headerBack = dialog.getByRole("button", { name: "Back", exact: true });
+	await expect(headerBack).toHaveCount(1);
+	expect(
+		await headerBack.evaluate((node) => Boolean(node.closest('[data-slot="dialog-header"]'))),
+	).toBe(true);
+	await dialog.getByRole("button", { name: "Kimi Code", exact: true }).click();
+	await expect(dialog.getByLabel("API key", { exact: true })).toBeVisible();
+	await expect(headerBack).toHaveCount(1);
+	await headerBack.click();
 	await expect(dialog.getByRole("button", { name: "Kimi Code", exact: true })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "API · Global", exact: true })).toBeVisible();
 	await page.screenshot({ path: testInfo.outputPath("provider-variants.png") });
-	await dialog.getByRole("button", { name: "Back to providers", exact: true }).click();
+	await dialog.getByRole("button", { name: "Back", exact: true }).click();
 	for (const choice of [
 		{
 			query: "Hugging Face",

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -38,7 +38,11 @@ import {
 	useUpdateConnectionProvider,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { codexProviderBody } from "@/hosted/v2/ai-providers/codex-oauth";
-import { type ProviderChoice, ProviderChooser } from "@/hosted/v2/ai-providers/provider-chooser";
+import {
+	type ProviderChoice,
+	ProviderChooser,
+	type ProviderGroup,
+} from "@/hosted/v2/ai-providers/provider-chooser";
 import { ProviderFieldsForm } from "@/hosted/v2/ai-providers/provider-fields-form";
 import { ProviderOAuthFlow } from "@/hosted/v2/ai-providers/provider-oauth-flow";
 import {
@@ -88,6 +92,7 @@ export function AddProviderDialog({
 	const { state: form, reset: resetForm, update: updateForm } = useProviderForm();
 	const isEdit = Boolean(editing);
 	const [step, setStep] = useState<DialogStep>(editing ? "configure" : "choose");
+	const [providerGroup, setProviderGroup] = useState<ProviderGroup | null>(null);
 	const acceptAttemptRef = useRef<AcceptAttempt | null>(null);
 	const {
 		session: oauth,
@@ -159,6 +164,7 @@ export function AddProviderDialog({
 
 	useEffect(() => {
 		if (!open) return;
+		setProviderGroup(null);
 		oauthExit.beginOpen();
 		invalidateOAuth();
 		clearOAuth();
@@ -472,6 +478,18 @@ export function AddProviderDialog({
 		oauthDeviceStart.isPending ||
 		oauthDevicePoll.isPending;
 
+	const canGoBack = Boolean(renderedOAuth || (!isEdit && (step === "configure" || providerGroup)));
+	function goBack() {
+		if (busy) return;
+		if (renderedOAuth) {
+			invalidateOAuth();
+			clearOAuth();
+			return;
+		}
+		if (step === "configure") setStep("choose");
+		else setProviderGroup(null);
+	}
+
 	return (
 		<Dialog open={open} onOpenChange={requestClose} onOpenChangeComplete={completeOpenChange}>
 			<DialogContent
@@ -479,35 +497,51 @@ export function AddProviderDialog({
 				data-v2="true"
 				className="flex max-h-[min(36rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
 			>
-				<DialogHeader className="shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
-					<DialogTitle className="flex min-w-0 items-center gap-3">
-						{step === "configure" || isEdit || renderedOAuth ? (
-							<span aria-hidden="true" className="shrink-0">
-								<EntityIcon
-									kind="provider"
-									id={
-										renderedOAuth || form.authMethod === "oauth"
-											? "openai"
-											: (selectedPreset?.id ?? form.type)
-									}
-									label={providerLabel}
-									size="md"
-								/>
-							</span>
+				<DialogHeader className="relative shrink-0 px-5 pt-5 pr-14 sm:px-6 sm:pt-6 sm:pr-14">
+					<div className="flex min-w-0 items-center gap-2">
+						{canGoBack ? (
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								aria-label="Back"
+								disabled={busy}
+								onClick={goBack}
+								className="shrink-0"
+							>
+								<ArrowLeft />
+							</Button>
 						) : null}
-						<span className="min-w-0 break-words">
-							{renderedOAuth
-								? "Sign in with ChatGPT"
-								: isEdit
-									? (editing?.readiness?.deployable ?? editing?.usable) &&
-										editing.auth.type !== "none"
-										? `Edit ${providerLabel}`
-										: `Finish ${providerLabel} setup`
-									: step === "choose"
-										? "Add a provider"
-										: `Set up ${providerLabel}`}
-						</span>
-					</DialogTitle>
+						<DialogTitle className="flex min-w-0 items-center gap-3">
+							{step === "configure" || isEdit || renderedOAuth || providerGroup ? (
+								<span aria-hidden="true" className="shrink-0">
+									<EntityIcon
+										kind="provider"
+										id={
+											renderedOAuth || form.authMethod === "oauth"
+												? "openai"
+												: step === "choose" && providerGroup
+													? providerGroup.iconId
+													: (selectedPreset?.id ?? form.type)
+										}
+										label={step === "choose" && providerGroup ? providerGroup.label : providerLabel}
+										size="md"
+									/>
+								</span>
+							) : null}
+							<span className="min-w-0 break-words">
+								{renderedOAuth
+									? "Sign in with ChatGPT"
+									: isEdit
+										? (editing?.readiness?.deployable ?? editing?.usable) &&
+											editing.auth.type !== "none"
+											? `Edit ${providerLabel}`
+											: `Finish ${providerLabel} setup`
+										: step === "choose"
+											? (providerGroup?.label ?? "Add a provider")
+											: `Set up ${providerLabel}`}
+							</span>
+						</DialogTitle>
+					</div>
 				</DialogHeader>
 
 				<div
@@ -524,7 +558,11 @@ export function AddProviderDialog({
 							onRestart={() => void runAction(restartOAuth)}
 						/>
 					) : step === "choose" && !isEdit ? (
-						<ProviderChooser onSelect={selectProvider} />
+						<ProviderChooser
+							onSelect={selectProvider}
+							selected={providerGroup}
+							onGroupChange={setProviderGroup}
+						/>
 					) : (
 						<div className="flex flex-col gap-3">
 							{!providerListReady ? (
@@ -576,17 +614,11 @@ export function AddProviderDialog({
 							</Button>
 						) : (
 							<>
-								<Button
-									variant="outline"
-									onClick={() => {
-										if (isEdit) requestClose(false);
-										else setStep("choose");
-									}}
-									disabled={busy}
-								>
-									{isEdit ? null : <ArrowLeft />}
-									{isEdit ? "Cancel" : "Back"}
-								</Button>
+								{isEdit ? (
+									<Button variant="outline" onClick={() => requestClose(false)} disabled={busy}>
+										Cancel
+									</Button>
+								) : null}
 								<Button onClick={() => void runAction(submit)} disabled={!canSubmit || busy}>
 									{busy ? <Spinner data-icon="inline-start" /> : null}
 									{form.authMethod === "oauth" && !isEdit

--- a/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/provider-chooser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
@@ -18,7 +18,7 @@ interface ChoiceEntry {
 	label: string;
 	choice: ProviderChoice;
 }
-interface ProviderGroup {
+export interface ProviderGroup {
 	id: string;
 	label: string;
 	iconId: string;
@@ -76,9 +76,16 @@ for (const preset of PROVIDER_PRESETS) {
 }
 GROUPS.push(typeGroup("custom_openai_compatible"));
 
-export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoice) => void }) {
+export function ProviderChooser({
+	onSelect,
+	selected,
+	onGroupChange,
+}: {
+	onSelect: (choice: ProviderChoice) => void;
+	selected: ProviderGroup | null;
+	onGroupChange: (group: ProviderGroup | null) => void;
+}) {
 	const [query, setQuery] = useState("");
-	const [selected, setSelected] = useState<ProviderGroup | null>(null);
 	const normalized = query.trim().toLowerCase();
 	const groups = GROUPS.filter((group) =>
 		[group.id, group.label, ...group.entries.map((entry) => `${entry.id} ${entry.label}`)]
@@ -89,33 +96,19 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 	return (
 		<div data-hosted="true" data-v2="true" className="flex flex-col gap-3">
 			{selected ? (
-				<>
-					<div className="flex items-center gap-2">
+				<div className="grid gap-2 sm:grid-cols-2" data-testid="provider-variant-grid">
+					{selected.entries.map((entry) => (
 						<Button
-							variant="ghost"
-							size="icon-sm"
-							aria-label="Back to providers"
-							onClick={() => setSelected(null)}
+							key={entry.id}
+							variant="outline"
+							className="h-auto min-h-11 justify-between whitespace-normal px-3 py-2 text-left"
+							onClick={() => onSelect(entry.choice)}
 						>
-							<ArrowLeft />
+							{entry.label}
+							<ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
 						</Button>
-						<EntityIcon kind="provider" id={selected.iconId} size="sm" />
-						<span className="text-sm font-medium">{selected.label}</span>
-					</div>
-					<div className="grid gap-2 sm:grid-cols-2" data-testid="provider-variant-grid">
-						{selected.entries.map((entry) => (
-							<Button
-								key={entry.id}
-								variant="outline"
-								className="h-auto min-h-11 justify-between whitespace-normal px-3 py-2 text-left"
-								onClick={() => onSelect(entry.choice)}
-							>
-								{entry.label}
-								<ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-							</Button>
-						))}
-					</div>
-				</>
+					))}
+				</div>
 			) : (
 				<>
 					<SearchInput
@@ -134,7 +127,7 @@ export function ProviderChooser({ onSelect }: { onSelect: (choice: ProviderChoic
 								onClick={() => {
 									const first = group.entries[0];
 									if (group.entries.length === 1 && first) onSelect(first.choice);
-									else setSelected(group);
+									else onGroupChange(group);
 								}}
 							>
 								<span aria-hidden="true" className="shrink-0">


### PR DESCRIPTION
Place one Back button at the left of the provider dialog title for every nested step. Move brand selection into the dialog so returning from credential setup restores the previous brand options; a second Back returns to the brand list. Remove the body and footer Back controls, retaining Close and edit Cancel.

Returning from sign-in uses the existing OAuth invalidation and cleanup lifecycle. Credential routing and submission are unchanged.

Validation: focused Web and OAuth lifecycle checks, typecheck, OSS build, production SSR, and Chromium provider flows in disposable Docker. The existing chooser browser case verifies the single header Back button and the credential → variants → brands sequence.
