### PR TITLE
fix(channels): fence Discord interactions and isolate profile shadows

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -47,6 +47,7 @@ from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_STATUS_ACTIVE,
     ChannelAccount,
+    ChannelAgentReference,
     ChannelBinding,
     ChannelBindingAlias,
     ChannelBotAgentLink,
@@ -366,7 +367,9 @@ async def discord_agent_rest(
     if segments == ["users", "@me"]:
         if request.method == "PATCH":
             params = await request_params(request)
-            config = dict(account.config) if isinstance(account.config, dict) else {}
+            # Share the Link lock with command-shadow writes to preserve unrelated config.
+            await db.refresh(agent.link, with_for_update=True)
+            config = dict(agent.link.config) if isinstance(agent.link.config, dict) else {}
             username = optional_str(params.get("username"))
             if username:
                 config["bot_username"] = username
@@ -378,9 +381,9 @@ async def discord_agent_rest(
                         detail="avatar must be a JSON value",
                     )
                 config["bot_avatar"] = avatar
-            account.config = config
+            agent.link.config = config
             await db.commit()
-        return discord_bot_user(account)
+        return discord_bot_user(account, agent.link)
     command_response = await handle_discord_application_commands(
         db,
         agent=agent,
@@ -390,7 +393,7 @@ async def discord_agent_rest(
     if command_response is not None:
         return command_response
     if segments in (["oauth2", "applications", "@me"], ["applications", "@me"]):
-        user = discord_bot_user(account)
+        user = discord_bot_user(account, agent.link)
         return {
             "id": user["id"],
             "name": user["username"],
@@ -1257,7 +1260,7 @@ async def discord_agent_gateway(
                                 else public_ws_url("/v1/channels/discord/gateway")
                             )
                         ),
-                        "user": discord_bot_user(account),
+                        "user": discord_bot_user(account, resolved_agent.link),
                         "application": {"id": discord_application_id(account)},
                         "guilds": [{"id": guild_id, "unavailable": False} for guild_id in guilds],
                         "private_channels": [
@@ -1787,6 +1790,30 @@ async def cleanup_discord_guild_commands_after_authority_revoked(
         return False
 
 
+async def _discord_interaction_reference_is_authorized(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+    reference: ChannelAgentReference | None,
+) -> bool:
+    # Agent interactions require a live Binding. Unbound/control interactions
+    # are answered by the platform; orphaned historical references grant no authority.
+    if reference is None or reference.binding_id is None:
+        return False
+    binding = await db.get(ChannelBinding, reference.binding_id)
+    if binding is None:
+        return False
+    leased = await lock_active_discord_binding_lease(
+        db,
+        account_id=account.id,
+        bot_agent_link_id=bot_agent_link_id,
+        binding_id=binding.id,
+        external_chat_id=binding.external_chat_id,
+    )
+    return leased is not None and leased.user_id == reference.user_id
+
+
 async def _handle_discord_interaction_callback(
     db: AsyncSession,
     *,
@@ -1807,7 +1834,9 @@ async def _handle_discord_interaction_callback(
         ref_value=f"{interaction_id}:{token}",
         bot_agent_link_id=bot_agent_link_id,
     )
-    if reference is None:
+    if not await _discord_interaction_reference_is_authorized(
+        db, account=account, bot_agent_link_id=bot_agent_link_id, reference=reference
+    ):
         return _discord_rest_error("Unknown Interaction", 10062, 404)
     return await proxy_discord_request(account=account, request=request, path=path)
 
@@ -1835,6 +1864,10 @@ async def _handle_discord_webhook_followup(
     metadata = reference.metadata_ if reference is not None else None
     recorded_application_id = metadata.get("application_id") if isinstance(metadata, dict) else None
     if reference is None or recorded_application_id != application_id:
+        return _discord_rest_error("Unknown Webhook", 10015, 404)
+    if not await _discord_interaction_reference_is_authorized(
+        db, account=account, bot_agent_link_id=bot_agent_link_id, reference=reference
+    ):
         return _discord_rest_error("Unknown Webhook", 10015, 404)
     return await proxy_discord_request(account=account, request=request, path=path)
 

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -303,16 +303,21 @@ def discord_application_id(account: ChannelAccount) -> str:
     return str(abs(hash(str(account.id))) % 10_000_000_000_000_000_000)
 
 
-def discord_bot_user(account: ChannelAccount) -> JsonObject:
+def discord_bot_user(account: ChannelAccount, link: ChannelBotAgentLink) -> JsonObject:
     config = account.config if isinstance(account.config, dict) else {}
+    shadow = link.config if isinstance(link.config, dict) else {}
     app_id = discord_application_id(account)
-    username = optional_str(config.get("bot_username")) or account.name
+    username = (
+        optional_str(shadow.get("bot_username"))
+        or optional_str(config.get("bot_username"))
+        or account.name
+    )
     return {
         "id": app_id,
         "username": username,
         "global_name": username,
         "discriminator": "0000",
-        "avatar": config.get("bot_avatar"),
+        "avatar": shadow.get("bot_avatar", config.get("bot_avatar")),
         "bot": True,
         "system": False,
     }

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11206,6 +11206,173 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["callback", "followup"])
+@pytest.mark.parametrize("binding_state", ["unpaired", "reassigned", "missing"])
+async def test_discord_interaction_reference_requires_current_binding(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    binding_state: str,
+):
+    _reset_fake_provider_client({"id": "discord-upstream"})
+    monkeypatch.setattr(shared_router.httpx, "AsyncClient", _FakeProviderClient)
+    created = await _create_paired_discord_channel(
+        client, name="discord-reference-revocation", agent_id=channel_agent.id
+    )
+    ingress = await _record_discord_interaction(
+        client,
+        created=created,
+        interaction_id="revoked-interaction",
+        token="revoked-token",
+        application_id=DISCORD_TEST_APPLICATION_ID,
+    )
+    assert ingress.status_code == 202
+    binding = await db_session.scalar(
+        select(ChannelBinding).where(ChannelBinding.account_id == UUID(created["id"]))
+    )
+    assert binding is not None
+    unpaired = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+    assert unpaired.status_code == 200, unpaired.text
+    assert unpaired.json()["unpaired"] is True
+    if binding_state == "reassigned":
+        second = await client.post(
+            f"/v1/channels/{created['id']}/agent-links",
+            json={"agent_id": str(second_channel_agent.id)},
+        )
+        assert second.status_code == 201, second.text
+        pair = await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": second.json()["id"], "ttl_seconds": 900},
+        )
+        assert pair.status_code == 201, pair.text
+        repaired = await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json={
+                "type": 2,
+                "id": "repair-interaction",
+                "token": "repair-token",
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "channel_id": "discord-chan-1",
+                "guild_id": "discord-guild-1",
+                "context": 0,
+                "authorizing_integration_owners": {"0": "discord-guild-1"},
+                "member": {"permissions": "32", "user": {"id": "discord-pair-user"}},
+                "data": {
+                    "name": "clawdi_pair",
+                    "options": [{"name": "code", "value": pair.json()["code"]}],
+                },
+            },
+        )
+        assert repaired.status_code == 200, repaired.text
+        assert repaired.json()["data"]["content"].startswith("Server paired.")
+        await db_session.refresh(binding)
+        assert binding.status == BINDING_STATUS_ACTIVE
+        assert str(binding.bot_agent_link_id) == second.json()["id"]
+    elif binding_state == "missing":
+        # Historical references can lose their Binding through ON DELETE SET NULL.
+        await db_session.delete(binding)
+        await db_session.commit()
+
+    _reset_fake_provider_client({"id": "must-not-send"})
+    path = (
+        "interactions/revoked-interaction/revoked-token/callback"
+        if endpoint == "callback"
+        else f"webhooks/{DISCORD_TEST_APPLICATION_ID}/revoked-token"
+    )
+    response = await client.post(
+        f"/v1/channels/discord/v10/{path}",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"type": 4, "data": {"content": "must not send"}, "content": "must not send"},
+    )
+    assert (response.status_code, len(_FakeProviderClient.calls)) == (404, 0)
+
+
+@pytest.mark.asyncio
+async def test_discord_shared_profile_shadow_is_link_scoped(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_discord_gateway_sessions(monkeypatch)
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "discord",
+            "name": "discord-shared-profile",
+            "provider_token": "discord-provider-token",
+            "config": _discord_ready_config(),
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    second_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert second_response.status_code == 201, second_response.text
+    second = second_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
+    account.config = {**account.config, "bot_username": "Legacy Bot", "bot_avatar": "legacy"}
+    await db_session.commit()
+    original_config = dict(account.config)
+    headers_a = {"Authorization": f"Bot {created['agent_token']}"}
+    headers_b = {"Authorization": f"Bot {second['agent_token']}"}
+    patched = await client.patch(
+        "/v1/channels/discord/v10/users/@me",
+        headers=headers_a,
+        json={"username": "Link A", "avatar": None},
+    )
+    assert patched.status_code == 200, patched.text
+    # An omitted avatar preserves an explicit clear, rather than restoring the fallback.
+    patched = await client.patch(
+        "/v1/channels/discord/v10/users/@me", headers=headers_a, json={"username": "Link A"}
+    )
+    assert patched.status_code == 200
+    for path in ("users/@me", "applications/@me", "oauth2/applications/@me"):
+        first = await client.get(f"/v1/channels/discord/v10/{path}", headers=headers_a)
+        second_get = await client.get(f"/v1/channels/discord/v10/{path}", headers=headers_b)
+        assert first.status_code == second_get.status_code == 200
+        user_a = first.json() if path == "users/@me" else first.json()["bot"]
+        user_b = second_get.json() if path == "users/@me" else second_get.json()["bot"]
+        assert (user_a["username"], user_a["avatar"]) == ("Link A", None)
+        assert (user_b["username"], user_b["avatar"]) == ("Legacy Bot", "legacy")
+
+    _install_discord_gateway_test_session_factory(monkeypatch)
+    placeholder = channel_runtime_placeholder_token(
+        CHANNEL_PROVIDER_DISCORD, channel_runtime_account_key(account.id)
+    )
+
+    def ready_user(token: str) -> dict[str, Any]:
+        with TestClient(app) as sync_client:
+            with sync_client.websocket_connect(
+                "/v1/channels/discord/gateway?v=10&encoding=json",
+                headers={"Authorization": f"Bearer {token}"},
+            ) as websocket:
+                assert websocket.receive_json()["op"] == 10
+                websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+                ready = websocket.receive_json()
+                assert ready["t"] == "READY"
+                return ready["d"]["user"]
+
+    user_a = ready_user(created["agent_token"])
+    user_b = ready_user(second["agent_token"])
+    assert (user_a["username"], user_a["avatar"]) == ("Link A", None)
+    assert (user_b["username"], user_b["avatar"]) == ("Legacy Bot", "legacy")
+    await db_session.refresh(account)
+    assert account.config == original_config
+
+
+@pytest.mark.asyncio
 async def test_discord_bot_profile_shadow_is_account_scoped(
     client: httpx.AsyncClient,
     channel_agent,


### PR DESCRIPTION
Discord interaction callbacks and followups accepted historical Link-owned references after their Chat Binding was unpaired or reassigned. Require the existing active Binding lease, including account, Link, and reference-user ownership, before provider I/O. Missing or unbound references do not grant callback authority.

Agent profile PATCH requests also wrote shared Account configuration, changing every Link's projected identity. Store the shadow on the requesting Link under its existing config lock and use the same overlay for REST identity, application identity, and Gateway READY. Preserve Account defaults and explicit avatar clearing.

Validation: seven regression cases failed before the fix; the initial focused suite passed 11 tests afterward. Broader isolated verification passed 210 Discord tests and all 12 WebSocket tests. Ruff passed; scoped typing reported zero errors or warnings. Root and Fable reviewed the actual diff. No schema change or provider-profile mutation.

Integrated through #1458 at commit `69f7ad493693c11deead97d56c4747e10201edda`.
