### PR TITLE
fix(channels): redact credentials from request path logs

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
 import logging
+import re
 
 _HTTP_CLIENT_LOGGERS = ("httpx", "httpcore", "httpx2", "httpcore2")
+TELEGRAM_BOT_API_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+_DISCORD_TOKEN_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/discord/(?:api/)?v10/"
+    r"(?:interactions|webhooks)/[^/]+/)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+_DISCORD_GATEWAY_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/discord/gateway/)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+
+
+def redact_request_path(path: str) -> str:
+    """Keep route context without credentials embedded in channel URL paths."""
+    for pattern in (
+        TELEGRAM_BOT_API_PATH_RE,
+        _DISCORD_TOKEN_PATH_RE,
+        _DISCORD_GATEWAY_PATH_RE,
+    ):
+        match = pattern.match(path)
+        if match is not None:
+            return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
+    return path
 
 
 def configure_application_logging() -> None:

--- a/backend/app/middleware/body_size_limit.py
+++ b/backend/app/middleware/body_size_limit.py
@@ -27,6 +27,8 @@ import logging
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from app.core.logging_config import redact_request_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,7 +77,7 @@ class BodySizeLimitMiddleware:
                     logger.info(
                         "body_size_rejected_header method=%s path=%s declared=%d cap=%d",
                         method,
-                        scope.get("path", ""),
+                        redact_request_path(scope.get("path", "")),
                         declared,
                         self.max_bytes,
                     )
@@ -117,7 +119,7 @@ class BodySizeLimitMiddleware:
                 logger.info(
                     "body_size_rejected_stream method=%s path=%s read=%d cap=%d",
                     method,
-                    scope.get("path", ""),
+                    redact_request_path(scope.get("path", "")),
                     total,
                     self.max_bytes,
                 )

--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -9,18 +9,15 @@ of application logs.
 from __future__ import annotations
 
 import logging
-import re
 import time
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from app.core.logging_config import TELEGRAM_BOT_API_PATH_RE, redact_request_path
+
 logger = logging.getLogger(__name__)
 _PROCESS_TIME_HEADER = b"x-process-time-ms"
 _SYNC_EVENTS_PATHS = frozenset(("/v1/sync/events", "/api/sync/events"))
-_TELEGRAM_BOT_API_PATH_RE = re.compile(
-    r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
-    re.IGNORECASE,
-)
 
 
 class RequestTimingMiddleware:
@@ -38,7 +35,7 @@ class RequestTimingMiddleware:
         method = raw_method if isinstance(raw_method, str) else "GET"
         raw_path_value: object = scope.get("path", "")
         raw_path = raw_path_value if isinstance(raw_path_value, str) else ""
-        path = _log_safe_path(raw_path)
+        path = redact_request_path(raw_path)
         status_code = 500
 
         async def timed_send(message: Message) -> None:
@@ -97,17 +94,10 @@ def _is_slow(*, duration_ms: float, slow_ms: float) -> bool:
     return slow_ms > 0 and duration_ms >= slow_ms
 
 
-def _log_safe_path(path: str) -> str:
-    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
-    if match is None:
-        return path
-    return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
-
-
 def _is_expected_long_request(path: str) -> bool:
     if path in _SYNC_EVENTS_PATHS:
         return True
-    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
+    match = TELEGRAM_BOT_API_PATH_RE.match(path)
     if match is None or "/file/" in match.group("prefix").lower():
         return False
     return (match.group("suffix") or "").lower() == "/getupdates"

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -9,6 +9,8 @@ oversized-Content-Length path doesn't reach the handler at all.
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 import pytest
 from httpx import ASGITransport
