### PR TITLE
fix(discord): share and monitor Gateway ownership sessions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,8 @@ from app.core.database import (
     ControlLockTimeoutError,
     control_engine,
     control_snapshot_engine,
+    engine,
+    finish_cleanup,
     get_session,
 )
 from app.core.logging_config import configure_application_logging
@@ -77,6 +79,7 @@ from app.routes.vault import router as vault_router
 from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorruptError
 from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client, run_tool_router_mcp_session_reaper
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.embedding import LocalEmbedder, LocalServiceEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
 from app.services.metrics import db_control_lock_timeouts, db_pool_timeouts, observe_event_loop_lag
@@ -157,34 +160,42 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         background.add(task)
         task.add_done_callback(background.discard)
 
+    discord_locks = DiscordAdvisorySession(
+        engine, liveness_interval_seconds=settings.discord_gateway_poll_interval_seconds
+    )
+    _app.state.discord_gateway_locks = discord_locks
     try:
         yield
     finally:
-        # On shutdown, cancel anything still running and wait for it so we
-        # don't leak a task into whatever signal handler runs next.
-        for t in background:
-            t.cancel()
-        if background:
-            await asyncio.gather(*background, return_exceptions=True)
         try:
-            await whatsapp_sidecars.stop()
+            await finish_cleanup(discord_locks.close)
         finally:
+            del _app.state.discord_gateway_locks
+            # On shutdown, cancel anything still running and wait for it so we
+            # don't leak a task into whatever signal handler runs next.
+            for t in background:
+                t.cancel()
+            if background:
+                await asyncio.gather(*background, return_exceptions=True)
             try:
-                await stop_postgres_listener()
+                await whatsapp_sidecars.stop()
             finally:
                 try:
-                    await close_channel_provider_http_client()
+                    await stop_postgres_listener()
                 finally:
                     try:
-                        await close_composio_client()
+                        await close_channel_provider_http_client()
                     finally:
                         try:
-                            await LocalServiceEmbedder.close_shared()
+                            await close_composio_client()
                         finally:
                             try:
-                                await control_engine.dispose()
+                                await LocalServiceEmbedder.close_shared()
                             finally:
