### PR TITLE
fix(cli): allow Hermes version checks to finish in 0.14.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- CLI 0.14.64 allows more time for Hermes version checks so slow native update
+  checks do not interrupt agent setup or reconnection.
 - CLI 0.14.63 lets Hermes wait up to 20 minutes for Clawdi AI Responses calls,
   preserving explicit timeout settings and withdrawing the default when switching
   to a self-managed provider.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.63",
+      "version": "0.14.64",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.63",
+	"version": "0.14.64",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -482,16 +482,19 @@ export function runtimeCommandVersion(command: string, home: string, cwd: string
 	const cacheKey = `${command}\0${home}\0${cwd}`;
 	const cached = runtimeCommandRevisions.get(cacheKey);
 	if (cached?.executableRevision === executableRevision) return cached.version;
+	// Hermes --version synchronously checks updates: git fetch and the compare API
+	// each allow 10 seconds upstream. Leave room for both plus native startup.
+	const timeoutMs = command === runtimeCommandPath("hermes", home) ? 30_000 : 10_000;
 	try {
 		const versionResult = spawnRuntimeUserCommand(command, ["--version"], home, cwd, {
-			timeoutMs: 10_000,
+			timeoutMs,
 		});
 		if (
 			versionResult.error &&
 			"code" in versionResult.error &&
 			versionResult.error.code === "ETIMEDOUT"
 		) {
-			throw new RuntimeUserCommandTimeoutError(`runtime --version probe for ${command}`, 10_000);
+			throw new RuntimeUserCommandTimeoutError(`runtime --version probe for ${command}`, timeoutMs);
 		}
 		if (versionResult.status !== 0) return null;
 		const stdout = Buffer.isBuffer(versionResult.stdout)

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -24,6 +24,7 @@ import { OFFICIAL_INSTALL_URLS, officialInstallArgs } from "./manifest-contract"
 import {
 	observeRuntimeInstall,
 	runtimeCommandCurrentRevision,
+	runtimeCommandVersion,
 	writeRuntimeInstallerLog,
 } from "./manifest-install";
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
@@ -76,6 +77,23 @@ printf '%s\n' '${version}'
 	expect(revised).not.toBe(first);
 	expect(readFileSync(log, "utf8").trim().split("\n")).toEqual(["--version", "--version"]);
 });
+
+test("accepts a Hermes native version check that takes more than ten seconds", () => {
+	const paths = tempRuntimePaths();
+	const command = join(paths.userHome, ".local", "bin", "hermes");
+	writeFakeGatewayCli({
+		path: command,
+		logPath: join(paths.runRoot, "commands.log"),
+		runtime: "hermes",
+		unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+		version: "Hermes Agent v0.21.1",
+		versionDelaySeconds: 11,
+	});
+
+	expect(runtimeCommandVersion(command, paths.userHome, paths.userHome)).toBe(
+		"Hermes Agent v0.21.1",
+	);
+}, 20_000);
 
 test("adopts a persisted native Hermes service in a fresh process without reinstalling", () => {
 	const paths = tempRuntimePaths();
@@ -361,6 +379,7 @@ function writeFakeGatewayCli(input: {
 	runtime: "openclaw" | "hermes";
 	unitPath: string;
 	version?: string;
+	versionDelaySeconds?: number;
 	hangVersion?: boolean;
 	failVersion?: boolean;
 	failInstall?: boolean;
@@ -393,6 +412,7 @@ function writeFakeGatewayCli(input: {
 	set -euo pipefail
 	case "$*" in
 	  "--version")
+		${input.versionDelaySeconds ? `sleep ${input.versionDelaySeconds}` : ""}
 		${input.hangVersion ? "exec sleep 60" : input.failVersion ? "exit 1" : `printf '%s\\n' '${version}'`}
 		;;
   "gateway install --force --json"|"gateway install --force --no-start-now"|"gateway install")


### PR DESCRIPTION
Hermes setup can fail after a successful official installation because its native `--version` command synchronously checks for updates. A Git fetch can consume the CLI's entire 10-second version-probe deadline before Hermes finishes. Give only the canonical `runtimeCommandPath("hermes", home)` probe 30 seconds; keep other probes at 10 seconds and use the selected deadline for both execution and timeout errors. Native output, exit-status handling, and revision caching remain intact.

The installed upstream commit was `a785db3672970395f6f872113610a05186a0e919`. Its [version path](https://github.com/NousResearch/hermes-agent/blob/a785db3672970395f6f872113610a05186a0e919/hermes_cli/_startup_fast.py#L164) synchronously invokes the update check, whose [Git fetch](https://github.com/NousResearch/hermes-agent/blob/a785db3672970395f6f872113610a05186a0e919/hermes_cli/banner.py#L304) and possible [compare API request](https://github.com/NousResearch/hermes-agent/blob/a785db3672970395f6f872113610a05186a0e919/hermes_cli/banner.py#L229) each allow 10 seconds. The new budget leaves startup headroom around those network steps without disabling native update checks or adding retries.

Prepare CLI 0.14.64 in the package manifest, lockfile, and user changelog; 0.14.63 is already published.

Validation:
- `bash scripts/test.sh cli src/runtime/manifest-services.test.ts`: CLI typecheck and 29 tests passed (313 assertions), using frozen dependencies in the Docker clean runner.
- One new regression uses the existing executable fixture and takes 11.01 seconds to return the native version successfully. The unchanged hanging OpenClaw regression still returns the 10-second timeout (10.10 seconds observed).
- Biome 2.5.11 checked the changed TypeScript and package manifest in a disposable Bun 1.4.0 container; `git diff --check` passed. The local commit hook reported missing lefthook; Biome was run independently.

The signed-image native qualification remains a release gate for the new artifact. No merge, publication, or rollout has been performed.