@@ -18,6 +20,46 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
+
+
+@pytest.mark.parametrize("declared", [True, False])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/channels/telegram/botsecret/sendMessage",
+        "/api/channels/discord/api/v10/webhooks/123/secret",
+        "/v1/channels/discord/v10/interactions/123/secret/callback",
+    ],
+)
+async def test_body_rejection_redacts_channel_credentials(caplog, declared, path):
+    async def inner(scope, receive, send):
+        assert scope["path"] == path
+        await receive()
+
+    async def receive():
+        return {"type": "http.request", "body": b"xx", "more_body": False}
+
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    caplog.set_level(logging.INFO, logger="app.middleware.body_size_limit")
+    await BodySizeLimitMiddleware(inner, max_bytes=1)(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [(b"content-length", b"2")] if declared else [],
+        },
+        receive,
+        send,
+    )
+    assert messages[0]["status"] == 413
+    event = "body_size_rejected_header" if declared else "body_size_rejected_stream"
+    assert event in caplog.text
+    assert path.replace("secret", "[redacted]") in caplog.text
+    assert "secret" not in caplog.text
 
 
 def _build_app(*, max_bytes: int) -> tuple[Starlette, list[bool]]:

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -84,8 +84,8 @@ async def test_request_timing_logs_errors_without_query_string(caplog: pytest.Lo
     ("path", "expected_path"),
     [
         (
-            "/v1/channels/telegram/bot123456:secret/getUpdates",
-            "/v1/channels/telegram/bot[redacted]/getUpdates",
+            "/v1/channels/telegram/bot123456:secret/getMe",
+            "/v1/channels/telegram/bot[redacted]/getMe",
         ),
         (
             "/api/channels/telegram/bot/123456:secret/sendMessage",
@@ -95,19 +95,59 @@ async def test_request_timing_logs_errors_without_query_string(caplog: pytest.Lo
             "/v1/channels/telegram/file/bot123456:secret/documents/file.txt",
             "/v1/channels/telegram/file/bot[redacted]/documents/file.txt",
         ),
+        (
+            "/v1/channels/discord/v10/interactions/123/123456:secret/callback",
+            "/v1/channels/discord/v10/interactions/123/[redacted]/callback",
+        ),
+        (
+            "/api/channels/discord/api/v10/webhooks/123/123456:secret/messages/@original",
+            "/api/channels/discord/api/v10/webhooks/123/[redacted]/messages/@original",
+        ),
+        (
+            "/v1/channels/discord/api/v10/webhooks/123/123456:secret",
+            "/v1/channels/discord/api/v10/webhooks/123/[redacted]",
+        ),
+        (
+            "/api/channels/discord/v10/interactions/123/123456:secret/callback",
+            "/api/channels/discord/v10/interactions/123/[redacted]/callback",
+        ),
+        (
+            "/v1/channels/discord/gateway/123456:secret",
+            "/v1/channels/discord/gateway/[redacted]",
+        ),
+        (
+            "/v1/channels/discord/v10/channels/123/messages",
+            "/v1/channels/discord/v10/channels/123/messages",
+        ),
     ],
 )
-async def test_request_timing_redacts_telegram_routing_credentials(
+@pytest.mark.parametrize("outcome", ["slow", "error", "exception"])
+async def test_request_timing_redacts_channel_routing_credentials(
     caplog: pytest.LogCaptureFixture,
     path: str,
     expected_path: str,
+    outcome: str,
 ):
     async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 500, "headers": []})
+        assert _scope["path"] == path
+        if outcome == "exception":
+            raise RuntimeError("synthetic failure")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200 if outcome == "slow" else 500,
+                "headers": [],
+            }
+        )
         await send({"type": "http.response.body", "body": b"error"})
 
     caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
-    await _collect(RequestTimingMiddleware(inner, slow_ms=750), _scope(path=path))
+    app = RequestTimingMiddleware(inner, slow_ms=0.000_001)
+    if outcome == "exception":
+        with pytest.raises(RuntimeError, match="synthetic failure"):
+            await _collect(app, _scope(path=path))
+    else:
+        await _collect(app, _scope(path=path))
 
     assert f"path={expected_path}" in caplog.text
     assert "123456:secret" not in caplog.text


### PR DESCRIPTION
Slow/error request logs exposed Discord interaction tokens embedded in URL paths, and both body-size rejection logs recorded raw channel paths, including Telegram routing credentials. Use one explicit path-redaction helper for both middleware components, covering supported channel route aliases and HTTP requests to Discord Gateway capability paths while preserving useful method/path context.

No new logging framework or dependencies. Request paths passed to handlers and successful long-poll suppression are unchanged. This scopes redaction to the request-path field; it is not a blanket guarantee about arbitrary exception text or unrelated routes.

Validation: 45 isolated Python 3.14.7 tests passed; Ruff lint/format and scoped type checks passed (three production files, zero diagnostics). Tests exercise slow/error/exception logs, both 413 paths, aliases, credential omission, unchanged handler paths, and ordinary non-token paths. Fable reviewed the actual diff; the reported formatting issue was fixed and checks rerun.

Integrated through #1458 at commit `69f7ad493693c11deead97d56c4747e10201edda`.