-                                await control_snapshot_engine.dispose()
+                                try:
+                                    await control_engine.dispose()
+                                finally:
+                                    await control_snapshot_engine.dispose()
 
 
 app = FastAPI(

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -33,14 +33,13 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, Response
 from pydantic import JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import and_, select, text
+from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
-from app.core.database import engine as database_engine
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
@@ -106,9 +105,9 @@ from app.services.channels import (
     verify_discord_signature,
     verify_webhook_secret,
 )
-from app.services.discord_gateway_worker import (
-    release_advisory_lock,
-    try_advisory_lock,
+from app.services.discord_advisory_session import (
+    DiscordAdvisorySession,
+    DiscordAdvisorySessionLost,
 )
 
 router = APIRouter(prefix="/channels/discord", tags=["channels"])
@@ -1068,6 +1067,7 @@ async def discord_agent_gateway(
                 consumer_lease = _discord_gateway_consumer_lease(
                     account_id=resolved_account.id,
                     bot_agent_link_id=resolved_link_id,
+                    lock_session=_consumer_lock_session(websocket),
                 )
                 lease_acquired = await consumer_lease.__aenter__()
                 consumer_lease_entered = True
@@ -1197,6 +1197,7 @@ async def discord_agent_gateway(
                 consumer_lease = _discord_gateway_consumer_lease(
                     account_id=resolved_account.id,
                     bot_agent_link_id=resolved_link_id,
+                    lock_session=_consumer_lock_session(websocket),
                 )
                 lease_acquired = await consumer_lease.__aenter__()
                 consumer_lease_entered = True
@@ -2035,99 +2036,43 @@ async def _send_discord_gateway_message(
         return "dropped", None
 
 
+def _consumer_lock_session(websocket: WebSocket) -> DiscordAdvisorySession:
+    session = getattr(websocket.app.state, "discord_gateway_locks", None)
+    if not isinstance(session, DiscordAdvisorySession):
+        raise RuntimeError("Discord consumer lock owner is not running")
+    return session
+
+
 @asynccontextmanager
 async def _discord_gateway_consumer_lease(
     *,
     account_id: UUID,
     bot_agent_link_id: UUID,
-    lock_engine: AsyncEngine | None = None,
-    liveness_interval_seconds: float | None = None,
+    lock_session: DiscordAdvisorySession,
 ):
-    """Allow one synthetic shard consumer per AgentLink across processes."""
-    connection = await (lock_engine or database_engine).connect()
-    acquired = False
-    lock_key: int | None = None
-    safe_to_pool = False
-    monitor_failure: Exception | None = None
-    body_error: BaseException | None = None
-    cleanup_error: BaseException | None = None
-    monitor_stop = asyncio.Event()
-    monitor_task: asyncio.Task[None] | None = None
-    owner_task = asyncio.current_task()
-    if owner_task is None:
-        await connection.close()
-        raise RuntimeError("discord gateway consumer lease requires an asyncio task")
-    lock_name = f"discord-agent-gateway:{account_id}:{bot_agent_link_id}"
-
-    async def monitor_connection() -> None:
-        nonlocal monitor_failure
-        interval = max(
-            0.001,
-            liveness_interval_seconds
-            if liveness_interval_seconds is not None
-            else settings.discord_gateway_poll_interval_seconds,
-        )
-        try:
-            while True:
-                try:
-                    await asyncio.wait_for(monitor_stop.wait(), timeout=interval)
-                    return
-                except TimeoutError:
-                    await connection.execute(text("SELECT 1"))
-                    await connection.commit()
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            monitor_failure = exc
-            owner_task.cancel()
-
+    """Allow one synthetic shard consumer per AgentLink locally and across processes."""
     try:
-        await connection.execution_options(isolation_level="AUTOCOMMIT")
-        # Keep the transaction-level lease identity used by older rolling-deploy peers.
-        lock_key_result = await connection.execute(
-            text("SELECT hashtextextended(:lock_name, 0)"),
-            {"lock_name": lock_name},
-        )
-        await connection.commit()
-        resolved_lock_key = lock_key_result.scalar_one()
-        if not isinstance(resolved_lock_key, int) or isinstance(resolved_lock_key, bool):
-            raise RuntimeError("discord gateway consumer advisory lock key is invalid")
-        lock_key = resolved_lock_key
-        acquired = await try_advisory_lock(connection, lock_key)
-        safe_to_pool = not acquired
-        if acquired:
-            monitor_task = asyncio.create_task(
-                monitor_connection(),
-                name=f"discord-gateway-consumer-lease-{bot_agent_link_id}",
-            )
-        try:
-            yield acquired
-        except BaseException as exc:
-            body_error = exc
-    finally:
-        monitor_stop.set()
-        try:
-            if monitor_task is not None:
-                await monitor_task
-            if acquired:
-                if lock_key is None:
-                    raise RuntimeError("discord gateway consumer advisory lock key is missing")
-                if not await release_advisory_lock(connection, lock_key):
-                    raise RuntimeError("discord gateway consumer advisory unlock failed")
-                safe_to_pool = True
-        except BaseException as exc:
-            cleanup_error = exc
-        finally:
-            try:
-                if not safe_to_pool:
-                    await connection.invalidate()
-            finally:
-                await connection.close()
-
-    if monitor_failure is not None:
+        lease = await lock_session.claim(f"discord-agent-gateway:{account_id}:{bot_agent_link_id}")
+    except DiscordAdvisorySessionLost as exc:
         raise _DiscordGatewayConsumerLeaseLost(
             "discord gateway consumer lease connection lost"
-        ) from monitor_failure
+        ) from exc
+    body_error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+    try:
+        yield lease is not None
+    except BaseException as exc:
+        body_error = exc
+    finally:
+        if lease is not None:
+            try:
+                await lock_session.release(lease)
+            except BaseException as exc:
+                cleanup_error = exc
+            if lease.failed:
+                raise _DiscordGatewayConsumerLeaseLost(
+                    "discord gateway consumer lease connection lost"
+                ) from (cleanup_error or lease.session.failure)
     if cleanup_error is not None:
         raise cleanup_error
     if body_error is not None:

--- a/backend/app/services/discord_advisory_session.py
+++ b/backend/app/services/discord_advisory_session.py
@@ -1,0 +1,247 @@
+"""One PostgreSQL ownership session for a role's Discord Gateway tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+from app.core.database import finish_cleanup
+
+log = logging.getLogger(__name__)
+
+
+class DiscordAdvisorySessionLost(RuntimeError):
+    """The PostgreSQL session cannot prove ownership of its Discord tasks."""
+
+
+@dataclass
+class _Session:
+    connection: AsyncConnection
+    leases: dict[int, DiscordAdvisoryLease] = field(default_factory=dict)
+    monitor: asyncio.Task[None] | None = None
+    retirement: asyncio.Task[None] | None = None
+    failure: BaseException | None = None
+    closing: bool = False
+
+
+@dataclass(frozen=True)
+class DiscordAdvisoryLease:
+    key: int
+    owner: asyncio.Task[None]
+    session: _Session
+
+    @property
+    def failed(self) -> bool:
+        return self.session.failure is not None
+
+
+class DiscordAdvisorySession:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        liveness_interval_seconds: float = 1.0,
+        liveness_timeout_seconds: float = 5.0,
+    ) -> None:
+        self._engine = engine
+        self._interval = max(0.001, liveness_interval_seconds)
+        self._timeout = max(0.001, liveness_timeout_seconds)
+        self._serial = asyncio.Lock()
+        self._lifecycle = asyncio.Lock()
+        self._session: _Session | None = None
+        self._closed = False
+
+    @property
+    def failed(self) -> bool:
+        return self._session is not None and self._session.failure is not None
+
+    async def _get_session(self) -> _Session:
+        # Recovery must be driven by a new claimant, not an old owner whose
+        # completion the retirement operation needs to join.
+        if self.failed:
+            self._check_lifecycle_caller()
+        while True:
+            async with self._lifecycle:
+                if self._closed:
+                    raise DiscordAdvisorySessionLost("Discord lock owner is closed")
+                if self._session is None:
+                    self._session = _Session(await self._engine.connect())
+                    self._session.monitor = asyncio.create_task(
+                        self._monitor(self._session), name="discord-advisory-session-monitor"
+                    )
+                if self._session.failure is None:
+                    return self._session
+                self._check_lifecycle_caller()
+                retirement = self._session.retirement
+            if retirement is None:
+                raise DiscordAdvisorySessionLost("Discord lock retirement is unavailable")
+            await asyncio.shield(retirement)
+
+    async def claim(self, key: int | str) -> DiscordAdvisoryLease | None:
+        owner = asyncio.current_task()
+        if owner is None:
+            raise RuntimeError("Discord advisory locks require an asyncio task")
+        session = await self._get_session()
+        async with self._connection(session) as connection:
+            if isinstance(key, str):
+                # Preserve the released consumer Account/Link lock identity.
+                resolved = await connection.scalar(
+                    text("SELECT hashtextextended(:lock_name, 0)"), {"lock_name": key}
+                )
+                await connection.commit()
+                if not isinstance(resolved, int) or isinstance(resolved, bool):
+                    raise RuntimeError("Discord consumer advisory key is invalid")
+                key = resolved
+            # PostgreSQL session locks are reentrant, not local task mutexes.
+            if key in session.leases or not await try_advisory_lock(connection, key):
+                return None
+            if session.closing or session.failure is not None:
+                raise DiscordAdvisorySessionLost from session.failure
+            lease = DiscordAdvisoryLease(key, owner, session)
+            session.leases[key] = lease
+            return lease
+
+    async def release(self, lease: DiscordAdvisoryLease) -> None:
+        await finish_cleanup(lambda: self._release(lease))
+
+    async def _release(self, lease: DiscordAdvisoryLease) -> None:
+        session = lease.session
+        if session.failure is not None:
+            raise DiscordAdvisorySessionLost from session.failure
+        if session.closing:
+            return  # Shutdown invalidates the connection after joining owners.
+        try:
+            async with self._connection(session, lease.owner) as connection:
+                if session.leases.get(lease.key) is not lease:
+                    return
+                if not await release_advisory_lock(connection, lease.key):
+                    raise RuntimeError("Discord advisory unlock failed")
+                session.leases.pop(lease.key)
+        except DiscordAdvisorySessionLost:
+            if not session.closing or session.failure is not None:
+                raise
+
+    @asynccontextmanager
+    async def _connection(
+        self, session: _Session, owner: asyncio.Task[None] | None = None
+    ) -> AsyncGenerator[AsyncConnection]:
+        async with self._serial:
+            if session.closing or session.failure is not None:
+                raise DiscordAdvisorySessionLost from session.failure
+            try:
+                async with asyncio.timeout(self._timeout):
+                    yield session.connection
+            except BaseException as exc:
+                self._fail(session, exc, owner)
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                raise DiscordAdvisorySessionLost from exc
+
+    def _fail(
+        self, session: _Session, exc: BaseException, owner: asyncio.Task[None] | None = None
+    ) -> None:
+        if session.failure is None and not session.closing:
+            session.failure = exc
+            for task in {lease.owner for lease in session.leases.values()}:
+                if task is not (owner or asyncio.current_task()):
+                    task.cancel()
+            # Consumers have no discovery loop to reap a failed but still-live
+            # PG session. Retire it even if no new Gateway ever arrives.
+            session.retirement = asyncio.create_task(
+                self._retire_failed_session(session), name="discord-advisory-session-retire"
+            )
+            session.retirement.add_done_callback(_observe_retirement)
+
+    async def _retire_failed_session(self, session: _Session) -> None:
+        async with self._lifecycle:
+            await self._retire_session(session)
+
+    async def _monitor(self, session: _Session) -> None:
+        try:
+            while session.failure is None:
+                await asyncio.sleep(self._interval)
+                # Include time waiting for claim/release SQL. Driver/transport
+                # cancellation cleanup may outlast this application deadline.
+                async with asyncio.timeout(self._timeout):
+                    async with self._connection(session) as connection:
+                        await connection.execute(text("SELECT 1"))
+                        await connection.commit()
+        except (TimeoutError, DiscordAdvisorySessionLost) as exc:
+            self._fail(session, exc)
+            log.exception("Discord advisory session lost")
+
+    async def close(self) -> None:
+        # Check the real caller before finish_cleanup creates its child task,
+        # and before waiting behind a retirement that may already join it.
+        self._check_lifecycle_caller()
+        await finish_cleanup(self._close)
+
+    async def _close(self) -> None:
+        async with self._lifecycle:
+            self._closed = True
+            retirement = self._session.retirement if self._session is not None else None
+            if retirement is None:
+                await self._retire_session(self._session)
+        if retirement is not None:
+            await asyncio.shield(retirement)
+
+    def _check_lifecycle_caller(self) -> None:
+        if self._session is not None and any(
+            lease.owner is asyncio.current_task() for lease in self._session.leases.values()
+        ):
+            raise DiscordAdvisorySessionLost(
+                "Discord lock session lifecycle requires a task that owns no lease"
+            )
+
+    async def _retire_session(self, session: _Session | None) -> None:
+        if session is None or self._session is not session:
+            return
+        session.closing = True
+        if session.monitor is not None:
+            session.monitor.cancel()
+            await asyncio.gather(session.monitor, return_exceptions=True)
+        # Drain any claim already executing SQL before snapshotting owners.
+        # Never join owners under this gate: their cleanup also needs it.
+        async with self._serial:
+            owners = {lease.owner for lease in session.leases.values()}
+        if session.failure is None:
+            for owner in owners:
+                owner.cancel()
+        if owners:
+            await asyncio.gather(*owners, return_exceptions=True)
+        async with self._serial:
+            try:
+                # Even orderly shutdown discards the ownership connection. Never
+                # let an uncertain or remaining session lock reenter the pool.
+                await session.connection.invalidate()
+            finally:
+                await session.connection.close()
+                session.leases.clear()
+                self._session = None
+
+
+def _observe_retirement(task: asyncio.Task[None]) -> None:
+    if not task.cancelled() and (error := task.exception()) is not None:
+        log.error("Discord advisory session retirement failed", exc_info=error)
+
+
+async def try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    result = await connection.execute(
+        text("SELECT pg_try_advisory_lock(:lock_key)"), {"lock_key": lock_key}
+    )
+    await connection.commit()
+    return result.scalar_one() is True
+
+
+async def release_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    result = await connection.execute(
+        text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
+    )
+    await connection.commit()
+    return result.scalar_one() is True

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -6,8 +6,6 @@ import hashlib
 import json
 import logging
 import random
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -16,8 +14,8 @@ from uuid import UUID
 
 from fastapi import HTTPException
 from pydantic import JsonValue, TypeAdapter
-from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
@@ -35,6 +33,12 @@ from app.services.channels import (
     record_discord_dispatch,
     update_discord_binding_display_name_from_trusted_event,
 )
+from app.services.discord_advisory_session import (
+    DiscordAdvisorySession,
+    DiscordAdvisorySessionLost,
+)
+from app.services.discord_advisory_session import release_advisory_lock as release_advisory_lock
+from app.services.discord_advisory_session import try_advisory_lock as try_advisory_lock
 from app.services.discord_command_reconciliation_worker import (
     reconcile_discord_guild_commands,
     reconcile_discord_guild_departure,
@@ -57,10 +61,6 @@ _GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 class _GatewayReconnect(RuntimeError):
     """Discord requested an immediate reconnect so the session can resume."""
-
-
-class _GatewayLockLost(RuntimeError):
-    """The shared PostgreSQL session no longer owns the provider transports."""
 
 
 class _GatewayConnection(Protocol):
@@ -131,7 +131,11 @@ class DiscordGatewayWorker:
         connect_factory: _GatewayConnectFactory = connect,
     ) -> None:
         self._sessionmaker = sessionmaker
-        self._lock_engine = lock_engine or _sessionmaker_bind(sessionmaker)
+        self._locks = DiscordAdvisorySession(
+            lock_engine or _sessionmaker_bind(sessionmaker),
+            liveness_interval_seconds=lock_liveness_interval_seconds,
+            liveness_timeout_seconds=lock_liveness_timeout_seconds,
+        )
         self._scan_interval_seconds = scan_interval_seconds
         self._reconnect_initial_seconds = reconnect_initial_seconds
         self._reconnect_max_seconds = reconnect_max_seconds
@@ -139,25 +143,11 @@ class DiscordGatewayWorker:
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
         self._terminal_account_revisions: dict[UUID, str] = {}
         self._states: dict[UUID, _GatewayState] = {}
-        self._lock_connection: AsyncConnection | None = None
-        self._lock_monitor: asyncio.Task[None] | None = None
-        self._lock_lost = False
-        self._lock_serial = asyncio.Lock()
         self._lifecycle_serial = asyncio.Lock()
-        self._lock_liveness_interval_seconds = max(0.001, lock_liveness_interval_seconds)
-        self._lock_liveness_timeout_seconds = max(0.001, lock_liveness_timeout_seconds)
 
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
         async with self._lifecycle_serial:
-            if self._lock_lost:
-                await finish_cleanup(self._close_lock_session)
             accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
-            if accounts and self._lock_connection is None:
-                self._lock_connection = await self._lock_engine.connect()
-                self._lock_lost = False
-                self._lock_monitor = asyncio.create_task(
-                    self._monitor_lock_session(), name="discord-gateway-lock-monitor"
-                )
             self._sync_tasks(accounts, stop or asyncio.Event())
             return len(accounts)
 
@@ -185,63 +175,12 @@ class DiscordGatewayWorker:
             self._states.clear()
 
     async def _close_lock_session(self) -> None:
-        # Fence new claims, then join transports before closing the session.
-        # Invalidate even on orderly shutdown: remaining session locks must not
-        # become reentrant locks on a later borrow from the ordinary pool.
-        self._lock_lost = True
-        if self._lock_monitor is not None:
-            self._lock_monitor.cancel()
-            await asyncio.gather(self._lock_monitor, return_exceptions=True)
-            self._lock_monitor = None
         for task in self._tasks.values():
             task.cancel()
         if self._tasks:
             await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
-        connection = self._lock_connection
-        if connection is not None:
-            try:
-                await connection.invalidate()
-            finally:
-                await connection.close()
-                self._lock_connection = None
-
-    @asynccontextmanager
-    async def _locked_connection(
-        self, owner: asyncio.Task[None] | None = None
-    ) -> AsyncGenerator[AsyncConnection]:
-        async with self._lock_serial:
-            if self._lock_connection is None or self._lock_lost:
-                raise _GatewayLockLost
-            try:
-                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
-                    yield self._lock_connection
-            except BaseException as exc:
-                self._lose_lock_session(owner)
-                if isinstance(exc, asyncio.CancelledError):
-                    raise
-                raise _GatewayLockLost from exc
-
-    def _lose_lock_session(self, owner: asyncio.Task[None] | None = None) -> None:
-        if not self._lock_lost:
-            self._lock_lost = True
-            for task in self._tasks.values():
-                if task is not (owner or asyncio.current_task()):
-                    task.cancel()
-
-    async def _monitor_lock_session(self) -> None:
-        try:
-            while not self._lock_lost:
-                await asyncio.sleep(self._lock_liveness_interval_seconds)
-                # The deadline includes waiting for a claim/unlock. It bounds
-                # detection, not the transport/driver's cancellation cleanup.
-                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
-                    async with self._locked_connection() as connection:
-                        await connection.execute(text("SELECT 1"))
-                        await connection.commit()
-        except (TimeoutError, _GatewayLockLost):
-            self._lose_lock_session()
-            log.exception("discord gateway lock session lost")
+        await self._locks.close()
 
     def _sync_tasks(
         self,
@@ -287,7 +226,7 @@ class DiscordGatewayWorker:
                 backoff_seconds = self._reconnect_initial_seconds
             except asyncio.CancelledError:
                 raise
-            except _GatewayLockLost:
+            except DiscordAdvisorySessionLost:
                 return
             except _GatewayReconnect:
                 state.session_established = False
@@ -313,7 +252,7 @@ class DiscordGatewayWorker:
             if state.session_established:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
-            if self._lock_lost:
+            if self._locks.failed:
                 return
             await _sleep_until_stop(stop, backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, self._reconnect_max_seconds)
@@ -325,26 +264,17 @@ class DiscordGatewayWorker:
         state: _GatewayState,
     ) -> bool:
         lock_key = discord_gateway_advisory_lock_key(account_id)
-        async with self._locked_connection() as lock_connection:
-            acquired = await try_advisory_lock(lock_connection, lock_key)
-        if not acquired:
+        lease = await self._locks.claim(lock_key)
+        if lease is None:
             return False
         try:
             await self._connect_and_record(account_id, stop, state)
         finally:
-            # Preserve transport close codes/cancellation even if unlock fails.
-            # _locked_connection fences every sibling on failure; the lifecycle
-            # owner then invalidates this session rather than returning locks.
-            owner = asyncio.current_task()
-            await finish_cleanup(lambda: self._release_account_lock(lock_key, owner))
+            # The shared owner fences siblings on unlock failure. Preserve this
+            # account's transport close code or cancellation for the outer loop.
+            with contextlib.suppress(DiscordAdvisorySessionLost):
+                await self._locks.release(lease)
         return True
-
-    async def _release_account_lock(self, lock_key: int, owner: asyncio.Task[None] | None) -> None:
-        if not self._lock_lost:
-            with contextlib.suppress(_GatewayLockLost):
-                async with self._locked_connection(owner) as connection:
-                    if not await release_advisory_lock(connection, lock_key):
-                        raise RuntimeError("discord gateway advisory unlock failed")
 
     async def _connect_and_record(
         self,
@@ -775,24 +705,6 @@ def discord_gateway_advisory_lock_key(account_id: UUID) -> int:
 
 def discord_gateway_close_code(exc: ConnectionClosed) -> int | None:
     return exc.rcvd.code if exc.rcvd is not None else None
-
-
-async def try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
-    result = await connection.execute(
-        text("SELECT pg_try_advisory_lock(:lock_key)"),
-        {"lock_key": lock_key},
-    )
-    await connection.commit()
-    return result.scalar_one() is True
-
-
-async def release_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
-    result = await connection.execute(
-        text("SELECT pg_advisory_unlock(:lock_key)"),
-        {"lock_key": lock_key},
-    )
-    await connection.commit()
-    return result.scalar_one() is True
 
 
 async def _recv_gateway_frame(websocket: _GatewayConnection) -> GatewayFrame:

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 import logging
 import random
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -20,6 +22,7 @@ from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
 from app.core.config import settings
+from app.core.database import finish_cleanup
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
@@ -54,6 +57,10 @@ _GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 class _GatewayReconnect(RuntimeError):
     """Discord requested an immediate reconnect so the session can resume."""
+
+
+class _GatewayLockLost(RuntimeError):
+    """The shared PostgreSQL session no longer owns the provider transports."""
 
 
 class _GatewayConnection(Protocol):
@@ -119,6 +126,8 @@ class DiscordGatewayWorker:
         scan_interval_seconds: float = 10.0,
         reconnect_initial_seconds: float = 1.0,
         reconnect_max_seconds: float = 60.0,
+        lock_liveness_interval_seconds: float = 1.0,
+        lock_liveness_timeout_seconds: float = 5.0,
         connect_factory: _GatewayConnectFactory = connect,
     ) -> None:
         self._sessionmaker = sessionmaker
@@ -129,35 +138,110 @@ class DiscordGatewayWorker:
         self._connect_factory = connect_factory
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
         self._terminal_account_revisions: dict[UUID, str] = {}
+        self._states: dict[UUID, _GatewayState] = {}
+        self._lock_connection: AsyncConnection | None = None
+        self._lock_monitor: asyncio.Task[None] | None = None
+        self._lock_lost = False
+        self._lock_serial = asyncio.Lock()
+        self._lifecycle_serial = asyncio.Lock()
+        self._lock_liveness_interval_seconds = max(0.001, lock_liveness_interval_seconds)
+        self._lock_liveness_timeout_seconds = max(0.001, lock_liveness_timeout_seconds)
 
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
-        accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
-        stop_event = stop or asyncio.Event()
-        self._sync_tasks(accounts, stop_event)
-        return len(accounts)
+        async with self._lifecycle_serial:
+            if self._lock_lost:
+                await finish_cleanup(self._close_lock_session)
+            accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
+            if accounts and self._lock_connection is None:
+                self._lock_connection = await self._lock_engine.connect()
+                self._lock_lost = False
+                self._lock_monitor = asyncio.create_task(
+                    self._monitor_lock_session(), name="discord-gateway-lock-monitor"
+                )
+            self._sync_tasks(accounts, stop or asyncio.Event())
+            return len(accounts)
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
+        backoff = self._reconnect_initial_seconds
         try:
             while not stop_event.is_set():
-                await self.run_once(stop_event)
                 try:
-                    await asyncio.wait_for(
-                        stop_event.wait(),
-                        timeout=self._scan_interval_seconds,
-                    )
-                except TimeoutError:
-                    pass
+                    await self.run_once(stop_event)
+                except Exception:
+                    log.exception("discord gateway account scan failed")
+                    await _sleep_until_stop(stop_event, backoff)
+                    backoff = min(backoff * 2, self._reconnect_max_seconds)
+                else:
+                    backoff = self._reconnect_initial_seconds
+                    await _sleep_until_stop(stop_event, self._scan_interval_seconds)
         finally:
             await self.stop()
 
     async def stop(self) -> None:
+        async with self._lifecycle_serial:
+            await finish_cleanup(self._close_lock_session)
+            self._terminal_account_revisions.clear()
+            self._states.clear()
+
+    async def _close_lock_session(self) -> None:
+        # Fence new claims, then join transports before closing the session.
+        # Invalidate even on orderly shutdown: remaining session locks must not
+        # become reentrant locks on a later borrow from the ordinary pool.
+        self._lock_lost = True
+        if self._lock_monitor is not None:
+            self._lock_monitor.cancel()
+            await asyncio.gather(self._lock_monitor, return_exceptions=True)
+            self._lock_monitor = None
         for task in self._tasks.values():
             task.cancel()
         if self._tasks:
             await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
-        self._terminal_account_revisions.clear()
+        connection = self._lock_connection
+        if connection is not None:
+            try:
+                await connection.invalidate()
+            finally:
+                await connection.close()
+                self._lock_connection = None
+
+    @asynccontextmanager
+    async def _locked_connection(
+        self, owner: asyncio.Task[None] | None = None
+    ) -> AsyncGenerator[AsyncConnection]:
+        async with self._lock_serial:
+            if self._lock_connection is None or self._lock_lost:
+                raise _GatewayLockLost
+            try:
+                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
+                    yield self._lock_connection
+            except BaseException as exc:
+                self._lose_lock_session(owner)
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                raise _GatewayLockLost from exc
+
+    def _lose_lock_session(self, owner: asyncio.Task[None] | None = None) -> None:
+        if not self._lock_lost:
+            self._lock_lost = True
+            for task in self._tasks.values():
+                if task is not (owner or asyncio.current_task()):
+                    task.cancel()
+
+    async def _monitor_lock_session(self) -> None:
+        try:
+            while not self._lock_lost:
+                await asyncio.sleep(self._lock_liveness_interval_seconds)
+                # The deadline includes waiting for a claim/unlock. It bounds
+                # detection, not the transport/driver's cancellation cleanup.
+                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
+                    async with self._locked_connection() as connection:
+                        await connection.execute(text("SELECT 1"))
+                        await connection.commit()
+        except (TimeoutError, _GatewayLockLost):
+            self._lose_lock_session()
+            log.exception("discord gateway lock session lost")
 
     def _sync_tasks(
         self,
@@ -165,6 +249,8 @@ class DiscordGatewayWorker:
         stop: asyncio.Event,
     ) -> None:
         active = set(active_accounts)
+        for account_id in set(self._states) - active:
+            self._states.pop(account_id, None)
         for account_id, task in list(self._tasks.items()):
             if task.done():
                 self._observe_done_task(account_id, task)
@@ -181,6 +267,9 @@ class DiscordGatewayWorker:
                 continue
             if terminal_revision is not None:
                 self._terminal_account_revisions.pop(account_id, None)
+            state = self._states.get(account_id)
+            if state is not None and state.account_revision != revision:
+                self._states.pop(account_id, None)
             self._tasks[account_id] = asyncio.create_task(
                 self._run_account_forever(account_id, stop),
                 name=f"discord-gateway-{account_id}",
@@ -188,7 +277,7 @@ class DiscordGatewayWorker:
 
     async def _run_account_forever(self, account_id: UUID, stop: asyncio.Event) -> None:
         backoff_seconds = self._reconnect_initial_seconds
-        state = _GatewayState()
+        state = self._states.setdefault(account_id, _GatewayState())
         while not stop.is_set():
             try:
                 acquired = await self._run_account_with_lock(account_id, stop, state)
@@ -198,6 +287,8 @@ class DiscordGatewayWorker:
                 backoff_seconds = self._reconnect_initial_seconds
             except asyncio.CancelledError:
                 raise
+            except _GatewayLockLost:
+                return
             except _GatewayReconnect:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
@@ -222,6 +313,8 @@ class DiscordGatewayWorker:
             if state.session_established:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
+            if self._lock_lost:
+                return
             await _sleep_until_stop(stop, backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, self._reconnect_max_seconds)
 
@@ -232,16 +325,26 @@ class DiscordGatewayWorker:
         state: _GatewayState,
     ) -> bool:
         lock_key = discord_gateway_advisory_lock_key(account_id)
-        async with self._lock_engine.connect() as lock_connection:
+        async with self._locked_connection() as lock_connection:
             acquired = await try_advisory_lock(lock_connection, lock_key)
-            if not acquired:
-                return False
-            try:
-                await self._connect_and_record(account_id, stop, state)
-            finally:
-                if not await release_advisory_lock(lock_connection, lock_key):
-                    raise RuntimeError("discord gateway advisory unlock failed")
+        if not acquired:
+            return False
+        try:
+            await self._connect_and_record(account_id, stop, state)
+        finally:
+            # Preserve transport close codes/cancellation even if unlock fails.
+            # _locked_connection fences every sibling on failure; the lifecycle
+            # owner then invalidates this session rather than returning locks.
+            owner = asyncio.current_task()
+            await finish_cleanup(lambda: self._release_account_lock(lock_key, owner))
         return True
+
+    async def _release_account_lock(self, lock_key: int, owner: asyncio.Task[None] | None) -> None:
+        if not self._lock_lost:
+            with contextlib.suppress(_GatewayLockLost):
+                async with self._locked_connection(owner) as connection:
+                    if not await release_advisory_lock(connection, lock_key):
+                        raise RuntimeError("discord gateway advisory unlock failed")
 
     async def _connect_and_record(
         self,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -264,6 +264,7 @@ strict = [
     "app/services/codex_oauth.py",
     "app/services/composio.py",
     "app/services/connected_agent_fence.py",
+    "app/services/discord_advisory_session.py",
     "app/services/discord_command_reconciliation_worker.py",
     "app/services/discord_gateway_worker.py",
     "app/services/discord_rate_limiter.py",

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -15806,7 +15806,7 @@ def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatc
         async_sessionmaker(gateway_engine, expire_on_commit=False),
     )
     monkeypatch.setattr(
-        "app.routes.channel_routers.discord.database_engine",
+        "app.main.engine",
         gateway_engine,
     )
 

--- a/backend/tests/test_discord_consumer_resource_boundary.py
+++ b/backend/tests/test_discord_consumer_resource_boundary.py
@@ -1,0 +1,268 @@
+"""Consumer leases use the lifespan-owned Discord session, not one pool slot per Link."""
+
+import asyncio
+import json
+import os
+import sys
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.database import _create_engine
+from app.routes.channel_routers import discord
+from app.services import discord_advisory_session as advisory
+
+
+async def eventually(predicate):
+    async with asyncio.timeout(5):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+@pytest_asyncio.fixture
+async def consumer(monkeypatch):
+    monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
+    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    locks = advisory.DiscordAdvisorySession(
+        ordinary, liveness_interval_seconds=0.02, liveness_timeout_seconds=0.2
+    )
+    try:
+        yield ordinary, locks
+    finally:
+        await locks.close()
+        await ordinary.dispose()
+
+
+def lease(locks, identity):
+    account_id, link_id = identity
+    return discord._discord_gateway_consumer_lease(
+        account_id=account_id, bot_agent_link_id=link_id, lock_session=locks
+    )
+
+
+async def hold(locks, identity, ready, stop):
+    async with lease(locks, identity) as acquired:
+        assert acquired
+        ready.set()
+        await stop.wait()
+
+
+async def attempt(locks, identity):
+    async with lease(locks, identity) as acquired:
+        return acquired
+
+
+async def peer_claim(engine, identity):
+    account_id, link_id = identity
+    async with engine.connect() as connection:
+        key = await connection.scalar(
+            text("SELECT hashtextextended(:name, 0)"),
+            {"name": f"discord-agent-gateway:{account_id}:{link_id}"},
+        )
+        acquired = await advisory.try_advisory_lock(connection, key)
+        if acquired:
+            assert await advisory.release_advisory_lock(connection, key)
+        return acquired
+
+
+async def subprocess_claim(identity):
+    # A separate Python process executes the released consumer SQL/key. It has
+    # no shared Python ownership map and only contacts the disposable test PG.
+    code = """
+import asyncio, asyncpg, json, os, sys
+async def main():
+    db = await asyncpg.connect(os.environ['DATABASE_URL'].replace('+asyncpg', ''))
+    try:
+        key = await db.fetchval('SELECT hashtextextended($1, 0)', sys.argv[1])
+        acquired = await db.fetchval('SELECT pg_try_advisory_lock($1)', key)
+        if acquired:
+            assert await db.fetchval('SELECT pg_advisory_unlock($1)', key)
+        print(json.dumps(acquired))
+    finally:
+        await db.close()
+asyncio.run(main())
+"""
+    account_id, link_id = identity
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        f"discord-agent-gateway:{account_id}:{link_id}",
+        env=os.environ.copy(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), 5)
+        assert process.returncode == 0, stderr.decode()
+        return json.loads(stdout)
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+
+async def test_consumer_more_links_than_pool_local_and_cross_process_exclusion(consumer):
+    ordinary, locks = consumer
+    identities = [(uuid4(), uuid4()) for _ in range(4)]
+    stop = asyncio.Event()
+    ready = [asyncio.Event() for _ in identities]
+    tasks = [
+        asyncio.create_task(hold(locks, identity, entered, stop))
+        for identity, entered in zip(identities, ready, strict=True)
+    ]
+    try:
+        await asyncio.wait_for(asyncio.gather(*(event.wait() for event in ready)), 5)
+        assert ordinary.pool.checkedout() == 1
+        async with ordinary.connect() as connection:
+            assert await connection.scalar(text("SELECT 1")) == 1
+        # This task differs from all four lease owners; PostgreSQL's reentrant
+        # success on the shared session must not admit a duplicate owner.
+        assert await attempt(locks, identities[0]) is False
+        assert await subprocess_claim(identities[0]) is False
+        stop.set()
+        await asyncio.wait_for(asyncio.gather(*tasks), 5)
+        assert await subprocess_claim(identities[0]) is True
+        await locks.close()
+        assert ordinary.pool.checkedout() == 0
+        assert locks._session is None
+    finally:
+        stop.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def test_live_failed_pg_session_is_retired_without_new_claim_or_shutdown(
+    consumer,
+    engine,
+):
+    ordinary, locks = consumer
+    identities = [(uuid4(), uuid4()) for _ in range(3)]
+    ready = [asyncio.Event() for _ in identities]
+    tasks = [
+        asyncio.create_task(hold(locks, identity, entered, asyncio.Event()))
+        for identity, entered in zip(identities, ready, strict=True)
+    ]
+    unrelated = asyncio.create_task(asyncio.Event().wait())
+    try:
+        await asyncio.wait_for(asyncio.gather(*(event.wait() for event in ready)), 5)
+        session = locks._session
+        assert session is not None
+        async with locks._connection(session) as connection:
+            pid = await connection.scalar(text("SELECT pg_backend_pid()"))
+        # An actual SQL error leaves this PostgreSQL backend alive, holding its
+        # session-level keys until the component explicitly retires it.
+        with pytest.raises(advisory.DiscordAdvisorySessionLost):
+            async with locks._connection(session) as connection:
+                await connection.execute(text("SELECT 1 / 0"))
+        assert not session.connection.invalidated
+        results = await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 5)
+        assert all(
+            isinstance(result, discord._DiscordGatewayConsumerLeaseLost) for result in results
+        )
+        assert not unrelated.done()
+        await eventually(lambda: locks._session is None and ordinary.pool.checkedout() == 0)
+        for identity in identities:
+            assert await peer_claim(engine, identity)
+        async with engine.connect() as connection:
+            assert (
+                await connection.scalar(
+                    text("SELECT count(*) FROM pg_stat_activity WHERE pid = :pid"), {"pid": pid}
+                )
+                == 0
+            )
+        assert session.retirement is not None and session.retirement.done()
+    finally:
+        unrelated.cancel()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(unrelated, *tasks, return_exceptions=True)
+
+
+async def test_cancelled_consumer_claim_waiter_does_not_cancel_owner(consumer):
+    _, locks = consumer
+    ready, stop = asyncio.Event(), asyncio.Event()
+    owner = asyncio.create_task(hold(locks, (uuid4(), uuid4()), ready, stop))
+    waiter = None
+    try:
+        await asyncio.wait_for(ready.wait(), 5)
+        async with locks._serial:
+            waiter = asyncio.create_task(attempt(locks, (uuid4(), uuid4())))
+            await asyncio.sleep(0)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            assert not locks.failed and not owner.done()
+        stop.set()
+        await owner
+    finally:
+        stop.set()
+        await asyncio.gather(
+            owner, *([waiter] if waiter is not None else []), return_exceptions=True
+        )
+
+
+async def test_close_fences_claim_after_pg_success_before_local_registration(
+    consumer,
+    engine,
+    monkeypatch,
+):
+    ordinary, locks = consumer
+    identity = (uuid4(), uuid4())
+    claimed, proceed = asyncio.Event(), asyncio.Event()
+    original = advisory.try_advisory_lock
+
+    async def paused_claim(connection, key):
+        result = await original(connection, key)
+        assert result
+        claimed.set()
+        await proceed.wait()
+        return result
+
+    monkeypatch.setattr(advisory, "try_advisory_lock", paused_claim)
+    claimant = asyncio.create_task(attempt(locks, identity))
+    closing = None
+    try:
+        await asyncio.wait_for(claimed.wait(), 5)
+        closing = asyncio.create_task(locks.close())
+        await eventually(lambda: locks._session is not None and locks._session.closing)
+        proceed.set()
+        with pytest.raises(discord._DiscordGatewayConsumerLeaseLost):
+            await asyncio.wait_for(claimant, 5)
+        await asyncio.wait_for(closing, 5)
+        assert ordinary.pool.checkedout() == 0 and locks._session is None
+        monkeypatch.setattr(advisory, "try_advisory_lock", original)
+        assert await peer_claim(engine, identity)
+    finally:
+        proceed.set()
+        await asyncio.gather(
+            claimant, *([closing] if closing is not None else []), return_exceptions=True
+        )
+
+
+async def test_lease_owner_cannot_close_or_recover_its_own_session(consumer):
+    _, locks = consumer
+    identity = (uuid4(), uuid4())
+    async with lease(locks, identity) as acquired:
+        assert acquired
+        with pytest.raises(advisory.DiscordAdvisorySessionLost, match="owns no lease"):
+            await locks.close()
+        assert not locks._closed
+
+    # Failure recovery checks the real caller before acquiring the lifecycle
+    # gate, including when automatic retirement already waits for that owner.
+    async def owner():
+        async with lease(locks, identity):
+            session = locks._session
+            assert session is not None
+            try:
+                async with locks._connection(session) as connection:
+                    await connection.execute(text("SELECT 1 / 0"))
+            except advisory.DiscordAdvisorySessionLost:
+                with pytest.raises(advisory.DiscordAdvisorySessionLost, match="owns no lease"):
+                    await locks.claim(f"discord-agent-gateway:{uuid4()}:{uuid4()}")
+
+    with pytest.raises(discord._DiscordGatewayConsumerLeaseLost):
+        await asyncio.wait_for(asyncio.create_task(owner()), 5)

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -7,8 +7,9 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, text, update
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.schema import CreateSchema, DropSchema
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
@@ -82,9 +83,34 @@ class Network:
 
 
 @pytest_asyncio.fixture
+async def engine(engine):
+    """Isolate global account scans while retaining independent real PG observers."""
+    schema = f"discord_gateway_{uuid4().hex}"
+    async with engine.begin() as connection:
+        await connection.execute(CreateSchema(schema))
+    try:
+        async with engine.begin() as connection:
+            quoted_schema = connection.dialect.identifier_preparer.quote(schema)
+            # These probes use only platform-owned accounts and no tenant FKs.
+            # Clone the migrated table's columns, checks, defaults and indexes.
+            await connection.execute(
+                text(
+                    f"CREATE TABLE {quoted_schema}.channel_accounts "
+                    "(LIKE public.channel_accounts INCLUDING ALL)"
+                )
+            )
+        yield engine.execution_options(schema_translate_map={None: schema})
+    finally:
+        async with engine.begin() as connection:
+            await connection.execute(DropSchema(schema, cascade=True))
+
+
+@pytest_asyncio.fixture
 async def provider(engine, monkeypatch):
     monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
-    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    ordinary = _create_engine(pool_size=2, max_overflow=0).execution_options(
+        schema_translate_map=engine.get_execution_options()["schema_translate_map"]
+    )
     accounts = [uuid4() for _ in range(4)]
     async with async_sessionmaker(engine)() as db:
         for account_id in accounts:
@@ -118,9 +144,6 @@ async def provider(engine, monkeypatch):
         yield ordinary, accounts, network, worker
     finally:
         await worker.stop()
-        async with async_sessionmaker(engine)() as db:
-            await db.execute(delete(ChannelAccount).where(ChannelAccount.id.in_(accounts)))
-            await db.commit()
         await ordinary.dispose()
 
 

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -1,0 +1,428 @@
+"""Real PostgreSQL ownership and pool boundaries with an isolated provider transport."""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, text, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from app.core.config import settings
+from app.core.database import _create_engine
+from app.models.channel import ChannelAccount
+from app.services import discord_gateway_worker as gateway
+from app.services.vault_crypto import encrypt
+from app.workers import channels
+
+
+async def eventually(predicate):
+    async with asyncio.timeout(5):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+class Transport:
+    def __init__(self):
+        self.frames = asyncio.Queue()
+        self.frames.put_nowait(json.dumps({"op": 10, "d": {"heartbeat_interval": 100}}))
+        self.sent = []
+        self.closed = False
+        self.account_id = None
+
+    async def recv(self):
+        frame = await self.frames.get()
+        if isinstance(frame, Exception):
+            raise frame
+        return frame
+
+    async def send(self, message):
+        frame = json.loads(message)
+        self.sent.append(frame)
+        if frame["op"] in {2, 6}:
+            self.account_id = UUID(frame["d"]["token"])
+            self.frames.put_nowait(
+                json.dumps(
+                    {
+                        "op": 0,
+                        "t": "READY" if frame["op"] == 2 else "RESUMED",
+                        "s": 17,
+                        "d": {
+                            "session_id": str(self.account_id),
+                            "resume_gateway_url": "wss://gateway.discord.gg/resume",
+                        },
+                    }
+                )
+            )
+        elif frame["op"] == 1:
+            self.frames.put_nowait('{"op":11}')
+
+    async def close(self, *, code, reason):
+        self.closed = True
+
+
+class Network:
+    def __init__(self):
+        self.transports = []
+
+    @asynccontextmanager
+    async def connect(self, uri, **kwargs):
+        assert uri.startswith("wss://gateway.discord.gg/")
+        transport = Transport()
+        self.transports.append(transport)
+        try:
+            yield transport
+        finally:
+            transport.closed = True
+
+
+@pytest_asyncio.fixture
+async def provider(engine, monkeypatch):
+    monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
+    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    accounts = [uuid4() for _ in range(4)]
+    async with async_sessionmaker(engine)() as db:
+        for account_id in accounts:
+            ciphertext, nonce = encrypt(str(account_id))
+            db.add(
+                ChannelAccount(
+                    id=account_id,
+                    provider="discord",
+                    name=f"resource-boundary-{account_id}",
+                    user_id=None,
+                    visibility="public",
+                    status="active",
+                    encrypted_provider_token=ciphertext,
+                    provider_token_nonce=nonce,
+                    webhook_secret_hash="test-only",
+                    config={"gateway_enabled": True},
+                )
+            )
+        await db.commit()
+    network = Network()
+    worker = gateway.DiscordGatewayWorker(
+        async_sessionmaker(ordinary, expire_on_commit=False),
+        scan_interval_seconds=0.02,
+        reconnect_initial_seconds=0.02,
+        reconnect_max_seconds=0.1,
+        lock_liveness_interval_seconds=0.02,
+        lock_liveness_timeout_seconds=0.2,
+        connect_factory=network.connect,
+    )
+    try:
+        yield ordinary, accounts, network, worker
+    finally:
+        await worker.stop()
+        async with async_sessionmaker(engine)() as db:
+            await db.execute(delete(ChannelAccount).where(ChannelAccount.id.in_(accounts)))
+            await db.commit()
+        await ordinary.dispose()
+
+
+async def lock_pid(engine, account_id):
+    key = gateway.discord_gateway_advisory_lock_key(account_id)
+    async with engine.connect() as db:
+        return await db.scalar(
+            text("""
+            SELECT pid FROM pg_locks WHERE locktype = 'advisory' AND granted
+              AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+              AND classid::bigint = :high AND objid::bigint = :low AND objsubid = 1
+        """),
+            {"high": key >> 32, "low": key & 0xFFFFFFFF},
+        )
+
+
+async def legacy_can_claim(engine, account_id):
+    # Exactly the released per-account key and SQL, on another PG session.
+    key = gateway.discord_gateway_advisory_lock_key(account_id)
+    async with engine.connect() as db:
+        acquired = await gateway.try_advisory_lock(db, key)
+        if acquired:
+            assert await gateway.release_advisory_lock(db, key)
+        return acquired
+
+
+async def archive(engine, account_id):
+    async with engine.begin() as db:
+        await db.execute(
+            update(ChannelAccount).where(ChannelAccount.id == account_id).values(status="inactive")
+        )
+
+
+async def connected(network, count=4):
+    await eventually(
+        lambda: (
+            len(network.transports) == count
+            and all(
+                any(frame == {"op": 1, "d": 17} for frame in transport.sent)
+                for transport in network.transports
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize("shutdown", ["stop", "event", "cancel"])
+async def test_more_accounts_than_pool_and_no_reentrant_scan_locks(provider, engine, shutdown):
+    ordinary, accounts, network, worker = provider
+    stop = asyncio.Event()
+    runner = None
+    try:
+        assert await worker.run_once(stop) == 4
+        await connected(network)
+        assert ordinary.pool.checkedout() == 1
+        pids = {await lock_pid(engine, account_id) for account_id in accounts}
+        assert len(pids) == 1 and None not in pids
+        async with ordinary.connect() as db:
+            assert await db.scalar(text("SELECT 1")) == 1
+        for _ in range(4):
+            assert await worker.run_once(stop) == 4
+        for account_id in accounts:
+            assert not await legacy_can_claim(engine, account_id)
+
+        await archive(engine, accounts[0])
+        await worker.run_once(stop)
+        removed = next(t for t in network.transports if t.account_id == accounts[0])
+        await eventually(lambda: removed.closed and worker._tasks[accounts[0]].done())
+        # A single release must suffice after repeated scans, while the same
+        # session still owns the other three keys (not a disconnect shortcut).
+        assert await legacy_can_claim(engine, accounts[0])
+        assert {await lock_pid(engine, account_id) for account_id in accounts[1:]} == pids
+        if shutdown == "stop":
+            await worker.stop()
+        else:
+            runner = asyncio.create_task(worker.run_forever(stop))
+            await asyncio.sleep(0.05)
+            if shutdown == "event":
+                stop.set()
+                await asyncio.wait_for(runner, 5)
+            else:
+                runner.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(runner, 5)
+        assert all(t.closed for t in network.transports)
+        for account_id in accounts:
+            assert await legacy_can_claim(engine, account_id)
+        async with ordinary.connect() as db:
+            assert await db.scalar(text("SELECT pg_backend_pid()")) not in pids
+    finally:
+        stop.set()
+        if runner is not None:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+
+async def test_lock_session_loss_stops_every_transport_and_reconnects_with_resume(provider, engine):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    old_transports = list(network.transports)
+    old_tasks = list(worker._tasks.values())
+    pid = await lock_pid(engine, accounts[0])
+    assert isinstance(pid, int)
+    async with engine.connect() as db:
+        # PID comes from this test's random key; never target a shared database.
+        assert await db.scalar(
+            text("""
+            SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+            WHERE pid = :pid AND datname = current_database() AND pid <> pg_backend_pid()
+        """),
+            {"pid": pid},
+        )
+    await eventually(
+        lambda: all(t.closed for t in old_transports) and all(t.done() for t in old_tasks)
+    )
+    for account_id in accounts:
+        assert await legacy_can_claim(engine, account_id)
+    assert await worker.run_once() == 4
+    await connected(network, 8)
+    for transport in network.transports[4:]:
+        authentication = next(frame for frame in transport.sent if frame["op"] in {2, 6})
+        assert authentication == {
+            "op": 6,
+            "d": {
+                "token": str(transport.account_id),
+                "session_id": str(transport.account_id),
+                "seq": 17,
+            },
+        }
+    replacement_pids = {await lock_pid(engine, account_id) for account_id in accounts}
+    assert (
+        len(replacement_pids) == 1 and None not in replacement_pids and pid not in replacement_pids
+    )
+
+
+async def test_real_scan_pool_timeout_recovers_without_cancelling_taskgroup(
+    provider,
+    engine,
+    monkeypatch,
+    caplog,
+):
+    ordinary, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    sibling_cancelled = asyncio.Event()
+
+    class Sibling:
+        async def run_forever(self, stop):
+            try:
+                await stop.wait()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+    async def no_listener():
+        pass
+
+    monkeypatch.setattr(channels, "build_channel_workers", lambda: (worker, Sibling()))
+    monkeypatch.setattr(channels, "start_postgres_listener", no_listener)
+    monkeypatch.setattr(channels, "stop_postgres_listener", no_listener)
+    stop = asyncio.Event()
+    runner = None
+    try:
+        async with ordinary.connect():
+            runner = asyncio.create_task(channels.run_channel_workers(stop))
+            await eventually(lambda: "discord gateway account scan failed" in caplog.text)
+            assert not runner.done() and not sibling_cancelled.is_set()
+            assert all(not t.closed for t in network.transports)
+            await archive(engine, accounts[0])
+        removed = next(t for t in network.transports if t.account_id == accounts[0])
+        await eventually(lambda: removed.closed)
+        assert not runner.done() and not sibling_cancelled.is_set()
+        stop.set()
+        await asyncio.wait_for(runner, 5)
+    finally:
+        stop.set()
+        if runner is not None:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+
+@pytest.mark.parametrize("fault", ["sql_error", "cancel"])
+async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
+    provider,
+    engine,
+    monkeypatch,
+    fault,
+):
+    ordinary, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    pid = await lock_pid(engine, accounts[0])
+    original_release = gateway.release_advisory_lock
+    releasing = asyncio.Event()
+
+    async def interrupted_release(connection, key):
+        if key == gateway.discord_gateway_advisory_lock_key(accounts[0]):
+            releasing.set()
+            if fault == "sql_error":
+                await connection.execute(text("SELECT 1 / 0"))
+            else:
+                await connection.execute(text("SELECT pg_sleep(10)"))
+        return await original_release(connection, key)
+
+    monkeypatch.setattr(gateway, "release_advisory_lock", interrupted_release)
+    await archive(engine, accounts[0])
+    await worker.run_once()
+    await asyncio.wait_for(releasing.wait(), 2)
+    if fault == "cancel":
+        worker._tasks[accounts[0]].cancel()
+    await eventually(
+        lambda: (
+            worker._lock_lost
+            and all(t.closed for t in network.transports)
+            and all(t.done() for t in worker._tasks.values())
+        )
+    )
+    await worker.stop()
+    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    for account_id in accounts:
+        assert await legacy_can_claim(engine, account_id)
+    async with ordinary.connect() as db:
+        assert await db.scalar(text("SELECT pg_backend_pid()")) != pid
+
+
+async def test_cancelled_claim_waiter_does_not_invalidate_sibling_ownership(provider, engine):
+    _, accounts, network, worker = provider
+    async with worker._lock_serial:
+        await worker.run_once()
+        task = worker._tasks[accounts[0]]
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not worker._lock_lost
+        assert all(not task.done() for key, task in worker._tasks.items() if key != accounts[0])
+    await worker.run_once()
+    await connected(network)
+    assert len({await lock_pid(engine, account_id) for account_id in accounts}) == 1
+
+
+async def test_ping_deadline_includes_serial_wait_and_stops_transports(provider):
+    _, _, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    async with worker._lock_serial:
+        await eventually(lambda: worker._lock_lost and all(t.closed for t in network.transports))
+    await worker.stop()
+
+
+async def test_repeated_stop_cancellation_finishes_session_cleanup(provider, engine, monkeypatch):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    started, release = asyncio.Event(), asyncio.Event()
+    original_close = worker._close_lock_session
+
+    async def delayed_close():
+        started.set()
+        await release.wait()
+        await original_close()
+
+    monkeypatch.setattr(worker, "_close_lock_session", delayed_close)
+    stopping = asyncio.create_task(worker.stop())
+    try:
+        await started.wait()
+        stopping.cancel()
+        await asyncio.sleep(0)
+        stopping.cancel()
+        await asyncio.sleep(0)
+        assert not stopping.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(stopping, 5)
+        assert all(t.closed for t in network.transports)
+        for account_id in accounts:
+            assert await legacy_can_claim(engine, account_id)
+    finally:
+        release.set()
+        await asyncio.gather(stopping, return_exceptions=True)
+
+
+async def test_terminal_close_survives_unlock_failure_and_session_recovery(provider, monkeypatch):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    account_id = accounts[0]
+    original_release = gateway.release_advisory_lock
+
+    async def failed_unlock(connection, key):
+        if key == gateway.discord_gateway_advisory_lock_key(account_id):
+            await connection.execute(text("SELECT 1 / 0"))
+        return await original_release(connection, key)
+
+    monkeypatch.setattr(gateway, "release_advisory_lock", failed_unlock)
+    transport = next(t for t in network.transports if t.account_id == account_id)
+    transport.frames.put_nowait(
+        ConnectionClosedError(Close(4004, "test invalid token"), None, None)
+    )
+    await eventually(lambda: all(t.done() for t in worker._tasks.values()))
+    assert account_id in worker._terminal_account_revisions
+    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    await worker.run_once()
+    await connected(network, 7)
+    assert all(t.account_id != account_id for t in network.transports[4:])
+    assert all(t.closed for t in network.transports[:4])

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -15,6 +15,7 @@ from websockets.frames import Close
 from app.core.config import settings
 from app.core.database import _create_engine
 from app.models.channel import ChannelAccount
+from app.services import discord_advisory_session as locks
 from app.services import discord_gateway_worker as gateway
 from app.services.vault_crypto import encrypt
 from app.workers import channels
@@ -312,8 +313,10 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
     await worker.run_once()
     await connected(network)
     pid = await lock_pid(engine, accounts[0])
-    original_release = gateway.release_advisory_lock
+    original_release = locks.release_advisory_lock
     releasing = asyncio.Event()
+    session = worker._locks._session
+    assert session is not None
 
     async def interrupted_release(connection, key):
         if key == gateway.discord_gateway_advisory_lock_key(accounts[0]):
@@ -324,7 +327,7 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
                 await connection.execute(text("SELECT pg_sleep(10)"))
         return await original_release(connection, key)
 
-    monkeypatch.setattr(gateway, "release_advisory_lock", interrupted_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", interrupted_release)
     await archive(engine, accounts[0])
     await worker.run_once()
     await asyncio.wait_for(releasing.wait(), 2)
@@ -332,13 +335,13 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
         worker._tasks[accounts[0]].cancel()
     await eventually(
         lambda: (
-            worker._lock_lost
+            session.failure is not None
             and all(t.closed for t in network.transports)
             and all(t.done() for t in worker._tasks.values())
         )
     )
     await worker.stop()
-    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", original_release)
     for account_id in accounts:
         assert await legacy_can_claim(engine, account_id)
     async with ordinary.connect() as db:
@@ -347,14 +350,14 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
 
 async def test_cancelled_claim_waiter_does_not_invalidate_sibling_ownership(provider, engine):
     _, accounts, network, worker = provider
-    async with worker._lock_serial:
+    async with worker._locks._serial:
         await worker.run_once()
         task = worker._tasks[accounts[0]]
         await asyncio.sleep(0)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        assert not worker._lock_lost
+        assert not worker._locks.failed
         assert all(not task.done() for key, task in worker._tasks.items() if key != accounts[0])
     await worker.run_once()
     await connected(network)
@@ -365,8 +368,8 @@ async def test_ping_deadline_includes_serial_wait_and_stops_transports(provider)
     _, _, network, worker = provider
     await worker.run_once()
     await connected(network)
-    async with worker._lock_serial:
-        await eventually(lambda: worker._lock_lost and all(t.closed for t in network.transports))
+    async with worker._locks._serial:
+        await eventually(lambda: worker._locks.failed and all(t.closed for t in network.transports))
     await worker.stop()
 
 
@@ -407,21 +410,21 @@ async def test_terminal_close_survives_unlock_failure_and_session_recovery(provi
     await worker.run_once()
     await connected(network)
     account_id = accounts[0]
-    original_release = gateway.release_advisory_lock
+    original_release = locks.release_advisory_lock
 
     async def failed_unlock(connection, key):
         if key == gateway.discord_gateway_advisory_lock_key(account_id):
             await connection.execute(text("SELECT 1 / 0"))
         return await original_release(connection, key)
 
-    monkeypatch.setattr(gateway, "release_advisory_lock", failed_unlock)
+    monkeypatch.setattr(locks, "release_advisory_lock", failed_unlock)
     transport = next(t for t in network.transports if t.account_id == account_id)
     transport.frames.put_nowait(
         ConnectionClosedError(Close(4004, "test invalid token"), None, None)
     )
     await eventually(lambda: all(t.done() for t in worker._tasks.values()))
     assert account_id in worker._terminal_account_revisions
-    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", original_release)
     await worker.run_once()
     await connected(network, 7)
     assert all(t.account_id != account_id for t in network.transports[4:])

--- a/backend/tests/test_discord_gateway_websockets.py
+++ b/backend/tests/test_discord_gateway_websockets.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlsplit
 from uuid import UUID, uuid4
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from websockets.asyncio.server import ServerConnection, serve
@@ -14,6 +15,7 @@ from websockets.exceptions import ConnectionClosedError
 
 import app.services.discord_gateway_worker as discord_gateway_worker_module
 from app.routes.channel_routers import discord as discord_router
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.discord_gateway_worker import (
     DiscordGatewayWorker,
     GatewayFrame,
@@ -22,6 +24,17 @@ from app.services.discord_gateway_worker import (
     discord_gateway_uri,
     parse_gateway_frame,
 )
+
+
+@pytest_asyncio.fixture
+async def consumer_locks(engine, request):
+    locks = DiscordAdvisorySession(
+        engine, liveness_interval_seconds=getattr(request, "param", 60.0)
+    )
+    try:
+        yield locks
+    finally:
+        await locks.close()
 
 
 @dataclass
@@ -78,6 +91,7 @@ async def _legacy_consumer_lease_lock_key(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_transaction(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000910")
     link_id = UUID("00000000-0000-4000-8000-000000000911")
@@ -86,8 +100,7 @@ async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_tra
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as acquired:
         assert acquired is True
         backend_pid = await _consumer_lease_backend_pid(engine, legacy_lock_key)
@@ -106,6 +119,7 @@ async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_tra
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000912")
     link_id = UUID("00000000-0000-4000-8000-000000000913")
@@ -113,14 +127,12 @@ async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as first_acquired:
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=60,
+            lock_session=consumer_locks,
         ) as second_acquired:
             assert first_acquired is True
             assert second_acquired is False
@@ -129,6 +141,7 @@ async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000914")
     link_id = UUID("00000000-0000-4000-8000-000000000915")
@@ -136,16 +149,14 @@ async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as acquired:
         assert acquired is True
 
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as reacquired:
         assert reacquired is True
 
@@ -153,6 +164,7 @@ async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000916")
     link_id = UUID("00000000-0000-4000-8000-000000000917")
@@ -162,8 +174,7 @@ async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=60,
+            lock_session=consumer_locks,
         ) as acquired:
             assert acquired is True
             entered.set()
@@ -178,15 +189,16 @@ async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as reacquired:
         assert reacquired is True
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("consumer_locks", [0.01], indirect=True)
 async def test_synthetic_gateway_consumer_stops_when_lease_connection_is_lost(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000918")
     link_id = UUID("00000000-0000-4000-8000-000000000919")
@@ -197,8 +209,7 @@ async def test_synthetic_gateway_consumer_stops_when_lease_connection_is_lost(
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=0.01,
+            lock_session=consumer_locks,
         ) as acquired:
             assert acquired is True
             entered.set()

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -41,6 +41,7 @@ from app.routes import admin as admin_route
 from app.routes import sync as sync_route
 from app.routes.channel_routers.discord import _discord_gateway_consumer_lease
 from app.services import platform_workload_auth, runtime_source_authority
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.platform_workload_auth import (
     PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
     PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
@@ -276,6 +277,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
     """Real pool contention must not strand token issuance or deployment recovery."""
     monkeypatch.setattr(settings, "db_pool_timeout", 1.0)
     ordinary = database._create_engine(pool_size=2, max_overflow=0)
+    gateway_locks = DiscordAdvisorySession(ordinary)
     control = database._create_engine(pool_size=database.CONTROL_POOL_SIZE, max_overflow=0)
     snapshot = database._create_engine(pool_size=1, max_overflow=0)
     ordinary_sessions = async_sessionmaker(
@@ -318,7 +320,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
         # A gateway lease and a channel transaction awaiting provider I/O consume
         # both ordinary slots. Only the external provider call is stubbed.
         async with _discord_gateway_consumer_lease(
-            account_id=uuid.uuid4(), bot_agent_link_id=uuid.uuid4(), lock_engine=ordinary
+            account_id=uuid.uuid4(), bot_agent_link_id=uuid.uuid4(), lock_session=gateway_locks
         ) as acquired:
             assert acquired
             pressure = asyncio.create_task(
@@ -380,6 +382,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
                 await asyncio.gather(pressure, return_exceptions=True)
         assert (await client.get("/ready")).status_code == 200
     finally:
+        await gateway_locks.close()
         await ordinary.dispose()
         await control.dispose()
         await snapshot.dispose()

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -81,29 +81,43 @@ uv run ruff format --check .
 uv run python -m compileall app scripts tests alembic
 ```
 
-## Discord provider Gateway ownership
+## Discord Gateway ownership
 
-Each `DiscordGatewayWorker` holds one PostgreSQL connection for its account
-advisory locks. Account tasks claim the existing per-account key once per
-transport attempt and release it after the transport closes; discovery scans
-do not reacquire held keys. Lock SQL and liveness probes share a serial gate.
-Ordinary account/dispatch queries continue to use the ordinary pool.
+[`DiscordAdvisorySession`](../backend/app/services/discord_advisory_session.py)
+shares one PostgreSQL connection across a role's Gateway locks. The provider
+worker owns one instance; ASGI lifespan owns the agent-facing consumer instance
+in application state. Tests inject an explicit shared instance. There is no
+engine-keyed global cache or per-lease connection. Existing provider account
+keys and consumer Account/Link keys remain unchanged. A local ownership table
+rejects duplicate keys before PostgreSQL's reentrant lock can admit them.
+
+Claim, unlock, and liveness SQL share a serial gate. Discovery does not claim
+keys already held by account tasks. Ordinary account/dispatch queries continue
+to use the ordinary pool.
 
 The default liveness interval is one second, with a five-second probe deadline
 including serial-gate waiting. Lock SQL also has a five-second deadline. These
 are application cancellation deadlines, not guarantees about TCP blackhole or
 driver/transport cleanup latency. A failed or uncertain lock operation fences
-the shared session and cancels its Gateway tasks. The worker joins those tasks
-before invalidating the connection; it never returns that ownership session
-to the pool on shutdown or recovery. Recovery acquires fresh locks and keeps
-the existing Gateway resume state and last durably admitted sequence.
+the session and cancels its owners. One observed retirement task joins owners
+and invalidates the connection without waiting for another request or scan.
+The account whose unlock failed exits through its original transport exception;
+failure retirement does not cancel it again. Normal shutdown cancels owners,
+joins them outside the SQL gate, then invalidates the connection. Cleanup uses
+`finish_cleanup`, including repeated cancellation. Closing or recovering one's
+own active lease is rejected before entering cleanup; lifespan and worker
+supervisors own those operations.
+
+Recovery obtains new locks without carrying ownership across sessions. Provider
+resume state, consumer LeaseLost/4008 behavior, and durable sequence acknowledgements
+remain at their existing protocol boundaries.
 
 Account discovery errors retry with bounded backoff without ending the channel
 worker TaskGroup. Account terminal close codes still require a credential or
 configuration revision before retrying.
 
-Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py`
-starts its own disposable PostgreSQL and reports passing ownership tests.
+Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py tests/test_discord_consumer_resource_boundary.py`
+starts disposable PostgreSQL and reports passing ownership tests.
 
 ## Python type governance
 

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -81,6 +81,30 @@ uv run ruff format --check .
 uv run python -m compileall app scripts tests alembic
 ```
 
+## Discord provider Gateway ownership
+
+Each `DiscordGatewayWorker` holds one PostgreSQL connection for its account
+advisory locks. Account tasks claim the existing per-account key once per
+transport attempt and release it after the transport closes; discovery scans
+do not reacquire held keys. Lock SQL and liveness probes share a serial gate.
+Ordinary account/dispatch queries continue to use the ordinary pool.
+
+The default liveness interval is one second, with a five-second probe deadline
+including serial-gate waiting. Lock SQL also has a five-second deadline. These
+are application cancellation deadlines, not guarantees about TCP blackhole or
+driver/transport cleanup latency. A failed or uncertain lock operation fences
+the shared session and cancels its Gateway tasks. The worker joins those tasks
+before invalidating the connection; it never returns that ownership session
+to the pool on shutdown or recovery. Recovery acquires fresh locks and keeps
+the existing Gateway resume state and last durably admitted sequence.
+
+Account discovery errors retry with bounded backoff without ending the channel
+worker TaskGroup. Account terminal close codes still require a credential or
+configuration revision before retrying.
+
+Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py`
+starts its own disposable PostgreSQL and reports passing ownership tests.
+
 ## Python type governance
 
 BasedPyright runs from the uv development environment. The owned gate covers


### PR DESCRIPTION
Each provider Gateway Account and synthetic Gateway consumer previously pinned an ordinary PostgreSQL connection. Enough Gateways could starve ordinary queries; provider discovery errors could then stop sibling channel workers, and a lost provider lock connection did not stop its transport.

Use one monitored Discord advisory-lock session per role instance. The worker owns the provider instance and ASGI lifespan owns the consumer instance. Local key ownership prevents PostgreSQL reentrant locks from admitting two local consumers; existing provider and consumer keys retain cross-process and rolling-version exclusion. Claims, unlocks, and liveness SQL are serialized with deadlines.

Failed sessions stop their associated Gateway tasks and retire automatically, even without a subsequent request. Cleanup joins owners before discarding the session; normal shutdown, claim/close races, cancellation, terminal close codes, and durable Resume sequences retain explicit ownership. A session failure can reconnect all Gateways owned by that role instance. No extra database pool or schema migration is required.

Validation: the complete isolated Python 3.14.7/PostgreSQL 18.4 suite passed 2794 tests (12 skipped, one expected failure); Ruff and strict production typing passed. Real PostgreSQL tests cover four consumers sharing one slot in a two-slot ordinary pool, ordinary SELECT progress, local and separate-process exclusion, live-backend SQL failure with automatic lock release, lock-session termination, claim/close races, cancelled waiters, repeated cancellation, terminal 4004 with unlock failure, and Resume behavior. Resource fixtures use an owned schema so global scans remain independent of other tests' committed rows. Root and Fable reviewed the runtime diff. The measured benefit is bounded connection use; end-to-end production latency has not been measured.

Integrated through #1458 at commit `69f7ad493693c11deead97d56c4747e10201edda`.
