### PR TITLE
perf(channels): reduce avoidable message delivery waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- Discord messages reach connected agents sooner, especially after idle periods.
 - Telegram agents receive available updates sooner when earlier updates have
   already been acknowledged or excluded by their requested update types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- Telegram agents receive available updates sooner when earlier updates have
+  already been acknowledged or excluded by their requested update types.
+
 - CLI 0.14.60 updates bundled and Hosted Skill guidance to manage connector
   accounts through Composio with explicit list, add, rename, and remove actions.
 - Resources opened from an Agent stay in that Agent, including unlinked Projects,

--- a/backend/alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py
+++ b/backend/alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py
@@ -1,0 +1,32 @@
+"""Persist Telegram webhook fallback backoff per Binding."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a6d9c2e4f7b1"
+down_revision = "9b3e2a71c640"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("channel_bindings", sa.Column("webhook_retry_at", sa.DateTime(timezone=True)))
+    op.add_column(
+        "channel_bindings",
+        sa.Column("webhook_retry_step", sa.SmallInteger(), nullable=False, server_default="0"),
+    )
+    op.create_check_constraint(
+        "ck_channel_bindings_webhook_retry_step_nonnegative",
+        "channel_bindings",
+        "webhook_retry_step >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_channel_bindings_webhook_retry_step_nonnegative",
+        "channel_bindings",
+        type_="check",
+    )
+    op.drop_column("channel_bindings", "webhook_retry_step")
+    op.drop_column("channel_bindings", "webhook_retry_at")

--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
 import logging
+import re
 
 _HTTP_CLIENT_LOGGERS = ("httpx", "httpcore", "httpx2", "httpcore2")
+TELEGRAM_BOT_API_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+_DISCORD_TOKEN_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/discord/(?:api/)?v10/"
+    r"(?:interactions|webhooks)/[^/]+/)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+_DISCORD_GATEWAY_PATH_RE = re.compile(
+    r"^(?P<prefix>/(?:api|v1)/channels/discord/gateway/)[^/]+(?P<suffix>/.*)?$",
+    re.IGNORECASE,
+)
+
+
+def redact_request_path(path: str) -> str:
+    """Keep route context without credentials embedded in channel URL paths."""
+    for pattern in (
+        TELEGRAM_BOT_API_PATH_RE,
+        _DISCORD_TOKEN_PATH_RE,
+        _DISCORD_GATEWAY_PATH_RE,
+    ):
+        match = pattern.match(path)
+        if match is not None:
+            return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
+    return path
 
 
 def configure_application_logging() -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,8 @@ from app.core.database import (
     ControlLockTimeoutError,
     control_engine,
     control_snapshot_engine,
+    engine,
+    finish_cleanup,
     get_session,
 )
 from app.core.logging_config import configure_application_logging
@@ -77,6 +79,7 @@ from app.routes.vault import router as vault_router
 from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorruptError
 from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client, run_tool_router_mcp_session_reaper
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.embedding import LocalEmbedder, LocalServiceEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
 from app.services.metrics import db_control_lock_timeouts, db_pool_timeouts, observe_event_loop_lag
@@ -157,34 +160,42 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         background.add(task)
         task.add_done_callback(background.discard)
 
+    discord_locks = DiscordAdvisorySession(
+        engine, liveness_interval_seconds=settings.discord_gateway_poll_interval_seconds
+    )
+    _app.state.discord_gateway_locks = discord_locks
     try:
         yield
     finally:
-        # On shutdown, cancel anything still running and wait for it so we
-        # don't leak a task into whatever signal handler runs next.
-        for t in background:
-            t.cancel()
-        if background:
-            await asyncio.gather(*background, return_exceptions=True)
         try:
-            await whatsapp_sidecars.stop()
+            await finish_cleanup(discord_locks.close)
         finally:
+            del _app.state.discord_gateway_locks
+            # On shutdown, cancel anything still running and wait for it so we
+            # don't leak a task into whatever signal handler runs next.
+            for t in background:
+                t.cancel()
+            if background:
+                await asyncio.gather(*background, return_exceptions=True)
             try:
-                await stop_postgres_listener()
+                await whatsapp_sidecars.stop()
             finally:
                 try:
-                    await close_channel_provider_http_client()
+                    await stop_postgres_listener()
                 finally:
                     try:
-                        await close_composio_client()
+                        await close_channel_provider_http_client()
                     finally:
                         try:
-                            await LocalServiceEmbedder.close_shared()
+                            await close_composio_client()
                         finally:
                             try:
-                                await control_engine.dispose()
+                                await LocalServiceEmbedder.close_shared()
                             finally:
-                                await control_snapshot_engine.dispose()
+                                try:
+                                    await control_engine.dispose()
+                                finally:
+                                    await control_snapshot_engine.dispose()
 
 
 app = FastAPI(

--- a/backend/app/middleware/body_size_limit.py
+++ b/backend/app/middleware/body_size_limit.py
@@ -27,6 +27,8 @@ import logging
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from app.core.logging_config import redact_request_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,7 +77,7 @@ class BodySizeLimitMiddleware:
                     logger.info(
                         "body_size_rejected_header method=%s path=%s declared=%d cap=%d",
                         method,
-                        scope.get("path", ""),
+                        redact_request_path(scope.get("path", "")),
                         declared,
                         self.max_bytes,
                     )
@@ -117,7 +119,7 @@ class BodySizeLimitMiddleware:
                 logger.info(
                     "body_size_rejected_stream method=%s path=%s read=%d cap=%d",
                     method,
-                    scope.get("path", ""),
+                    redact_request_path(scope.get("path", "")),
                     total,
                     self.max_bytes,
                 )

--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -9,18 +9,15 @@ of application logs.
 from __future__ import annotations
 
 import logging
-import re
 import time
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from app.core.logging_config import TELEGRAM_BOT_API_PATH_RE, redact_request_path
+
 logger = logging.getLogger(__name__)
 _PROCESS_TIME_HEADER = b"x-process-time-ms"
 _SYNC_EVENTS_PATHS = frozenset(("/v1/sync/events", "/api/sync/events"))
-_TELEGRAM_BOT_API_PATH_RE = re.compile(
-    r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
-    re.IGNORECASE,
-)
 
 
 class RequestTimingMiddleware:
@@ -38,7 +35,7 @@ class RequestTimingMiddleware:
         method = raw_method if isinstance(raw_method, str) else "GET"
         raw_path_value: object = scope.get("path", "")
         raw_path = raw_path_value if isinstance(raw_path_value, str) else ""
-        path = _log_safe_path(raw_path)
+        path = redact_request_path(raw_path)
         status_code = 500
 
         async def timed_send(message: Message) -> None:
@@ -97,17 +94,10 @@ def _is_slow(*, duration_ms: float, slow_ms: float) -> bool:
     return slow_ms > 0 and duration_ms >= slow_ms
 
 
-def _log_safe_path(path: str) -> str:
-    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
-    if match is None:
-        return path
-    return f"{match.group('prefix')}[redacted]{match.group('suffix') or ''}"
-
-
 def _is_expected_long_request(path: str) -> bool:
     if path in _SYNC_EVENTS_PATHS:
         return True
-    match = _TELEGRAM_BOT_API_PATH_RE.match(path)
+    match = TELEGRAM_BOT_API_PATH_RE.match(path)
     if match is None or "/file/" in match.group("prefix").lower():
         return False
     return (match.group("suffix") or "").lower() == "/getupdates"

--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -2,15 +2,19 @@
 
 Adds a cheap per-request process-time response header and logs only slow
 requests or server errors. Logs intentionally include method/path/status/time
-and request id only; query strings, headers, bodies, and user identity stay out
-of application logs.
+and request id, plus fixed channel stage timings; query strings, headers, bodies,
+and user identity stay out of application logs.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Literal, cast
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -23,6 +27,44 @@ _TELEGRAM_BOT_API_PATH_RE = re.compile(
 )
 
 
+# Wall-clock stages include event-loop waits. Initially instrumented only on the
+# Telegram Bot API proxy. Provider time includes pool waits, TCP/TLS and RTT,
+# not just provider processing. Request body arrival/parsing, response parsing
+# and result reference writes remain unattributed: the stage sum is not the
+# whole request duration.
+type ChannelStage = Literal["channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms"]
+_CHANNEL_STAGES: tuple[ChannelStage, ...] = (
+    "channel_auth_ms",
+    "channel_url_validation_ms",
+    "channel_provider_ms",
+)
+_CHANNEL_TIMING_STATE = "_channel_stage_timings"
+
+
+@contextmanager
+def channel_stage(scope: Scope, stage: ChannelStage) -> Generator[None]:
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        scope.setdefault("state", {}).setdefault(_CHANNEL_TIMING_STATE, {})[stage] = _elapsed_ms(
+            started
+        )
+
+
+def _channel_stage_log_fields(scope: Scope) -> str:
+    timings: object = scope.get("state", {}).get(_CHANNEL_TIMING_STATE)
+    if not isinstance(timings, dict):
+        return ""
+    values = cast(dict[object, object], timings)
+    fields: list[str] = []
+    for stage in _CHANNEL_STAGES:
+        value = values.get(stage)
+        if isinstance(value, float) and math.isfinite(value) and value >= 0:
+            fields.append(f" {stage}={value:.1f}")
+    return "".join(fields)
+
+
 class RequestTimingMiddleware:
     def __init__(self, app: ASGIApp, *, slow_ms: float) -> None:
         self.app = app
@@ -33,6 +75,8 @@ class RequestTimingMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # ASGI lifespan state is shallow-copied; replace the nested dict per request.
+        scope.setdefault("state", {})[_CHANNEL_TIMING_STATE] = {}
         started = time.perf_counter()
         raw_method: object = scope.get("method", "GET")
         method = raw_method if isinstance(raw_method, str) else "GET"
@@ -57,35 +101,38 @@ class RequestTimingMiddleware:
         except Exception:
             duration_ms = _elapsed_ms(started)
             logger.exception(
-                "request_failed method=%s path=%s status=500 duration_ms=%.1f request_id=%s",
+                "request_failed method=%s path=%s status=500 duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
             raise
 
         duration_ms = _elapsed_ms(started)
         if status_code >= 500:
             logger.warning(
-                "request_error method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                "request_error method=%s path=%s status=%d duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 status_code,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
         elif not _is_expected_long_request(raw_path) and _is_slow(
             duration_ms=duration_ms,
             slow_ms=self.slow_ms,
         ):
             logger.warning(
-                "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s%s",
                 method,
                 path,
                 status_code,
                 duration_ms,
                 _request_id(scope),
+                _channel_stage_log_fields(scope),
             )
 
 

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Index,
     Integer,
     LargeBinary,
+    SmallInteger,
     String,
     Text,
     UniqueConstraint,
@@ -361,8 +362,16 @@ class ChannelBinding(Base, TimestampMixin):
         default=BINDING_STATUS_ACTIVE,
         server_default=BINDING_STATUS_ACTIVE,
     )
+    webhook_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    webhook_retry_step: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0, server_default="0"
+    )
 
     __table_args__ = (
+        CheckConstraint(
+            "webhook_retry_step >= 0",
+            name="ck_channel_bindings_webhook_retry_step_nonnegative",
+        ),
         Index(
             "uq_channel_bindings_account_external_chat_active",
             "account_id",

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -47,6 +47,7 @@ from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_STATUS_ACTIVE,
     ChannelAccount,
+    ChannelAgentReference,
     ChannelBinding,
     ChannelBindingAlias,
     ChannelBotAgentLink,
@@ -366,7 +367,9 @@ async def discord_agent_rest(
     if segments == ["users", "@me"]:
         if request.method == "PATCH":
             params = await request_params(request)
-            config = dict(account.config) if isinstance(account.config, dict) else {}
+            # Share the Link lock with command-shadow writes to preserve unrelated config.
+            await db.refresh(agent.link, with_for_update=True)
+            config = dict(agent.link.config) if isinstance(agent.link.config, dict) else {}
             username = optional_str(params.get("username"))
             if username:
                 config["bot_username"] = username
@@ -378,9 +381,9 @@ async def discord_agent_rest(
                         detail="avatar must be a JSON value",
                     )
                 config["bot_avatar"] = avatar
-            account.config = config
+            agent.link.config = config
             await db.commit()
-        return discord_bot_user(account)
+        return discord_bot_user(account, agent.link)
     command_response = await handle_discord_application_commands(
         db,
         agent=agent,
@@ -390,7 +393,7 @@ async def discord_agent_rest(
     if command_response is not None:
         return command_response
     if segments in (["oauth2", "applications", "@me"], ["applications", "@me"]):
-        user = discord_bot_user(account)
+        user = discord_bot_user(account, agent.link)
         return {
             "id": user["id"],
             "name": user["username"],
@@ -1257,7 +1260,7 @@ async def discord_agent_gateway(
                                 else public_ws_url("/v1/channels/discord/gateway")
                             )
                         ),
-                        "user": discord_bot_user(account),
+                        "user": discord_bot_user(account, resolved_agent.link),
                         "application": {"id": discord_application_id(account)},
                         "guilds": [{"id": guild_id, "unavailable": False} for guild_id in guilds],
                         "private_channels": [
@@ -1787,6 +1790,30 @@ async def cleanup_discord_guild_commands_after_authority_revoked(
         return False
 
 
+async def _discord_interaction_reference_is_authorized(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+    reference: ChannelAgentReference | None,
+) -> bool:
+    # Agent interactions require a live Binding. Unbound/control interactions
+    # are answered by the platform; orphaned historical references grant no authority.
+    if reference is None or reference.binding_id is None:
+        return False
+    binding = await db.get(ChannelBinding, reference.binding_id)
+    if binding is None:
+        return False
+    leased = await lock_active_discord_binding_lease(
+        db,
+        account_id=account.id,
+        bot_agent_link_id=bot_agent_link_id,
+        binding_id=binding.id,
+        external_chat_id=binding.external_chat_id,
+    )
+    return leased is not None and leased.user_id == reference.user_id
+
+
 async def _handle_discord_interaction_callback(
     db: AsyncSession,
     *,
@@ -1807,7 +1834,9 @@ async def _handle_discord_interaction_callback(
         ref_value=f"{interaction_id}:{token}",
         bot_agent_link_id=bot_agent_link_id,
     )
-    if reference is None:
+    if not await _discord_interaction_reference_is_authorized(
+        db, account=account, bot_agent_link_id=bot_agent_link_id, reference=reference
+    ):
         return _discord_rest_error("Unknown Interaction", 10062, 404)
     return await proxy_discord_request(account=account, request=request, path=path)
 
@@ -1835,6 +1864,10 @@ async def _handle_discord_webhook_followup(
     metadata = reference.metadata_ if reference is not None else None
     recorded_application_id = metadata.get("application_id") if isinstance(metadata, dict) else None
     if reference is None or recorded_application_id != application_id:
+        return _discord_rest_error("Unknown Webhook", 10015, 404)
+    if not await _discord_interaction_reference_is_authorized(
+        db, account=account, bot_agent_link_id=bot_agent_link_id, reference=reference
+    ):
         return _discord_rest_error("Unknown Webhook", 10015, 404)
     return await proxy_discord_request(account=account, request=request, path=path)
 

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -33,14 +33,13 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, Response
 from pydantic import JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import and_, select, text
+from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
-from app.core.database import engine as database_engine
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
@@ -106,9 +105,9 @@ from app.services.channels import (
     verify_discord_signature,
     verify_webhook_secret,
 )
-from app.services.discord_gateway_worker import (
-    release_advisory_lock,
-    try_advisory_lock,
+from app.services.discord_advisory_session import (
+    DiscordAdvisorySession,
+    DiscordAdvisorySessionLost,
 )
 
 router = APIRouter(prefix="/channels/discord", tags=["channels"])
@@ -1068,6 +1067,7 @@ async def discord_agent_gateway(
                 consumer_lease = _discord_gateway_consumer_lease(
                     account_id=resolved_account.id,
                     bot_agent_link_id=resolved_link_id,
+                    lock_session=_consumer_lock_session(websocket),
                 )
                 lease_acquired = await consumer_lease.__aenter__()
                 consumer_lease_entered = True
@@ -1197,6 +1197,7 @@ async def discord_agent_gateway(
                 consumer_lease = _discord_gateway_consumer_lease(
                     account_id=resolved_account.id,
                     bot_agent_link_id=resolved_link_id,
+                    lock_session=_consumer_lock_session(websocket),
                 )
                 lease_acquired = await consumer_lease.__aenter__()
                 consumer_lease_entered = True
@@ -2035,99 +2036,43 @@ async def _send_discord_gateway_message(
         return "dropped", None
 
 
+def _consumer_lock_session(websocket: WebSocket) -> DiscordAdvisorySession:
+    session = getattr(websocket.app.state, "discord_gateway_locks", None)
+    if not isinstance(session, DiscordAdvisorySession):
+        raise RuntimeError("Discord consumer lock owner is not running")
+    return session
+
+
 @asynccontextmanager
 async def _discord_gateway_consumer_lease(
     *,
     account_id: UUID,
     bot_agent_link_id: UUID,
-    lock_engine: AsyncEngine | None = None,
-    liveness_interval_seconds: float | None = None,
+    lock_session: DiscordAdvisorySession,
 ):
-    """Allow one synthetic shard consumer per AgentLink across processes."""
-    connection = await (lock_engine or database_engine).connect()
-    acquired = False
-    lock_key: int | None = None
-    safe_to_pool = False
-    monitor_failure: Exception | None = None
-    body_error: BaseException | None = None
-    cleanup_error: BaseException | None = None
-    monitor_stop = asyncio.Event()
-    monitor_task: asyncio.Task[None] | None = None
-    owner_task = asyncio.current_task()
-    if owner_task is None:
-        await connection.close()
-        raise RuntimeError("discord gateway consumer lease requires an asyncio task")
-    lock_name = f"discord-agent-gateway:{account_id}:{bot_agent_link_id}"
-
-    async def monitor_connection() -> None:
-        nonlocal monitor_failure
-        interval = max(
-            0.001,
-            liveness_interval_seconds
-            if liveness_interval_seconds is not None
-            else settings.discord_gateway_poll_interval_seconds,
-        )
-        try:
-            while True:
-                try:
-                    await asyncio.wait_for(monitor_stop.wait(), timeout=interval)
-                    return
-                except TimeoutError:
-                    await connection.execute(text("SELECT 1"))
-                    await connection.commit()
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            monitor_failure = exc
-            owner_task.cancel()
-
+    """Allow one synthetic shard consumer per AgentLink locally and across processes."""
     try:
-        await connection.execution_options(isolation_level="AUTOCOMMIT")
-        # Keep the transaction-level lease identity used by older rolling-deploy peers.
-        lock_key_result = await connection.execute(
-            text("SELECT hashtextextended(:lock_name, 0)"),
-            {"lock_name": lock_name},
-        )
-        await connection.commit()
-        resolved_lock_key = lock_key_result.scalar_one()
-        if not isinstance(resolved_lock_key, int) or isinstance(resolved_lock_key, bool):
-            raise RuntimeError("discord gateway consumer advisory lock key is invalid")
-        lock_key = resolved_lock_key
-        acquired = await try_advisory_lock(connection, lock_key)
-        safe_to_pool = not acquired
-        if acquired:
-            monitor_task = asyncio.create_task(
-                monitor_connection(),
-                name=f"discord-gateway-consumer-lease-{bot_agent_link_id}",
-            )
-        try:
-            yield acquired
-        except BaseException as exc:
-            body_error = exc
-    finally:
-        monitor_stop.set()
-        try:
-            if monitor_task is not None:
-                await monitor_task
-            if acquired:
-                if lock_key is None:
-                    raise RuntimeError("discord gateway consumer advisory lock key is missing")
-                if not await release_advisory_lock(connection, lock_key):
-                    raise RuntimeError("discord gateway consumer advisory unlock failed")
-                safe_to_pool = True
-        except BaseException as exc:
-            cleanup_error = exc
-        finally:
-            try:
-                if not safe_to_pool:
-                    await connection.invalidate()
-            finally:
-                await connection.close()
-
-    if monitor_failure is not None:
+        lease = await lock_session.claim(f"discord-agent-gateway:{account_id}:{bot_agent_link_id}")
+    except DiscordAdvisorySessionLost as exc:
         raise _DiscordGatewayConsumerLeaseLost(
             "discord gateway consumer lease connection lost"
-        ) from monitor_failure
+        ) from exc
+    body_error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+    try:
+        yield lease is not None
+    except BaseException as exc:
+        body_error = exc
+    finally:
+        if lease is not None:
+            try:
+                await lock_session.release(lease)
+            except BaseException as exc:
+                cleanup_error = exc
+            if lease.failed:
+                raise _DiscordGatewayConsumerLeaseLost(
+                    "discord gateway consumer lease connection lost"
+                ) from (cleanup_error or lease.session.failure)
     if cleanup_error is not None:
         raise cleanup_error
     if body_error is not None:

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -39,7 +39,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from starlette.datastructures import UploadFile
 
 from app.core.config import settings
-from app.core.database import async_session_factory, get_session
+from app.core.database import async_session_factory, finish_cleanup, get_session
 from app.core.database import engine as database_engine
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
@@ -72,6 +72,7 @@ from app.routes.channel_routers.shared import (
     require_bound_chat,
     resolve_discord_agent_context,
 )
+from app.services.channel_wakeups import channel_inbound_messages_enqueued
 from app.services.channels import (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
@@ -865,6 +866,9 @@ async def discord_agent_gateway(
     consumer_lease: AbstractAsyncContextManager[bool] | None = None
     consumer_lease_entered = False
     owns_session_entry = False
+    notified: asyncio.Event | None = None
+    receive_task: asyncio.Task[JsonValue] | None = None
+    wakeup_task: asyncio.Task[bool] | None = None
 
     async def send_gateway_frame(
         payload: JsonObject,
@@ -1277,8 +1281,24 @@ async def discord_agent_gateway(
             await websocket.close(code=4004)
             return
         active_link_id = bot_agent_link_id
+        notified = channel_inbound_messages_enqueued.subscribe(str(account.id))
+        receive_task = asyncio.create_task(websocket.receive_json(), name="discord-gateway-receive")
 
         while True:
+            # Retain the reader across notifications/timeouts, including when
+            # both inputs complete together or dispatch batches keep arriving.
+            if receive_task.done():
+                frame = _JSON_VALUE_ADAPTER.validate_python(receive_task.result())
+                if isinstance(frame, dict) and frame.get("op") == 1:
+                    await acknowledge_gateway_sequence(optional_int_param(frame.get("d")))
+                    await send_gateway_frame({"op": 11, "d": None}, record=False)
+                receive_task = asyncio.create_task(
+                    websocket.receive_json(), name="discord-gateway-receive"
+                )
+            # Clear before querying so a concurrent commit forces a recheck.
+            notified.clear()
+            if wakeup_task is None or wakeup_task.done():
+                wakeup_task = asyncio.create_task(notified.wait(), name="discord-gateway-wakeup")
             checkpoints = (
                 session_state.get("message_checkpoints") if session_state is not None else None
             )
@@ -1438,25 +1458,32 @@ async def discord_agent_gateway(
                 else:
                     continue
 
-            try:
-                frame = _JSON_VALUE_ADAPTER.validate_python(
-                    await asyncio.wait_for(
-                        websocket.receive_json(),
-                        timeout=max(0.001, settings.discord_gateway_poll_interval_seconds),
-                    )
-                )
-                if isinstance(frame, dict) and frame.get("op") == 1:
-                    await acknowledge_gateway_sequence(optional_int_param(frame.get("d")))
-                    await send_gateway_frame({"op": 11, "d": None}, record=False)
-            except TimeoutError:
-                pass
+            await asyncio.wait(
+                {receive_task, wakeup_task},
+                timeout=max(0.001, settings.discord_gateway_poll_interval_seconds),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
     except WebSocketDisconnect:
         return
     finally:
-        if consumer_lease is not None and consumer_lease_entered:
-            await consumer_lease.__aexit__(None, None, None)
-        if owns_session_entry:
-            _DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
+        try:
+            if consumer_lease is not None and consumer_lease_entered:
+                await consumer_lease.__aexit__(None, None, None)
+        finally:
+            if owns_session_entry:
+                _DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
+            if notified is not None and account is not None:
+                channel_inbound_messages_enqueued.unsubscribe(str(account.id), notified)
+            tasks = [task for task in (receive_task, wakeup_task) if task is not None]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+
+            async def collect_tasks() -> None:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+            if tasks:
+                await finish_cleanup(collect_tasks)
 
 
 @router.post(

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -303,16 +303,21 @@ def discord_application_id(account: ChannelAccount) -> str:
     return str(abs(hash(str(account.id))) % 10_000_000_000_000_000_000)
 
 
-def discord_bot_user(account: ChannelAccount) -> JsonObject:
+def discord_bot_user(account: ChannelAccount, link: ChannelBotAgentLink) -> JsonObject:
     config = account.config if isinstance(account.config, dict) else {}
+    shadow = link.config if isinstance(link.config, dict) else {}
     app_id = discord_application_id(account)
-    username = optional_str(config.get("bot_username")) or account.name
+    username = (
+        optional_str(shadow.get("bot_username"))
+        or optional_str(config.get("bot_username"))
+        or account.name
+    )
     return {
         "id": app_id,
         "username": username,
         "global_name": username,
         "discriminator": "0000",
-        "avatar": config.get("bot_avatar"),
+        "avatar": shadow.get("bot_avatar", config.get("bot_avatar")),
         "bot": True,
         "system": False,
     }

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -29,6 +29,7 @@ from starlette.datastructures import UploadFile
 
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
+from app.middleware.request_timing import channel_stage
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
@@ -387,11 +388,12 @@ async def telegram_bot_api(
     # Read the bounded request body before checking out an auth connection.
     raw_body = await request.body()
     params = await _telegram_request_params(request)
-    agent, _agent_token = await _resolve_telegram_agent(
-        db,
-        routing_id=routing_id,
-        authorization=authorization,
-    )
+    with channel_stage(request.scope, "channel_auth_ms"):
+        agent, _agent_token = await _resolve_telegram_agent(
+            db,
+            routing_id=routing_id,
+            authorization=authorization,
+        )
     account = agent.account
     duplicate_parameter = await _telegram_duplicate_security_parameter(request, raw_body, params)
     if duplicate_parameter is not None:
@@ -2653,7 +2655,8 @@ async def _telegram_provider_response(
     translate_direct_topic: bool = False,
 ) -> httpx.Response:
     base_url = settings.channel_telegram_api_base_url.strip()
-    await _validate_telegram_provider_base_url(base_url)
+    with channel_stage(request.scope, "channel_url_validation_ms"):
+        await _validate_telegram_provider_base_url(base_url)
     url = httpx.URL(f"{base_url.rstrip('/')}/bot{provider_token}/{method}")
     headers: dict[str, str] = {}
     content_type = request.headers.get("content-type")
@@ -2670,7 +2673,10 @@ async def _telegram_provider_response(
     if query_string:
         url = url.copy_with(query=query_string)
     try:
-        with track_proxy_latency("telegram", method):
+        with (
+            track_proxy_latency("telegram", method),
+            channel_stage(request.scope, "channel_provider_ms"),
+        ):
             response = await get_channel_provider_http_client().request(
                 request.method,
                 url,

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -1067,7 +1067,11 @@ async def _deliver_telegram_agent_webhook_for_binding(
         link=current_link,
     ):
         return False
-    return await deliver_telegram_agent_webhook(current_link, payload)
+    delivered = await deliver_telegram_agent_webhook(current_link, payload)
+    if delivered:
+        current_binding.webhook_retry_at = None
+        current_binding.webhook_retry_step = 0
+    return delivered
 
 
 async def _validate_telegram_webhook_url(url: str) -> JSONResponse | None:

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -33,6 +33,7 @@ from app.routes.channel_routers.shared import (
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channel_wakeups import (
+    ChannelInboxPage,
     channel_inbound_messages_enqueued,
     wait_for_channel_inbound_messages,
 )
@@ -623,7 +624,7 @@ async def _wait_whatsapp_websocket_inbox(
     after_sequence: int,
     limit: int = 100,
 ) -> list[WhatsAppInboxPumpEvent]:
-    async def fetch() -> list[ChannelMessage]:
+    async def fetch() -> ChannelInboxPage[ChannelMessage]:
         async with async_session_factory() as db:
             result = await db.execute(
                 select(ChannelMessage)
@@ -638,7 +639,7 @@ async def _wait_whatsapp_websocket_inbox(
                 .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
                 .limit(max(0, limit))
             )
-            return list(result.scalars().all())
+            return ChannelInboxPage(list(result.scalars().all()))
 
     messages = await wait_for_channel_inbound_messages(
         fetch,

--- a/backend/app/services/channel_wakeups.py
+++ b/backend/app/services/channel_wakeups.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,8 +43,14 @@ channel_deliveries_enqueued = ChannelWakeup()
 channel_inbound_messages_enqueued = ChannelWakeup()
 
 
+@dataclass(frozen=True)
+class ChannelInboxPage[T]:
+    items: list[T]
+    progressed: bool = False
+
+
 async def wait_for_channel_inbound_messages[T](
-    fetch: Callable[[], Awaitable[list[T]]],
+    fetch: Callable[[], Awaitable[ChannelInboxPage[T]]],
     *,
     account_id: str,
     timeout_seconds: int | float | None,
@@ -69,9 +76,15 @@ async def wait_for_channel_inbound_messages[T](
             # during or immediately after the query remains set and forces a
             # recheck, closing the query-to-wait lost-wakeup window.
             notified.clear()
-            values = await fetch()
-            if values or timeout == 0 or loop.time() >= deadline:
-                return values
+            page = await fetch()
+            if page.items or timeout == 0 or loop.time() >= deadline:
+                return page.items
+            if page.progressed:
+                # The caller committed a consumed page, not an empty queue.
+                # Yield for cancellation/fairness; the request deadline bounds
+                # repeated progress, while timeout=0 retains its single-page limit.
+                await asyncio.sleep(0)
+                continue
             if notified.is_set():
                 continue
             try:

--- a/backend/app/services/channel_webhook_delivery_worker.py
+++ b/backend/app/services/channel_webhook_delivery_worker.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
@@ -49,10 +50,19 @@ class ChannelWebhookDeliveryWorker:
         backoff_cap_seconds: float = 60.0,
         ttl_seconds: int = int(TELEGRAM_UPDATE_RETENTION.total_seconds()),
     ) -> None:
+        if not (
+            math.isfinite(backoff_base_seconds)
+            and math.isfinite(backoff_cap_seconds)
+            and 0 < backoff_base_seconds <= backoff_cap_seconds
+        ):
+            raise ValueError("webhook backoff must be finite, positive, and capped above its base")
         self._sessionmaker = sessionmaker
         self._poll_interval_seconds = poll_interval_seconds
         self._backoff_base_seconds = backoff_base_seconds
         self._backoff_cap_seconds = backoff_cap_seconds
+        self._max_retry_step = (
+            math.ceil(math.log2(backoff_cap_seconds) - math.log2(backoff_base_seconds)) + 1
+        )
         self._ttl = timedelta(seconds=ttl_seconds)
 
     async def run_once(self) -> ChannelWebhookDeliveryResult | None:
@@ -61,14 +71,27 @@ class ChannelWebhookDeliveryWorker:
             if candidate is None:
                 await db.rollback()
                 return None
-            message, account, link = candidate
+            message, account, link, binding = candidate
             result = await self._deliver_message(db, message, account, link)
+            if result.delivered or result.expired:
+                binding.webhook_retry_at = None
+                binding.webhook_retry_step = 0
+            else:
+                binding.webhook_retry_step = min(
+                    binding.webhook_retry_step + 1, self._max_retry_step
+                )
+                delay = (
+                    self._backoff_cap_seconds
+                    if binding.webhook_retry_step == self._max_retry_step
+                    else math.ldexp(self._backoff_base_seconds, binding.webhook_retry_step - 1)
+                )
+                binding.webhook_retry_at = datetime.now(UTC) + timedelta(seconds=delay)
             await db.commit()
             return result
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
-        backoff = self._backoff_base_seconds
+        error_backoff = self._backoff_base_seconds
         while not stop_event.is_set():
             try:
                 result = await self.run_once()
@@ -76,23 +99,20 @@ class ChannelWebhookDeliveryWorker:
                 raise
             except Exception as exc:  # noqa: BLE001 - worker must survive one bad webhook.
                 log.exception("channel webhook delivery worker failed: %s", exc)
-                result = None
+                await _sleep_until_stop(stop_event, error_backoff)
+                error_backoff = min(error_backoff * 2, self._backoff_cap_seconds)
+                continue
 
+            error_backoff = self._backoff_base_seconds
             if result is None:
                 await _sleep_until_stop(stop_event, self._poll_interval_seconds)
-                continue
-            if result.delivered or result.expired:
-                backoff = self._backoff_base_seconds
-                continue
-            await _sleep_until_stop(stop_event, backoff)
-            backoff = min(backoff * 2, self._backoff_cap_seconds)
 
     async def _claim_next_telegram_webhook_message(
         self,
         db: AsyncSession,
-    ) -> tuple[ChannelMessage, ChannelAccount, ChannelBotAgentLink] | None:
+    ) -> tuple[ChannelMessage, ChannelAccount, ChannelBotAgentLink, ChannelBinding] | None:
         result = await db.execute(
-            select(ChannelMessage, ChannelAccount, ChannelBotAgentLink)
+            select(ChannelMessage, ChannelAccount, ChannelBotAgentLink, ChannelBinding)
             .join(
                 ChannelBinding,
                 ChannelBinding.id == ChannelMessage.binding_id,
@@ -112,6 +132,10 @@ class ChannelWebhookDeliveryWorker:
                 ChannelBinding.account_id == ChannelMessage.account_id,
                 ChannelBinding.bot_agent_link_id == ChannelMessage.bot_agent_link_id,
                 ChannelBinding.status == BINDING_STATUS_ACTIVE,
+                or_(
+                    ChannelBinding.webhook_retry_at.is_(None),
+                    ChannelBinding.webhook_retry_at <= datetime.now(UTC),
+                ),
                 ChannelAccount.provider == CHANNEL_PROVIDER_TELEGRAM,
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
@@ -141,8 +165,8 @@ class ChannelWebhookDeliveryWorker:
         row = result.first()
         if row is None:
             return None
-        message, account, link = row
-        return message, account, link
+        message, account, link, binding = row
+        return message, account, link, binding
 
     async def _deliver_message(
         self,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1897,6 +1897,9 @@ async def get_or_create_binding(
         if candidate_name is not None and candidate_name != external_chat_id:
             binding.external_chat_name = candidate_name
         binding.paired_external_user_id = external_user_id
+        if binding.status != BINDING_STATUS_ACTIVE:
+            binding.webhook_retry_at = None
+            binding.webhook_retry_step = 0
         binding.status = BINDING_STATUS_ACTIVE
         await db.execute(
             update(ChannelBindingAlias)
@@ -3217,6 +3220,9 @@ async def consume_pending_inbound_messages_for_bindings(
     bindings: list[ChannelBinding],
 ) -> int:
     """Revoke queued adapter delivery when binding authority is archived."""
+    for binding in bindings:
+        binding.webhook_retry_at = None
+        binding.webhook_retry_step = 0
     binding_ids = {binding.id for binding in bindings}
     if not binding_ids:
         return 0

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -73,6 +73,7 @@ from app.services.channel_config import (
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channel_wakeups import (
+    ChannelInboxPage,
     channel_inbound_messages_enqueued,
     notify_channel_delivery_enqueued,
     notify_channel_inbound_message_enqueued,
@@ -3783,7 +3784,7 @@ async def dequeue_telegram_updates(
     offset: int | None,
     limit: int,
     allowed_updates: set[str] | None = None,
-) -> list[JsonObject]:
+) -> ChannelInboxPage[JsonObject]:
     now = datetime.now(UTC)
     filters = [
         ChannelMessage.account_id == account_id,
@@ -3840,23 +3841,26 @@ async def dequeue_telegram_updates(
         )
     )
     updates: list[JsonObject] = []
+    progressed = False
     for message in result.scalars().all():
         update_payload = telegram_update_payload(message)
         update_id = telegram_update_id(message)
         if offset is not None and update_id < offset:
             message.delivered_at = now
+            progressed = True
             continue
         if allowed_updates and not _telegram_update_allowed(
             update_payload,
             allowed_updates,
         ):
             message.delivered_at = now
+            progressed = True
             continue
         updates.append(update_payload)
         if len(updates) >= limit:
             break
     await db.flush()
-    return updates
+    return ChannelInboxPage(updates, progressed=progressed)
 
 
 async def wait_for_telegram_updates(
@@ -3870,7 +3874,7 @@ async def wait_for_telegram_updates(
     timeout_seconds: int | float | None = None,
     poll_interval_seconds: float | None = None,
 ) -> list[JsonObject]:
-    async def fetch() -> list[JsonObject]:
+    async def fetch() -> ChannelInboxPage[JsonObject]:
         async with sessionmaker() as db:
             updates = await dequeue_telegram_updates(
                 db,
@@ -4589,7 +4593,7 @@ async def wait_for_channel_inbox_events(
     timeout_seconds: int | float | None = None,
     poll_interval_seconds: float | None = None,
 ) -> list[ChannelMessage]:
-    async def fetch() -> list[ChannelMessage]:
+    async def fetch() -> ChannelInboxPage[ChannelMessage]:
         async with sessionmaker() as db:
             events = await dequeue_channel_inbox_events(
                 db,
@@ -4599,7 +4603,7 @@ async def wait_for_channel_inbox_events(
                 limit=limit,
             )
             await db.commit()
-            return events
+            return ChannelInboxPage(events)
 
     return await wait_for_channel_inbound_messages(
         fetch,

--- a/backend/app/services/discord_advisory_session.py
+++ b/backend/app/services/discord_advisory_session.py
@@ -1,0 +1,247 @@
+"""One PostgreSQL ownership session for a role's Discord Gateway tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+from app.core.database import finish_cleanup
+
+log = logging.getLogger(__name__)
+
+
+class DiscordAdvisorySessionLost(RuntimeError):
+    """The PostgreSQL session cannot prove ownership of its Discord tasks."""
+
+
+@dataclass
+class _Session:
+    connection: AsyncConnection
+    leases: dict[int, DiscordAdvisoryLease] = field(default_factory=dict)
+    monitor: asyncio.Task[None] | None = None
+    retirement: asyncio.Task[None] | None = None
+    failure: BaseException | None = None
+    closing: bool = False
+
+
+@dataclass(frozen=True)
+class DiscordAdvisoryLease:
+    key: int
+    owner: asyncio.Task[None]
+    session: _Session
+
+    @property
+    def failed(self) -> bool:
+        return self.session.failure is not None
+
+
+class DiscordAdvisorySession:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        liveness_interval_seconds: float = 1.0,
+        liveness_timeout_seconds: float = 5.0,
+    ) -> None:
+        self._engine = engine
+        self._interval = max(0.001, liveness_interval_seconds)
+        self._timeout = max(0.001, liveness_timeout_seconds)
+        self._serial = asyncio.Lock()
+        self._lifecycle = asyncio.Lock()
+        self._session: _Session | None = None
+        self._closed = False
+
+    @property
+    def failed(self) -> bool:
+        return self._session is not None and self._session.failure is not None
+
+    async def _get_session(self) -> _Session:
+        # Recovery must be driven by a new claimant, not an old owner whose
+        # completion the retirement operation needs to join.
+        if self.failed:
+            self._check_lifecycle_caller()
+        while True:
+            async with self._lifecycle:
+                if self._closed:
+                    raise DiscordAdvisorySessionLost("Discord lock owner is closed")
+                if self._session is None:
+                    self._session = _Session(await self._engine.connect())
+                    self._session.monitor = asyncio.create_task(
+                        self._monitor(self._session), name="discord-advisory-session-monitor"
+                    )
+                if self._session.failure is None:
+                    return self._session
+                self._check_lifecycle_caller()
+                retirement = self._session.retirement
+            if retirement is None:
+                raise DiscordAdvisorySessionLost("Discord lock retirement is unavailable")
+            await asyncio.shield(retirement)
+
+    async def claim(self, key: int | str) -> DiscordAdvisoryLease | None:
+        owner = asyncio.current_task()
+        if owner is None:
+            raise RuntimeError("Discord advisory locks require an asyncio task")
+        session = await self._get_session()
+        async with self._connection(session) as connection:
+            if isinstance(key, str):
+                # Preserve the released consumer Account/Link lock identity.
+                resolved = await connection.scalar(
+                    text("SELECT hashtextextended(:lock_name, 0)"), {"lock_name": key}
+                )
+                await connection.commit()
+                if not isinstance(resolved, int) or isinstance(resolved, bool):
+                    raise RuntimeError("Discord consumer advisory key is invalid")
+                key = resolved
+            # PostgreSQL session locks are reentrant, not local task mutexes.
+            if key in session.leases or not await try_advisory_lock(connection, key):
+                return None
+            if session.closing or session.failure is not None:
+                raise DiscordAdvisorySessionLost from session.failure
+            lease = DiscordAdvisoryLease(key, owner, session)
+            session.leases[key] = lease
+            return lease
+
+    async def release(self, lease: DiscordAdvisoryLease) -> None:
+        await finish_cleanup(lambda: self._release(lease))
+
+    async def _release(self, lease: DiscordAdvisoryLease) -> None:
+        session = lease.session
+        if session.failure is not None:
+            raise DiscordAdvisorySessionLost from session.failure
+        if session.closing:
+            return  # Shutdown invalidates the connection after joining owners.
+        try:
+            async with self._connection(session, lease.owner) as connection:
+                if session.leases.get(lease.key) is not lease:
+                    return
+                if not await release_advisory_lock(connection, lease.key):
+                    raise RuntimeError("Discord advisory unlock failed")
+                session.leases.pop(lease.key)
+        except DiscordAdvisorySessionLost:
+            if not session.closing or session.failure is not None:
+                raise
+
+    @asynccontextmanager
+    async def _connection(
+        self, session: _Session, owner: asyncio.Task[None] | None = None
+    ) -> AsyncGenerator[AsyncConnection]:
+        async with self._serial:
+            if session.closing or session.failure is not None:
+                raise DiscordAdvisorySessionLost from session.failure
+            try:
+                async with asyncio.timeout(self._timeout):
+                    yield session.connection
+            except BaseException as exc:
+                self._fail(session, exc, owner)
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                raise DiscordAdvisorySessionLost from exc
+
+    def _fail(
+        self, session: _Session, exc: BaseException, owner: asyncio.Task[None] | None = None
+    ) -> None:
+        if session.failure is None and not session.closing:
+            session.failure = exc
+            for task in {lease.owner for lease in session.leases.values()}:
+                if task is not (owner or asyncio.current_task()):
+                    task.cancel()
+            # Consumers have no discovery loop to reap a failed but still-live
+            # PG session. Retire it even if no new Gateway ever arrives.
+            session.retirement = asyncio.create_task(
+                self._retire_failed_session(session), name="discord-advisory-session-retire"
+            )
+            session.retirement.add_done_callback(_observe_retirement)
+
+    async def _retire_failed_session(self, session: _Session) -> None:
+        async with self._lifecycle:
+            await self._retire_session(session)
+
+    async def _monitor(self, session: _Session) -> None:
+        try:
+            while session.failure is None:
+                await asyncio.sleep(self._interval)
+                # Include time waiting for claim/release SQL. Driver/transport
+                # cancellation cleanup may outlast this application deadline.
+                async with asyncio.timeout(self._timeout):
+                    async with self._connection(session) as connection:
+                        await connection.execute(text("SELECT 1"))
+                        await connection.commit()
+        except (TimeoutError, DiscordAdvisorySessionLost) as exc:
+            self._fail(session, exc)
+            log.exception("Discord advisory session lost")
+
+    async def close(self) -> None:
+        # Check the real caller before finish_cleanup creates its child task,
+        # and before waiting behind a retirement that may already join it.
+        self._check_lifecycle_caller()
+        await finish_cleanup(self._close)
+
+    async def _close(self) -> None:
+        async with self._lifecycle:
+            self._closed = True
+            retirement = self._session.retirement if self._session is not None else None
+            if retirement is None:
+                await self._retire_session(self._session)
+        if retirement is not None:
+            await asyncio.shield(retirement)
+
+    def _check_lifecycle_caller(self) -> None:
+        if self._session is not None and any(
+            lease.owner is asyncio.current_task() for lease in self._session.leases.values()
+        ):
+            raise DiscordAdvisorySessionLost(
+                "Discord lock session lifecycle requires a task that owns no lease"
+            )
+
+    async def _retire_session(self, session: _Session | None) -> None:
+        if session is None or self._session is not session:
+            return
+        session.closing = True
+        if session.monitor is not None:
+            session.monitor.cancel()
+            await asyncio.gather(session.monitor, return_exceptions=True)
+        # Drain any claim already executing SQL before snapshotting owners.
+        # Never join owners under this gate: their cleanup also needs it.
+        async with self._serial:
+            owners = {lease.owner for lease in session.leases.values()}
+        if session.failure is None:
+            for owner in owners:
+                owner.cancel()
+        if owners:
+            await asyncio.gather(*owners, return_exceptions=True)
+        async with self._serial:
+            try:
+                # Even orderly shutdown discards the ownership connection. Never
+                # let an uncertain or remaining session lock reenter the pool.
+                await session.connection.invalidate()
+            finally:
+                await session.connection.close()
+                session.leases.clear()
+                self._session = None
+
+
+def _observe_retirement(task: asyncio.Task[None]) -> None:
+    if not task.cancelled() and (error := task.exception()) is not None:
+        log.error("Discord advisory session retirement failed", exc_info=error)
+
+
+async def try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    result = await connection.execute(
+        text("SELECT pg_try_advisory_lock(:lock_key)"), {"lock_key": lock_key}
+    )
+    await connection.commit()
+    return result.scalar_one() is True
+
+
+async def release_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    result = await connection.execute(
+        text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
+    )
+    await connection.commit()
+    return result.scalar_one() is True

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -6,8 +6,6 @@ import hashlib
 import json
 import logging
 import random
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -16,8 +14,8 @@ from uuid import UUID
 
 from fastapi import HTTPException
 from pydantic import JsonValue, TypeAdapter
-from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
@@ -35,6 +33,12 @@ from app.services.channels import (
     record_discord_dispatch,
     update_discord_binding_display_name_from_trusted_event,
 )
+from app.services.discord_advisory_session import (
+    DiscordAdvisorySession,
+    DiscordAdvisorySessionLost,
+)
+from app.services.discord_advisory_session import release_advisory_lock as release_advisory_lock
+from app.services.discord_advisory_session import try_advisory_lock as try_advisory_lock
 from app.services.discord_command_reconciliation_worker import (
     reconcile_discord_guild_commands,
     reconcile_discord_guild_departure,
@@ -57,10 +61,6 @@ _GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 class _GatewayReconnect(RuntimeError):
     """Discord requested an immediate reconnect so the session can resume."""
-
-
-class _GatewayLockLost(RuntimeError):
-    """The shared PostgreSQL session no longer owns the provider transports."""
 
 
 class _GatewayConnection(Protocol):
@@ -131,7 +131,11 @@ class DiscordGatewayWorker:
         connect_factory: _GatewayConnectFactory = connect,
     ) -> None:
         self._sessionmaker = sessionmaker
-        self._lock_engine = lock_engine or _sessionmaker_bind(sessionmaker)
+        self._locks = DiscordAdvisorySession(
+            lock_engine or _sessionmaker_bind(sessionmaker),
+            liveness_interval_seconds=lock_liveness_interval_seconds,
+            liveness_timeout_seconds=lock_liveness_timeout_seconds,
+        )
         self._scan_interval_seconds = scan_interval_seconds
         self._reconnect_initial_seconds = reconnect_initial_seconds
         self._reconnect_max_seconds = reconnect_max_seconds
@@ -139,25 +143,11 @@ class DiscordGatewayWorker:
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
         self._terminal_account_revisions: dict[UUID, str] = {}
         self._states: dict[UUID, _GatewayState] = {}
-        self._lock_connection: AsyncConnection | None = None
-        self._lock_monitor: asyncio.Task[None] | None = None
-        self._lock_lost = False
-        self._lock_serial = asyncio.Lock()
         self._lifecycle_serial = asyncio.Lock()
-        self._lock_liveness_interval_seconds = max(0.001, lock_liveness_interval_seconds)
-        self._lock_liveness_timeout_seconds = max(0.001, lock_liveness_timeout_seconds)
 
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
         async with self._lifecycle_serial:
-            if self._lock_lost:
-                await finish_cleanup(self._close_lock_session)
             accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
-            if accounts and self._lock_connection is None:
-                self._lock_connection = await self._lock_engine.connect()
-                self._lock_lost = False
-                self._lock_monitor = asyncio.create_task(
-                    self._monitor_lock_session(), name="discord-gateway-lock-monitor"
-                )
             self._sync_tasks(accounts, stop or asyncio.Event())
             return len(accounts)
 
@@ -185,63 +175,12 @@ class DiscordGatewayWorker:
             self._states.clear()
 
     async def _close_lock_session(self) -> None:
-        # Fence new claims, then join transports before closing the session.
-        # Invalidate even on orderly shutdown: remaining session locks must not
-        # become reentrant locks on a later borrow from the ordinary pool.
-        self._lock_lost = True
-        if self._lock_monitor is not None:
-            self._lock_monitor.cancel()
-            await asyncio.gather(self._lock_monitor, return_exceptions=True)
-            self._lock_monitor = None
         for task in self._tasks.values():
             task.cancel()
         if self._tasks:
             await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
-        connection = self._lock_connection
-        if connection is not None:
-            try:
-                await connection.invalidate()
-            finally:
-                await connection.close()
-                self._lock_connection = None
-
-    @asynccontextmanager
-    async def _locked_connection(
-        self, owner: asyncio.Task[None] | None = None
-    ) -> AsyncGenerator[AsyncConnection]:
-        async with self._lock_serial:
-            if self._lock_connection is None or self._lock_lost:
-                raise _GatewayLockLost
-            try:
-                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
-                    yield self._lock_connection
-            except BaseException as exc:
-                self._lose_lock_session(owner)
-                if isinstance(exc, asyncio.CancelledError):
-                    raise
-                raise _GatewayLockLost from exc
-
-    def _lose_lock_session(self, owner: asyncio.Task[None] | None = None) -> None:
-        if not self._lock_lost:
-            self._lock_lost = True
-            for task in self._tasks.values():
-                if task is not (owner or asyncio.current_task()):
-                    task.cancel()
-
-    async def _monitor_lock_session(self) -> None:
-        try:
-            while not self._lock_lost:
-                await asyncio.sleep(self._lock_liveness_interval_seconds)
-                # The deadline includes waiting for a claim/unlock. It bounds
-                # detection, not the transport/driver's cancellation cleanup.
-                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
-                    async with self._locked_connection() as connection:
-                        await connection.execute(text("SELECT 1"))
-                        await connection.commit()
-        except (TimeoutError, _GatewayLockLost):
-            self._lose_lock_session()
-            log.exception("discord gateway lock session lost")
+        await self._locks.close()
 
     def _sync_tasks(
         self,
@@ -287,7 +226,7 @@ class DiscordGatewayWorker:
                 backoff_seconds = self._reconnect_initial_seconds
             except asyncio.CancelledError:
                 raise
-            except _GatewayLockLost:
+            except DiscordAdvisorySessionLost:
                 return
             except _GatewayReconnect:
                 state.session_established = False
@@ -313,7 +252,7 @@ class DiscordGatewayWorker:
             if state.session_established:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
-            if self._lock_lost:
+            if self._locks.failed:
                 return
             await _sleep_until_stop(stop, backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, self._reconnect_max_seconds)
@@ -325,26 +264,17 @@ class DiscordGatewayWorker:
         state: _GatewayState,
     ) -> bool:
         lock_key = discord_gateway_advisory_lock_key(account_id)
-        async with self._locked_connection() as lock_connection:
-            acquired = await try_advisory_lock(lock_connection, lock_key)
-        if not acquired:
+        lease = await self._locks.claim(lock_key)
+        if lease is None:
             return False
         try:
             await self._connect_and_record(account_id, stop, state)
         finally:
-            # Preserve transport close codes/cancellation even if unlock fails.
-            # _locked_connection fences every sibling on failure; the lifecycle
-            # owner then invalidates this session rather than returning locks.
-            owner = asyncio.current_task()
-            await finish_cleanup(lambda: self._release_account_lock(lock_key, owner))
+            # The shared owner fences siblings on unlock failure. Preserve this
+            # account's transport close code or cancellation for the outer loop.
+            with contextlib.suppress(DiscordAdvisorySessionLost):
+                await self._locks.release(lease)
         return True
-
-    async def _release_account_lock(self, lock_key: int, owner: asyncio.Task[None] | None) -> None:
-        if not self._lock_lost:
-            with contextlib.suppress(_GatewayLockLost):
-                async with self._locked_connection(owner) as connection:
-                    if not await release_advisory_lock(connection, lock_key):
-                        raise RuntimeError("discord gateway advisory unlock failed")
 
     async def _connect_and_record(
         self,
@@ -775,24 +705,6 @@ def discord_gateway_advisory_lock_key(account_id: UUID) -> int:
 
 def discord_gateway_close_code(exc: ConnectionClosed) -> int | None:
     return exc.rcvd.code if exc.rcvd is not None else None
-
-
-async def try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
-    result = await connection.execute(
-        text("SELECT pg_try_advisory_lock(:lock_key)"),
-        {"lock_key": lock_key},
-    )
-    await connection.commit()
-    return result.scalar_one() is True
-
-
-async def release_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
-    result = await connection.execute(
-        text("SELECT pg_advisory_unlock(:lock_key)"),
-        {"lock_key": lock_key},
-    )
-    await connection.commit()
-    return result.scalar_one() is True
 
 
 async def _recv_gateway_frame(websocket: _GatewayConnection) -> GatewayFrame:

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 import logging
 import random
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -20,6 +22,7 @@ from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
 from app.core.config import settings
+from app.core.database import finish_cleanup
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
@@ -54,6 +57,10 @@ _GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 class _GatewayReconnect(RuntimeError):
     """Discord requested an immediate reconnect so the session can resume."""
+
+
+class _GatewayLockLost(RuntimeError):
+    """The shared PostgreSQL session no longer owns the provider transports."""
 
 
 class _GatewayConnection(Protocol):
@@ -119,6 +126,8 @@ class DiscordGatewayWorker:
         scan_interval_seconds: float = 10.0,
         reconnect_initial_seconds: float = 1.0,
         reconnect_max_seconds: float = 60.0,
+        lock_liveness_interval_seconds: float = 1.0,
+        lock_liveness_timeout_seconds: float = 5.0,
         connect_factory: _GatewayConnectFactory = connect,
     ) -> None:
         self._sessionmaker = sessionmaker
@@ -129,35 +138,110 @@ class DiscordGatewayWorker:
         self._connect_factory = connect_factory
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
         self._terminal_account_revisions: dict[UUID, str] = {}
+        self._states: dict[UUID, _GatewayState] = {}
+        self._lock_connection: AsyncConnection | None = None
+        self._lock_monitor: asyncio.Task[None] | None = None
+        self._lock_lost = False
+        self._lock_serial = asyncio.Lock()
+        self._lifecycle_serial = asyncio.Lock()
+        self._lock_liveness_interval_seconds = max(0.001, lock_liveness_interval_seconds)
+        self._lock_liveness_timeout_seconds = max(0.001, lock_liveness_timeout_seconds)
 
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
-        accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
-        stop_event = stop or asyncio.Event()
-        self._sync_tasks(accounts, stop_event)
-        return len(accounts)
+        async with self._lifecycle_serial:
+            if self._lock_lost:
+                await finish_cleanup(self._close_lock_session)
+            accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
+            if accounts and self._lock_connection is None:
+                self._lock_connection = await self._lock_engine.connect()
+                self._lock_lost = False
+                self._lock_monitor = asyncio.create_task(
+                    self._monitor_lock_session(), name="discord-gateway-lock-monitor"
+                )
+            self._sync_tasks(accounts, stop or asyncio.Event())
+            return len(accounts)
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
+        backoff = self._reconnect_initial_seconds
         try:
             while not stop_event.is_set():
-                await self.run_once(stop_event)
                 try:
-                    await asyncio.wait_for(
-                        stop_event.wait(),
-                        timeout=self._scan_interval_seconds,
-                    )
-                except TimeoutError:
-                    pass
+                    await self.run_once(stop_event)
+                except Exception:
+                    log.exception("discord gateway account scan failed")
+                    await _sleep_until_stop(stop_event, backoff)
+                    backoff = min(backoff * 2, self._reconnect_max_seconds)
+                else:
+                    backoff = self._reconnect_initial_seconds
+                    await _sleep_until_stop(stop_event, self._scan_interval_seconds)
         finally:
             await self.stop()
 
     async def stop(self) -> None:
+        async with self._lifecycle_serial:
+            await finish_cleanup(self._close_lock_session)
+            self._terminal_account_revisions.clear()
+            self._states.clear()
+
+    async def _close_lock_session(self) -> None:
+        # Fence new claims, then join transports before closing the session.
+        # Invalidate even on orderly shutdown: remaining session locks must not
+        # become reentrant locks on a later borrow from the ordinary pool.
+        self._lock_lost = True
+        if self._lock_monitor is not None:
+            self._lock_monitor.cancel()
+            await asyncio.gather(self._lock_monitor, return_exceptions=True)
+            self._lock_monitor = None
         for task in self._tasks.values():
             task.cancel()
         if self._tasks:
             await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
-        self._terminal_account_revisions.clear()
+        connection = self._lock_connection
+        if connection is not None:
+            try:
+                await connection.invalidate()
+            finally:
+                await connection.close()
+                self._lock_connection = None
+
+    @asynccontextmanager
+    async def _locked_connection(
+        self, owner: asyncio.Task[None] | None = None
+    ) -> AsyncGenerator[AsyncConnection]:
+        async with self._lock_serial:
+            if self._lock_connection is None or self._lock_lost:
+                raise _GatewayLockLost
+            try:
+                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
+                    yield self._lock_connection
+            except BaseException as exc:
+                self._lose_lock_session(owner)
+                if isinstance(exc, asyncio.CancelledError):
+                    raise
+                raise _GatewayLockLost from exc
+
+    def _lose_lock_session(self, owner: asyncio.Task[None] | None = None) -> None:
+        if not self._lock_lost:
+            self._lock_lost = True
+            for task in self._tasks.values():
+                if task is not (owner or asyncio.current_task()):
+                    task.cancel()
+
+    async def _monitor_lock_session(self) -> None:
+        try:
+            while not self._lock_lost:
+                await asyncio.sleep(self._lock_liveness_interval_seconds)
+                # The deadline includes waiting for a claim/unlock. It bounds
+                # detection, not the transport/driver's cancellation cleanup.
+                async with asyncio.timeout(self._lock_liveness_timeout_seconds):
+                    async with self._locked_connection() as connection:
+                        await connection.execute(text("SELECT 1"))
+                        await connection.commit()
+        except (TimeoutError, _GatewayLockLost):
+            self._lose_lock_session()
+            log.exception("discord gateway lock session lost")
 
     def _sync_tasks(
         self,
@@ -165,6 +249,8 @@ class DiscordGatewayWorker:
         stop: asyncio.Event,
     ) -> None:
         active = set(active_accounts)
+        for account_id in set(self._states) - active:
+            self._states.pop(account_id, None)
         for account_id, task in list(self._tasks.items()):
             if task.done():
                 self._observe_done_task(account_id, task)
@@ -181,6 +267,9 @@ class DiscordGatewayWorker:
                 continue
             if terminal_revision is not None:
                 self._terminal_account_revisions.pop(account_id, None)
+            state = self._states.get(account_id)
+            if state is not None and state.account_revision != revision:
+                self._states.pop(account_id, None)
             self._tasks[account_id] = asyncio.create_task(
                 self._run_account_forever(account_id, stop),
                 name=f"discord-gateway-{account_id}",
@@ -188,7 +277,7 @@ class DiscordGatewayWorker:
 
     async def _run_account_forever(self, account_id: UUID, stop: asyncio.Event) -> None:
         backoff_seconds = self._reconnect_initial_seconds
-        state = _GatewayState()
+        state = self._states.setdefault(account_id, _GatewayState())
         while not stop.is_set():
             try:
                 acquired = await self._run_account_with_lock(account_id, stop, state)
@@ -198,6 +287,8 @@ class DiscordGatewayWorker:
                 backoff_seconds = self._reconnect_initial_seconds
             except asyncio.CancelledError:
                 raise
+            except _GatewayLockLost:
+                return
             except _GatewayReconnect:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
@@ -222,6 +313,8 @@ class DiscordGatewayWorker:
             if state.session_established:
                 state.session_established = False
                 backoff_seconds = self._reconnect_initial_seconds
+            if self._lock_lost:
+                return
             await _sleep_until_stop(stop, backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, self._reconnect_max_seconds)
 
@@ -232,16 +325,26 @@ class DiscordGatewayWorker:
         state: _GatewayState,
     ) -> bool:
         lock_key = discord_gateway_advisory_lock_key(account_id)
-        async with self._lock_engine.connect() as lock_connection:
+        async with self._locked_connection() as lock_connection:
             acquired = await try_advisory_lock(lock_connection, lock_key)
-            if not acquired:
-                return False
-            try:
-                await self._connect_and_record(account_id, stop, state)
-            finally:
-                if not await release_advisory_lock(lock_connection, lock_key):
-                    raise RuntimeError("discord gateway advisory unlock failed")
+        if not acquired:
+            return False
+        try:
+            await self._connect_and_record(account_id, stop, state)
+        finally:
+            # Preserve transport close codes/cancellation even if unlock fails.
+            # _locked_connection fences every sibling on failure; the lifecycle
+            # owner then invalidates this session rather than returning locks.
+            owner = asyncio.current_task()
+            await finish_cleanup(lambda: self._release_account_lock(lock_key, owner))
         return True
+
+    async def _release_account_lock(self, lock_key: int, owner: asyncio.Task[None] | None) -> None:
+        if not self._lock_lost:
+            with contextlib.suppress(_GatewayLockLost):
+                async with self._locked_connection(owner) as connection:
+                    if not await release_advisory_lock(connection, lock_key):
+                        raise RuntimeError("discord gateway advisory unlock failed")
 
     async def _connect_and_record(
         self,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -264,6 +264,7 @@ strict = [
     "app/services/codex_oauth.py",
     "app/services/composio.py",
     "app/services/connected_agent_fence.py",
+    "app/services/discord_advisory_session.py",
     "app/services/discord_command_reconciliation_worker.py",
     "app/services/discord_gateway_worker.py",
     "app/services/discord_rate_limiter.py",

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -9,6 +9,8 @@ oversized-Content-Length path doesn't reach the handler at all.
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 import pytest
 from httpx import ASGITransport
@@ -18,6 +20,46 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
+
+
+@pytest.mark.parametrize("declared", [True, False])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/channels/telegram/botsecret/sendMessage",
+        "/api/channels/discord/api/v10/webhooks/123/secret",
+        "/v1/channels/discord/v10/interactions/123/secret/callback",
+    ],
+)
+async def test_body_rejection_redacts_channel_credentials(caplog, declared, path):
+    async def inner(scope, receive, send):
+        assert scope["path"] == path
+        await receive()
+
+    async def receive():
+        return {"type": "http.request", "body": b"xx", "more_body": False}
+
+    messages = []
+
+    async def send(message):
+        messages.append(message)
+
+    caplog.set_level(logging.INFO, logger="app.middleware.body_size_limit")
+    await BodySizeLimitMiddleware(inner, max_bytes=1)(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [(b"content-length", b"2")] if declared else [],
+        },
+        receive,
+        send,
+    )
+    assert messages[0]["status"] == 413
+    event = "body_size_rejected_header" if declared else "body_size_rejected_stream"
+    assert event in caplog.text
+    assert path.replace("secret", "[redacted]") in caplog.text
+    assert "secret" not in caplog.text
 
 
 def _build_app(*, max_bytes: int) -> tuple[Starlette, list[bool]]:

--- a/backend/tests/test_channel_inbox.py
+++ b/backend/tests/test_channel_inbox.py
@@ -544,7 +544,7 @@ async def test_telegram_inbox_uses_update_id_offset_and_drains_filtered_updates(
     await db_session.refresh(filtered)
     await db_session.refresh(callback)
 
-    assert updates == [
+    assert updates.items == [
         {
             "update_id": 105,
             "callback_query": {
@@ -557,15 +557,13 @@ async def test_telegram_inbox_uses_update_id_offset_and_drains_filtered_updates(
     assert filtered.delivered_at is not None
     assert callback.delivered_at is None
 
-    assert (
-        await dequeue_telegram_updates(
-            db_session,
-            account_id=account.id,
-            offset=106,
-            limit=100,
-        )
-        == []
+    page = await dequeue_telegram_updates(
+        db_session,
+        account_id=account.id,
+        offset=106,
+        limit=100,
     )
+    assert page.items == []
     await db_session.refresh(callback)
     assert callback.delivered_at is not None
 
@@ -611,7 +609,7 @@ async def test_telegram_inbox_terminally_consumes_updates_older_than_official_re
     await db_session.refresh(expired)
     await db_session.refresh(current)
 
-    assert [update["update_id"] for update in updates] == [202]
+    assert [update["update_id"] for update in updates.items] == [202]
     assert expired.delivered_at is not None
     assert current.delivered_at is None
 

--- a/backend/tests/test_channel_webhook_retry.py
+++ b/backend/tests/test_channel_webhook_retry.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models.channel import ChannelBinding, ChannelMessage
+from app.models.hosted_runtime import HostedRuntimeState
+from app.services import channel_webhook_delivery_worker as worker_module
+from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
+from tests.test_channels import (
+    _create_paired_telegram_channel,
+    _pair_telegram_chat,
+    _telegram_agent_headers,
+    _telegram_bot_path,
+)
+
+pytestmark = pytest.mark.committed_db
+
+
+@pytest_asyncio.fixture
+async def webhook_queue(client, db_session, engine, channel_agent, second_channel_agent):
+    channels = []
+    bindings = []
+    for name, agent in (("a", channel_agent), ("b", second_channel_agent)):
+        channel = await _create_paired_telegram_channel(
+            client,
+            name=f"retry-{name}",
+            provider_token=None,
+            agent_id=agent.id,
+        )
+        # Enqueue before setWebhook so the fixture does not make inline HTTP calls.
+        for index in range(2 if name == "a" else 1):
+            response = await client.post(
+                f"/v1/channels/telegram/{channel['id']}/webhook",
+                headers={"x-telegram-bot-api-secret-token": channel["webhook_secret"]},
+                json={
+                    "update_id": 100 + index,
+                    "message": {
+                        "message_id": 100 + index,
+                        "text": f"{name}{index}",
+                        "chat": {"id": 42, "type": "private"},
+                    },
+                },
+            )
+            assert response.status_code == 200, response.text
+        response = await client.post(
+            _telegram_bot_path(channel, "setWebhook"),
+            headers=_telegram_agent_headers(channel),
+            json={"url": f"https://{name}.example/hook"},
+        )
+        assert response.status_code == 200, response.text
+        binding = await db_session.scalar(
+            select(ChannelBinding).where(ChannelBinding.account_id == UUID(channel["id"]))
+        )
+        bindings.append(binding.id)
+        channels.append(channel)
+    await db_session.rollback()
+    return async_sessionmaker(engine, expire_on_commit=False), bindings, channels
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    class Provider:
+        calls = []
+        fail_a = True
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        failed = asyncio.Event()
+        delivered_b = asyncio.Event()
+        block_a = False
+        failure_returned_at = None
+        b_called_at = None
+
+        def __init__(self, **_kwargs):
+            pass
+
+        async def post(self, url, **kwargs):
+            text = kwargs["json"]["message"]["text"]
+            self.calls.append((url, text))
+            if text.startswith("a"):
+                self.entered.set()
+                if self.block_a:
+                    await self.release.wait()
+                if self.fail_a:
+                    Provider.failure_returned_at = time.perf_counter()
+                    self.failed.set()
+                    return httpx.Response(503)
+            else:
+                Provider.b_called_at = time.perf_counter()
+                self.delivered_b.set()
+            return httpx.Response(200)
+
+    monkeypatch.setattr("app.services.channel_webhooks.SafePublicHttpClient", Provider)
+    return Provider
+
+
+async def make_due(factory, binding_id):
+    async with factory() as db:
+        await db.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == binding_id)
+            .values(webhook_retry_at=datetime.now(UTC) - timedelta(seconds=1))
+        )
+        await db.commit()
+
+
+async def test_failed_binding_does_not_sleep_before_healthy_binding(webhook_queue, provider):
+    factory, bindings, _ = webhook_queue
+    stop = asyncio.Event()
+    task = asyncio.create_task(ChannelWebhookDeliveryWorker(factory).run_forever(stop))
+    try:
+        await asyncio.wait_for(provider.failed.wait(), 2)
+        # Start the bound after A returns, not when B was enqueued. Serial HTTP
+        # can still block B for the entire duration of A's in-flight request.
+        await asyncio.wait_for(provider.delivered_b.wait(), 0.75)
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, 2)
+    assert [text for _, text in provider.calls] == ["a0", "b0"]
+    print(f"B called {provider.b_called_at - provider.failure_returned_at:.6f}s after A failure")
+    # A newly constructed worker respects the committed cooldown as well.
+    assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+    await make_due(factory, bindings[0])
+    provider.fail_a = False
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert (await worker.run_once()).delivered
+    assert (await worker.run_once()).delivered
+    assert [text for _, text in provider.calls] == ["a0", "b0", "a0", "a1"]
+    async with factory() as db:
+        binding = await db.get(ChannelBinding, bindings[0])
+        assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+
+
+async def test_retry_steps_persist_and_cap_without_retrying_early(
+    webhook_queue, provider, monkeypatch
+):
+    factory, bindings, _ = webhook_queue
+    now = datetime.now(UTC)
+
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    monkeypatch.setattr(worker_module, "datetime", Clock)
+    for index, seconds in enumerate((1, 2, 4, 8, 16, 32, 60, 60)):
+        worker = ChannelWebhookDeliveryWorker(factory)
+        assert not (await worker.run_once()).delivered
+        if index == 0:
+            assert (await worker.run_once()).delivered  # Drain independent B.
+        async with factory() as db:
+            binding = await db.get(ChannelBinding, bindings[0])
+            assert binding.webhook_retry_step == min(index + 1, 7)
+            assert binding.webhook_retry_at == now + timedelta(seconds=seconds)
+        now += timedelta(seconds=seconds, microseconds=-1)
+        assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+        now += timedelta(microseconds=1)
+    assert [text for _, text in provider.calls].count("a0") == 8
+    assert not any(text == "a1" for _, text in provider.calls)
+
+
+async def test_two_workers_skip_the_entire_locked_binding(webhook_queue, provider):
+    factory, _, _ = webhook_queue
+    provider.block_a = True
+    first = asyncio.create_task(ChannelWebhookDeliveryWorker(factory).run_once())
+    try:
+        await asyncio.wait_for(provider.entered.wait(), 2)
+        second = ChannelWebhookDeliveryWorker(factory)
+        assert (await asyncio.wait_for(second.run_once(), 1)).delivered
+        assert await asyncio.wait_for(second.run_once(), 1) is None
+        assert [text for _, text in provider.calls] == ["a0", "b0"]
+    finally:
+        provider.release.set()
+        assert not (await asyncio.wait_for(first, 2)).delivered
+
+
+@pytest.mark.parametrize("terminal", ["ttl", "authority", "inline", "retirement"])
+async def test_retry_state_clears_on_terminal_outcomes(
+    webhook_queue,
+    provider,
+    client,
+    terminal,
+    db_session,
+    seed_user,
+):
+    factory, bindings, channels = webhook_queue
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert not (await worker.run_once()).delivered
+    if terminal in {"ttl", "authority"}:
+        await make_due(factory, bindings[0])
+        async with factory() as db:
+            if terminal == "ttl":
+                await db.execute(
+                    update(ChannelMessage)
+                    .where(ChannelMessage.binding_id == bindings[0])
+                    .values(created_at=datetime.now(UTC) - timedelta(days=2))
+                )
+            else:
+                # A real persisted authority mismatch, not a mocked predicate.
+                state = await db.get(HostedRuntimeState, UUID(channels[0]["agent_id"]))
+                state.deployment_id = "retired-authority"
+            await db.commit()
+        assert (await worker.run_once()).expired
+        assert len(provider.calls) == 1
+    else:
+        provider.fail_a = False
+        response = await client.post(
+            f"/v1/channels/telegram/{channels[0]['id']}/webhook",
+            headers={"x-telegram-bot-api-secret-token": channels[0]["webhook_secret"]},
+            json={
+                "update_id": 200,
+                "message": {
+                    "message_id": 200,
+                    "text": "a-inline" if terminal == "inline" else "/clawdi_unpair",
+                    "chat": {"id": 42, "type": "private"},
+                    "from": {"id": 4242, "is_bot": False},
+                },
+            },
+        )
+        assert response.status_code == 200, response.text
+    async with factory() as db:
+        binding = await db.get(ChannelBinding, bindings[0])
+        assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+        if terminal == "retirement":
+            assert binding.status == "archived"
+            # Historical rows may still carry state. Reactivation must reset it.
+            binding.webhook_retry_at = datetime.now(UTC) + timedelta(seconds=60)
+            binding.webhook_retry_step = 7
+            await db.commit()
+    if terminal == "retirement":
+        await db_session.refresh(seed_user)
+        await _pair_telegram_chat(client, created=channels[0], chat_id="42", update_id=201)
+        async with factory() as db:
+            binding = await db.get(ChannelBinding, bindings[0])
+            assert binding.status == "active"
+            assert (binding.webhook_retry_at, binding.webhook_retry_step) == (None, 0)
+
+
+async def test_webhook_reconfiguration_keeps_cooldown_without_waiting_for_binding(
+    webhook_queue,
+    provider,
+    client,
+):
+    factory, bindings, channels = webhook_queue
+    worker = ChannelWebhookDeliveryWorker(factory)
+    assert not (await worker.run_once()).delivered
+    assert (await worker.run_once()).delivered
+    channel = channels[0]
+    async with factory() as locked_db:
+        binding = await locked_db.scalar(
+            select(ChannelBinding).where(ChannelBinding.id == bindings[0]).with_for_update()
+        )
+        original_retry = binding.webhook_retry_at
+        for method, body in (
+            ("deleteWebhook", {}),
+            ("setWebhook", {"url": "https://new.example/hook"}),
+        ):
+            response = await asyncio.wait_for(
+                client.post(
+                    _telegram_bot_path(channel, method),
+                    headers=_telegram_agent_headers(channel),
+                    json=body,
+                ),
+                1,
+            )
+            assert response.status_code == 200, response.text
+        await locked_db.refresh(binding)
+        assert binding.webhook_retry_at == original_retry
+        assert binding.webhook_retry_step == 1
+    info = await client.get(
+        _telegram_bot_path(channel, "getWebhookInfo"), headers=_telegram_agent_headers(channel)
+    )
+    assert info.json()["result"]["url"] == "https://new.example/hook"
+    assert info.json()["result"]["pending_update_count"] == 2
+    assert await ChannelWebhookDeliveryWorker(factory).run_once() is None
+    await make_due(factory, bindings[0])
+    provider.fail_a = False
+    assert (await worker.run_once()).delivered
+    assert provider.calls[-1] == ("https://new.example/hook", "a0")
+
+
+async def test_infrastructure_errors_back_off_and_stop(monkeypatch):
+    worker = ChannelWebhookDeliveryWorker(None)
+    stop = asyncio.Event()
+    waits = []
+
+    async def unavailable():
+        raise RuntimeError("synthetic database outage")
+
+    async def wait(event, seconds):
+        waits.append(seconds)
+        if len(waits) == 8:
+            event.set()
+
+    monkeypatch.setattr(worker, "run_once", unavailable)
+    monkeypatch.setattr(worker_module, "_sleep_until_stop", wait)
+    await worker.run_forever(stop)
+    assert waits == [1, 2, 4, 8, 16, 32, 60, 60]

--- a/backend/tests/test_channel_webhook_retry_migration.py
+++ b/backend/tests/test_channel_webhook_retry_migration.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from app.models.channel import ChannelBinding
+
+
+def test_webhook_retry_migration_defaults_constraint_and_downgrade(engine):
+    path = (
+        Path(__file__).parents[1]
+        / "alembic/versions/a6d9c2e4f7b1_add_binding_webhook_retry_state.py"
+    )
+    spec = importlib.util.spec_from_file_location("webhook_retry_migration", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    sync_engine = sa.create_engine(engine.url.set(drivername="postgresql+psycopg2"))
+    schema = f"webhook_retry_{uuid4().hex}"
+    try:
+        with sync_engine.begin() as connection:
+            # Compare the migrated real application table to the ORM contract.
+            columns = {
+                column["name"]: column
+                for column in sa.inspect(connection).get_columns("channel_bindings")
+            }
+            for name in ("webhook_retry_at", "webhook_retry_step"):
+                assert columns[name]["nullable"] == ChannelBinding.__table__.c[name].nullable
+                assert columns[name]["type"].compile(
+                    dialect=connection.dialect
+                ) == ChannelBinding.__table__.c[name].type.compile(dialect=connection.dialect)
+            connection.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+            connection.execute(sa.text(f'SET LOCAL search_path TO "{schema}"'))
+            connection.execute(sa.text("CREATE TABLE channel_bindings (id integer PRIMARY KEY)"))
+            connection.execute(sa.text("INSERT INTO channel_bindings VALUES (1)"))
+            migration.op = Operations(MigrationContext.configure(connection))
+            migration.upgrade()
+            assert connection.execute(
+                sa.text(
+                    "SELECT webhook_retry_at, webhook_retry_step FROM channel_bindings WHERE id = 1"
+                )
+            ).one() == (None, 0)
+            with pytest.raises(sa.exc.IntegrityError), connection.begin_nested():
+                connection.execute(sa.text("UPDATE channel_bindings SET webhook_retry_step = -1"))
+            connection.execute(
+                sa.text(
+                    "UPDATE channel_bindings SET webhook_retry_step = 7, webhook_retry_at = now()"
+                )
+            )
+            migration.downgrade()
+            assert [
+                column["name"]
+                for column in sa.inspect(connection).get_columns("channel_bindings", schema=schema)
+            ] == ["id"]
+            assert connection.scalar(sa.text("SELECT id FROM channel_bindings")) == 1
+            migration.upgrade()
+            assert connection.execute(
+                sa.text("SELECT webhook_retry_at, webhook_retry_step FROM channel_bindings")
+            ).one() == (None, 0)
+            connection.execute(sa.text(f'DROP SCHEMA "{schema}" CASCADE'))
+    finally:
+        sync_engine.dispose()

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -13,6 +13,7 @@ from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
 from app.services.channel_wakeups import (
     CHANNEL_DELIVERIES_ENQUEUED,
+    ChannelInboxPage,
     ChannelWakeup,
     wait_for_channel_inbound_messages,
 )
@@ -165,7 +166,7 @@ async def test_channel_inbound_wait_falls_back_when_notification_is_lost():
     async def fetch():
         nonlocal calls
         calls += 1
-        return [] if calls == 1 else ["message"]
+        return ChannelInboxPage([] if calls == 1 else ["message"])
 
     messages = await wait_for_channel_inbound_messages(
         fetch,

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -107,6 +107,7 @@ from app.services.channels import (
     telegram_message_thread_id_from_update,
     wait_for_telegram_updates,
 )
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.discord_command_reconciliation_worker import (
     DiscordCommandReconciliationWorker,
     reconcile_discord_guild_commands,
@@ -24384,7 +24385,8 @@ async def test_discord_gateway_commit_delivery_phases(client, db_session, monkey
         "async_session_factory",
         async_sessionmaker(gateway_engine, expire_on_commit=False),
     )
-    monkeypatch.setattr(discord_router, "database_engine", gateway_engine)
+    consumer_locks = DiscordAdvisorySession(gateway_engine)
+    monkeypatch.setattr(app.state, "discord_gateway_locks", consumer_locks, raising=False)
     sql_count = 0
     empty_queries = asyncio.Queue()
     original_dequeue = discord_router.dequeue_discord_gateway_events
@@ -24555,17 +24557,22 @@ async def test_discord_gateway_commit_delivery_phases(client, db_session, monkey
             try:
                 await stop_postgres_listener()
             finally:
-                await gateway_engine.dispose()
+                try:
+                    await consumer_locks.close()
+                finally:
+                    await gateway_engine.dispose()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("exit_kind", ["disconnect", "cancel", "lease_lost"])
-async def test_discord_gateway_wakeup_owns_reader_and_cleanup(monkeypatch, exit_kind):
+async def test_discord_gateway_wakeup_owns_reader_and_cleanup(monkeypatch, engine, exit_kind):
     from fastapi import WebSocket
 
     from app.services.channel_wakeups import ChannelWakeup
 
     _install_discord_gateway_protocol_fakes(monkeypatch)
+    consumer_locks = DiscordAdvisorySession(engine)
+    monkeypatch.setattr(app.state, "discord_gateway_locks", consumer_locks, raising=False)
     source = ChannelWakeup()
     monkeypatch.setattr(discord_router, "channel_inbound_messages_enqueued", source)
     monkeypatch.setattr(settings, "discord_gateway_poll_interval_seconds", 60)
@@ -24603,6 +24610,7 @@ async def test_discord_gateway_wakeup_owns_reader_and_cleanup(monkeypatch, exit_
         {
             "type": "websocket",
             "path": "/v1/channels/discord/gateway",
+            "app": app,
             "headers": [],
             "query_string": b"",
         },
@@ -24668,3 +24676,4 @@ async def test_discord_gateway_wakeup_owns_reader_and_cleanup(monkeypatch, exit_
         if not task.done():
             task.cancel()
         await asyncio.gather(task, return_exceptions=True)
+        await consumer_locks.close()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -15806,7 +15806,7 @@ def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatc
         async_sessionmaker(gateway_engine, expire_on_commit=False),
     )
     monkeypatch.setattr(
-        "app.routes.channel_routers.discord.database_engine",
+        "app.main.engine",
         gateway_engine,
     )
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -24153,3 +24153,337 @@ async def test_archived_agent_cannot_route_channels_and_reactivation_restores_au
         user_id=seed_user.id,
     )
     assert restored.id == channel_agent.id
+
+
+@pytest.mark.asyncio
+async def test_discord_gateway_commit_delivery_phases(client, db_session, monkeypatch):
+    """Real commits and TCP WebSockets; phases start after an empty inbox query."""
+    import statistics
+    from time import perf_counter
+
+    import uvicorn
+    from websockets.asyncio.client import connect
+
+    from app.services.channel_wakeups import notify_channel_inbound_message_enqueued
+    from app.services.sync_events import start_postgres_listener, stop_postgres_listener
+    from tests.conftest import create_env_with_project
+
+    _reset_discord_gateway_sessions(monkeypatch)
+    monkeypatch.setattr(settings, "discord_gateway_poll_interval_seconds", 1.0)
+    created = await _create_paired_discord_channel(client, name=f"gateway-phases-{uuid4().hex}")
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    other_agent = await create_env_with_project(
+        db_session,
+        user_id=binding.user_id,
+        machine_id=f"phase-other-{uuid4().hex}",
+        machine_name="Other phase agent",
+    )
+    other_link = ChannelBotAgentLink(
+        account_id=account_id, user_id=binding.user_id, agent_id=other_agent.id
+    )
+    db_session.add(other_link)
+    await db_session.flush()
+    other_binding = ChannelBinding(
+        account_id=account_id,
+        bot_agent_link_id=other_link.id,
+        user_id=binding.user_id,
+        external_chat_id="other-phase-guild",
+        external_chat_type="guild",
+    )
+    db_session.add(other_binding)
+    await db_session.commit()
+    gateway_engine = create_async_engine(settings.database_url)
+    monkeypatch.setattr(
+        discord_router,
+        "async_session_factory",
+        async_sessionmaker(gateway_engine, expire_on_commit=False),
+    )
+    monkeypatch.setattr(discord_router, "database_engine", gateway_engine)
+    sql_count = 0
+    empty_queries = asyncio.Queue()
+    original_dequeue = discord_router.dequeue_discord_gateway_events
+
+    def count_sql(*_args):
+        nonlocal sql_count
+        sql_count += 1
+
+    async def observed_dequeue(*args, **kwargs):
+        values = await original_dequeue(*args, **kwargs)
+        if not values:
+            empty_queries.put_nowait(perf_counter())
+        return values
+
+    async def provider(*, path, **_kwargs):
+        assert path == "channels/discord-chan-1"
+        return shared_router.DiscordProviderResult(
+            content=json.dumps(
+                {
+                    "id": "discord-chan-1",
+                    "guild_id": "discord-guild-1",
+                    "type": 0,
+                    "name": "phase-test",
+                }
+            ).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    sqlalchemy_event.listen(gateway_engine.sync_engine, "before_cursor_execute", count_sql)
+    monkeypatch.setattr(discord_router, "dequeue_discord_gateway_events", observed_dequeue)
+    monkeypatch.setattr(discord_router, "request_discord_provider", provider)
+    server = uvicorn.Server(uvicorn.Config(app, lifespan="off", log_level="error"))
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    samples = []
+    try:
+        await start_postgres_listener()
+        async with asyncio.timeout(10):
+            while not server.started:
+                await asyncio.sleep(0.01)
+        async with connect(f"ws://127.0.0.1:{port}/v1/channels/discord/gateway") as ws:
+
+            async def receive():
+                return json.loads(await asyncio.wait_for(ws.recv(), 5))
+
+            assert (await receive())["op"] == 10
+            await ws.send(
+                json.dumps({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+            )
+            assert (await receive())["t"] == "READY"
+            assert (await receive())["t"] == "GUILD_CREATE"
+            assert (await receive())["t"] == "CHANNEL_CREATE"
+            for index, phase in enumerate([0.05, 0.25, 0.5, 0.75, 0.95] * 3 + [0.05]):
+                if index == 15:
+                    await stop_postgres_listener()
+                while not empty_queries.empty():
+                    empty_queries.get_nowait()
+                # Heartbeat gives each sample a fresh empty-query boundary.
+                await ws.send(json.dumps({"op": 1, "d": None}))
+                assert (await receive())["op"] == 11
+                idle_at = await asyncio.wait_for(empty_queries.get(), 5)
+                await asyncio.sleep(max(0, idle_at + phase - perf_counter()))
+                message = ChannelMessage(
+                    account_id=account_id,
+                    bot_agent_link_id=UUID(created["agent_link_id"]),
+                    binding_id=binding.id,
+                    user_id=binding.user_id,
+                    direction=MESSAGE_DIRECTION_INBOUND,
+                    external_chat_id=binding.external_chat_id,
+                    provider_message_id=f"phase-{index}",
+                    payload={
+                        "t": "MESSAGE_CREATE",
+                        "d": {
+                            "id": f"phase-{index}",
+                            "channel_id": "discord-chan-1",
+                            "guild_id": "discord-guild-1",
+                            "content": "phase test",
+                            "author": {"id": "phase-user"},
+                        },
+                    },
+                )
+                db_session.add(message)
+                await db_session.flush()
+                await notify_channel_inbound_message_enqueued(
+                    db_session, account_id=str(account_id)
+                )
+                before_sql = sql_count
+                await db_session.commit()
+                committed_at = perf_counter()
+                dispatch = await receive()
+                elapsed = (perf_counter() - committed_at) * 1000
+                assert dispatch["t"] == "MESSAGE_CREATE"
+                assert dispatch["d"]["id"] == f"phase-{index}"
+                samples.append(
+                    {
+                        "phase": phase,
+                        "ms": round(elapsed, 3),
+                        "sql": sql_count - before_sql,
+                        "listening": index < 15,
+                    }
+                )
+                await ws.send(json.dumps({"op": 1, "d": dispatch["s"]}))
+                assert (await receive())["op"] == 11
+                await db_session.refresh(message)
+                assert message.delivered_at is not None
+            await start_postgres_listener()
+            unrelated = []
+            for index in range(3):
+                while not empty_queries.empty():
+                    empty_queries.get_nowait()
+                await ws.send(json.dumps({"op": 1, "d": None}))
+                assert (await receive())["op"] == 11
+                await asyncio.wait_for(empty_queries.get(), 5)
+                # Let the heartbeat's query and any already-coalesced wakeup
+                # finish before attributing SQL to the next foreign commit.
+                await asyncio.sleep(0.05)
+                while not empty_queries.empty():
+                    empty_queries.get_nowait()
+                foreign = ChannelMessage(
+                    account_id=account_id,
+                    bot_agent_link_id=other_link.id,
+                    binding_id=other_binding.id,
+                    user_id=binding.user_id,
+                    direction=MESSAGE_DIRECTION_INBOUND,
+                    external_chat_id=other_binding.external_chat_id,
+                    provider_message_id=f"other-phase-{index}",
+                    payload={"t": "MESSAGE_CREATE", "d": {"content": "other link"}},
+                )
+                db_session.add(foreign)
+                await db_session.flush()
+                await notify_channel_inbound_message_enqueued(
+                    db_session, account_id=str(account_id)
+                )
+                before_sql = sql_count
+                await db_session.commit()
+                committed_at = perf_counter()
+                await asyncio.wait_for(empty_queries.get(), 2)
+                unrelated.append(
+                    {
+                        "ms": round((perf_counter() - committed_at) * 1000, 3),
+                        "sql": sql_count - before_sql,
+                    }
+                )
+                # Other Link's message must not leak through this socket.
+                await ws.send(json.dumps({"op": 1, "d": None}))
+                assert (await receive())["op"] == 11
+            print("GATEWAY_OTHER_LINK", json.dumps(unrelated))
+        times = sorted(sample["ms"] for sample in samples if sample["listening"])
+        print(
+            "GATEWAY_PHASES",
+            json.dumps(
+                {
+                    "p50_ms": statistics.median(times),
+                    "p95_ms": times[int(len(times) * 0.95)],
+                    "samples": samples,
+                }
+            ),
+        )
+    finally:
+        try:
+            server.should_exit = True
+            await asyncio.wait_for(server_task, 10)
+        finally:
+            listener.close()
+            try:
+                await stop_postgres_listener()
+            finally:
+                await gateway_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_kind", ["disconnect", "cancel", "lease_lost"])
+async def test_discord_gateway_wakeup_owns_reader_and_cleanup(monkeypatch, exit_kind):
+    from fastapi import WebSocket
+
+    from app.services.channel_wakeups import ChannelWakeup
+
+    _install_discord_gateway_protocol_fakes(monkeypatch)
+    source = ChannelWakeup()
+    monkeypatch.setattr(discord_router, "channel_inbound_messages_enqueued", source)
+    monkeypatch.setattr(settings, "discord_gateway_poll_interval_seconds", 60)
+    account_key = str(_discord_gateway_protocol_agent().account.id)
+    inbox_checked = asyncio.Queue()
+    incoming = asyncio.Queue()
+    outgoing = asyncio.Queue()
+    original_dequeue = discord_router.dequeue_discord_gateway_events
+    cancelled_receives = 0
+
+    async def dequeue(*args, **kwargs):
+        result = await original_dequeue(*args, **kwargs)
+        inbox_checked.put_nowait(None)
+        return result
+
+    async def receive():
+        nonlocal cancelled_receives
+        try:
+            return await incoming.get()
+        except asyncio.CancelledError:
+            cancelled_receives += 1
+            raise
+
+    @asynccontextmanager
+    async def lost_lease(**_kwargs):
+        try:
+            yield True
+        finally:
+            raise discord_router._DiscordGatewayConsumerLeaseLost("test lease lost on exit")
+
+    monkeypatch.setattr(discord_router, "dequeue_discord_gateway_events", dequeue)
+    if exit_kind == "lease_lost":
+        monkeypatch.setattr(discord_router, "_discord_gateway_consumer_lease", lost_lease)
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "path": "/v1/channels/discord/gateway",
+            "headers": [],
+            "query_string": b"",
+        },
+        receive,
+        outgoing.put,
+    )
+    incoming.put_nowait({"type": "websocket.connect"})
+    task = asyncio.create_task(discord_router.discord_agent_gateway(websocket))
+
+    def frame(payload):
+        incoming.put_nowait({"type": "websocket.receive", "text": json.dumps(payload)})
+
+    async def dispatch():
+        message = await asyncio.wait_for(outgoing.get(), 2)
+        return json.loads(message["text"])
+
+    try:
+        assert (await outgoing.get())["type"] == "websocket.accept"
+        assert (await dispatch())["op"] == 10
+        frame({"op": 2, "d": {"token": "valid-discord-token", "intents": 0}})
+        ready = await dispatch()
+        assert ready["t"] == "READY"
+        assert (await dispatch())["t"] == "GUILD_CREATE"
+        assert (await dispatch())["t"] == "CHANNEL_CREATE"
+        await asyncio.wait_for(inbox_checked.get(), 2)
+        # A notification alone must leave the outstanding ASGI receive intact.
+        source.signal(account_key)
+        await asyncio.wait_for(inbox_checked.get(), 2)
+        assert cancelled_receives == 0
+        monkeypatch.setattr(settings, "discord_gateway_poll_interval_seconds", 0.01)
+        source.signal(account_key)
+        await asyncio.wait_for(inbox_checked.get(), 2)
+        await asyncio.wait_for(inbox_checked.get(), 2)
+        assert cancelled_receives == 0
+        monkeypatch.setattr(settings, "discord_gateway_poll_interval_seconds", 60)
+        # Make both inputs runnable in the same tick; neither may be discarded.
+        source.signal(account_key)
+        frame({"op": 1, "d": None})
+        assert (await dispatch()) == {"op": 11, "d": None}
+        assert cancelled_receives == 0
+        source.signal(account_key)
+        if exit_kind == "disconnect":
+            incoming.put_nowait({"type": "websocket.disconnect", "code": 1000})
+            await asyncio.wait_for(task, 2)
+        else:
+            task.cancel()
+            expected = (
+                discord_router._DiscordGatewayConsumerLeaseLost
+                if exit_kind == "lease_lost"
+                else asyncio.CancelledError
+            )
+            with pytest.raises(expected):
+                await asyncio.wait_for(task, 2)
+        assert not source._waiters
+        entry = discord_router._DISCORD_GATEWAY_SESSIONS._entries[ready["d"]["session_id"]]
+        assert entry.connection_count == 0
+        assert not [
+            child
+            for child in asyncio.all_tasks()
+            if child.get_name() in {"discord-gateway-receive", "discord-gateway-wakeup"}
+        ]
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -9470,9 +9470,16 @@ async def test_telegram_webhook_worker_retries_failed_agent_delivery(
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     worker = ChannelWebhookDeliveryWorker(sessionmaker)
-    first_result = await worker.run_once()
-    second_result = await worker.run_once()
-    result = await worker.run_once()
+    results = []
+    for _ in range(3):
+        await db_session.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == message.binding_id)
+            .values(webhook_retry_at=None)
+        )
+        await db_session.commit()
+        results.append(await worker.run_once())
+    first_result, second_result, result = results
     await db_session.refresh(message)
 
     assert first_result is not None
@@ -9653,9 +9660,16 @@ async def test_telegram_webhook_worker_skips_non_webhook_queue_head(
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     worker = ChannelWebhookDeliveryWorker(sessionmaker)
-    first_result = await worker.run_once()
-    second_result = await worker.run_once()
-    result = await worker.run_once()
+    results = []
+    for _ in range(3):
+        await db_session.execute(
+            update(ChannelBinding)
+            .where(ChannelBinding.id == webhook_message.binding_id)
+            .values(webhook_retry_at=None)
+        )
+        await db_session.commit()
+        results.append(await worker.run_once())
+    first_result, second_result, result = results
     await db_session.refresh(webhook_message)
 
     assert first_result is not None

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11206,6 +11206,173 @@ async def test_discord_interaction_callback_and_followup_require_recorded_token(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["callback", "followup"])
+@pytest.mark.parametrize("binding_state", ["unpaired", "reassigned", "missing"])
+async def test_discord_interaction_reference_requires_current_binding(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    binding_state: str,
+):
+    _reset_fake_provider_client({"id": "discord-upstream"})
+    monkeypatch.setattr(shared_router.httpx, "AsyncClient", _FakeProviderClient)
+    created = await _create_paired_discord_channel(
+        client, name="discord-reference-revocation", agent_id=channel_agent.id
+    )
+    ingress = await _record_discord_interaction(
+        client,
+        created=created,
+        interaction_id="revoked-interaction",
+        token="revoked-token",
+        application_id=DISCORD_TEST_APPLICATION_ID,
+    )
+    assert ingress.status_code == 202
+    binding = await db_session.scalar(
+        select(ChannelBinding).where(ChannelBinding.account_id == UUID(created["id"]))
+    )
+    assert binding is not None
+    unpaired = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding.id}")
+    assert unpaired.status_code == 200, unpaired.text
+    assert unpaired.json()["unpaired"] is True
+    if binding_state == "reassigned":
+        second = await client.post(
+            f"/v1/channels/{created['id']}/agent-links",
+            json={"agent_id": str(second_channel_agent.id)},
+        )
+        assert second.status_code == 201, second.text
+        pair = await client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": second.json()["id"], "ttl_seconds": 900},
+        )
+        assert pair.status_code == 201, pair.text
+        repaired = await client.post(
+            f"/v1/channels/discord/{created['id']}/webhook",
+            headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+            json={
+                "type": 2,
+                "id": "repair-interaction",
+                "token": "repair-token",
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "channel_id": "discord-chan-1",
+                "guild_id": "discord-guild-1",
+                "context": 0,
+                "authorizing_integration_owners": {"0": "discord-guild-1"},
+                "member": {"permissions": "32", "user": {"id": "discord-pair-user"}},
+                "data": {
+                    "name": "clawdi_pair",
+                    "options": [{"name": "code", "value": pair.json()["code"]}],
+                },
+            },
+        )
+        assert repaired.status_code == 200, repaired.text
+        assert repaired.json()["data"]["content"].startswith("Server paired.")
+        await db_session.refresh(binding)
+        assert binding.status == BINDING_STATUS_ACTIVE
+        assert str(binding.bot_agent_link_id) == second.json()["id"]
+    elif binding_state == "missing":
+        # Historical references can lose their Binding through ON DELETE SET NULL.
+        await db_session.delete(binding)
+        await db_session.commit()
+
+    _reset_fake_provider_client({"id": "must-not-send"})
+    path = (
+        "interactions/revoked-interaction/revoked-token/callback"
+        if endpoint == "callback"
+        else f"webhooks/{DISCORD_TEST_APPLICATION_ID}/revoked-token"
+    )
+    response = await client.post(
+        f"/v1/channels/discord/v10/{path}",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json={"type": 4, "data": {"content": "must not send"}, "content": "must not send"},
+    )
+    assert (response.status_code, len(_FakeProviderClient.calls)) == (404, 0)
+
+
+@pytest.mark.asyncio
+async def test_discord_shared_profile_shadow_is_link_scoped(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    channel_agent,
+    second_channel_agent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_discord_gateway_sessions(monkeypatch)
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "discord",
+            "name": "discord-shared-profile",
+            "provider_token": "discord-provider-token",
+            "config": _discord_ready_config(),
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    second_response = await client.post(
+        f"/v1/channels/{created['id']}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert second_response.status_code == 201, second_response.text
+    second = second_response.json()
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.visibility = CHANNEL_VISIBILITY_PUBLIC
+    account.user_id = None
+    account.config = {**account.config, "bot_username": "Legacy Bot", "bot_avatar": "legacy"}
+    await db_session.commit()
+    original_config = dict(account.config)
+    headers_a = {"Authorization": f"Bot {created['agent_token']}"}
+    headers_b = {"Authorization": f"Bot {second['agent_token']}"}
+    patched = await client.patch(
+        "/v1/channels/discord/v10/users/@me",
+        headers=headers_a,
+        json={"username": "Link A", "avatar": None},
+    )
+    assert patched.status_code == 200, patched.text
+    # An omitted avatar preserves an explicit clear, rather than restoring the fallback.
+    patched = await client.patch(
+        "/v1/channels/discord/v10/users/@me", headers=headers_a, json={"username": "Link A"}
+    )
+    assert patched.status_code == 200
+    for path in ("users/@me", "applications/@me", "oauth2/applications/@me"):
+        first = await client.get(f"/v1/channels/discord/v10/{path}", headers=headers_a)
+        second_get = await client.get(f"/v1/channels/discord/v10/{path}", headers=headers_b)
+        assert first.status_code == second_get.status_code == 200
+        user_a = first.json() if path == "users/@me" else first.json()["bot"]
+        user_b = second_get.json() if path == "users/@me" else second_get.json()["bot"]
+        assert (user_a["username"], user_a["avatar"]) == ("Link A", None)
+        assert (user_b["username"], user_b["avatar"]) == ("Legacy Bot", "legacy")
+
+    _install_discord_gateway_test_session_factory(monkeypatch)
+    placeholder = channel_runtime_placeholder_token(
+        CHANNEL_PROVIDER_DISCORD, channel_runtime_account_key(account.id)
+    )
+
+    def ready_user(token: str) -> dict[str, Any]:
+        with TestClient(app) as sync_client:
+            with sync_client.websocket_connect(
+                "/v1/channels/discord/gateway?v=10&encoding=json",
+                headers={"Authorization": f"Bearer {token}"},
+            ) as websocket:
+                assert websocket.receive_json()["op"] == 10
+                websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+                ready = websocket.receive_json()
+                assert ready["t"] == "READY"
+                return ready["d"]["user"]
+
+    user_a = ready_user(created["agent_token"])
+    user_b = ready_user(second["agent_token"])
+    assert (user_a["username"], user_a["avatar"]) == ("Link A", None)
+    assert (user_b["username"], user_b["avatar"]) == ("Legacy Bot", "legacy")
+    await db_session.refresh(account)
+    assert account.config == original_config
+
+
+@pytest.mark.asyncio
 async def test_discord_bot_profile_shadow_is_account_scoped(
     client: httpx.AsyncClient,
     channel_agent,

--- a/backend/tests/test_discord_consumer_resource_boundary.py
+++ b/backend/tests/test_discord_consumer_resource_boundary.py
@@ -1,0 +1,268 @@
+"""Consumer leases use the lifespan-owned Discord session, not one pool slot per Link."""
+
+import asyncio
+import json
+import os
+import sys
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.database import _create_engine
+from app.routes.channel_routers import discord
+from app.services import discord_advisory_session as advisory
+
+
+async def eventually(predicate):
+    async with asyncio.timeout(5):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+@pytest_asyncio.fixture
+async def consumer(monkeypatch):
+    monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
+    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    locks = advisory.DiscordAdvisorySession(
+        ordinary, liveness_interval_seconds=0.02, liveness_timeout_seconds=0.2
+    )
+    try:
+        yield ordinary, locks
+    finally:
+        await locks.close()
+        await ordinary.dispose()
+
+
+def lease(locks, identity):
+    account_id, link_id = identity
+    return discord._discord_gateway_consumer_lease(
+        account_id=account_id, bot_agent_link_id=link_id, lock_session=locks
+    )
+
+
+async def hold(locks, identity, ready, stop):
+    async with lease(locks, identity) as acquired:
+        assert acquired
+        ready.set()
+        await stop.wait()
+
+
+async def attempt(locks, identity):
+    async with lease(locks, identity) as acquired:
+        return acquired
+
+
+async def peer_claim(engine, identity):
+    account_id, link_id = identity
+    async with engine.connect() as connection:
+        key = await connection.scalar(
+            text("SELECT hashtextextended(:name, 0)"),
+            {"name": f"discord-agent-gateway:{account_id}:{link_id}"},
+        )
+        acquired = await advisory.try_advisory_lock(connection, key)
+        if acquired:
+            assert await advisory.release_advisory_lock(connection, key)
+        return acquired
+
+
+async def subprocess_claim(identity):
+    # A separate Python process executes the released consumer SQL/key. It has
+    # no shared Python ownership map and only contacts the disposable test PG.
+    code = """
+import asyncio, asyncpg, json, os, sys
+async def main():
+    db = await asyncpg.connect(os.environ['DATABASE_URL'].replace('+asyncpg', ''))
+    try:
+        key = await db.fetchval('SELECT hashtextextended($1, 0)', sys.argv[1])
+        acquired = await db.fetchval('SELECT pg_try_advisory_lock($1)', key)
+        if acquired:
+            assert await db.fetchval('SELECT pg_advisory_unlock($1)', key)
+        print(json.dumps(acquired))
+    finally:
+        await db.close()
+asyncio.run(main())
+"""
+    account_id, link_id = identity
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        f"discord-agent-gateway:{account_id}:{link_id}",
+        env=os.environ.copy(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), 5)
+        assert process.returncode == 0, stderr.decode()
+        return json.loads(stdout)
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+
+async def test_consumer_more_links_than_pool_local_and_cross_process_exclusion(consumer):
+    ordinary, locks = consumer
+    identities = [(uuid4(), uuid4()) for _ in range(4)]
+    stop = asyncio.Event()
+    ready = [asyncio.Event() for _ in identities]
+    tasks = [
+        asyncio.create_task(hold(locks, identity, entered, stop))
+        for identity, entered in zip(identities, ready, strict=True)
+    ]
+    try:
+        await asyncio.wait_for(asyncio.gather(*(event.wait() for event in ready)), 5)
+        assert ordinary.pool.checkedout() == 1
+        async with ordinary.connect() as connection:
+            assert await connection.scalar(text("SELECT 1")) == 1
+        # This task differs from all four lease owners; PostgreSQL's reentrant
+        # success on the shared session must not admit a duplicate owner.
+        assert await attempt(locks, identities[0]) is False
+        assert await subprocess_claim(identities[0]) is False
+        stop.set()
+        await asyncio.wait_for(asyncio.gather(*tasks), 5)
+        assert await subprocess_claim(identities[0]) is True
+        await locks.close()
+        assert ordinary.pool.checkedout() == 0
+        assert locks._session is None
+    finally:
+        stop.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def test_live_failed_pg_session_is_retired_without_new_claim_or_shutdown(
+    consumer,
+    engine,
+):
+    ordinary, locks = consumer
+    identities = [(uuid4(), uuid4()) for _ in range(3)]
+    ready = [asyncio.Event() for _ in identities]
+    tasks = [
+        asyncio.create_task(hold(locks, identity, entered, asyncio.Event()))
+        for identity, entered in zip(identities, ready, strict=True)
+    ]
+    unrelated = asyncio.create_task(asyncio.Event().wait())
+    try:
+        await asyncio.wait_for(asyncio.gather(*(event.wait() for event in ready)), 5)
+        session = locks._session
+        assert session is not None
+        async with locks._connection(session) as connection:
+            pid = await connection.scalar(text("SELECT pg_backend_pid()"))
+        # An actual SQL error leaves this PostgreSQL backend alive, holding its
+        # session-level keys until the component explicitly retires it.
+        with pytest.raises(advisory.DiscordAdvisorySessionLost):
+            async with locks._connection(session) as connection:
+                await connection.execute(text("SELECT 1 / 0"))
+        assert not session.connection.invalidated
+        results = await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 5)
+        assert all(
+            isinstance(result, discord._DiscordGatewayConsumerLeaseLost) for result in results
+        )
+        assert not unrelated.done()
+        await eventually(lambda: locks._session is None and ordinary.pool.checkedout() == 0)
+        for identity in identities:
+            assert await peer_claim(engine, identity)
+        async with engine.connect() as connection:
+            assert (
+                await connection.scalar(
+                    text("SELECT count(*) FROM pg_stat_activity WHERE pid = :pid"), {"pid": pid}
+                )
+                == 0
+            )
+        assert session.retirement is not None and session.retirement.done()
+    finally:
+        unrelated.cancel()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(unrelated, *tasks, return_exceptions=True)
+
+
+async def test_cancelled_consumer_claim_waiter_does_not_cancel_owner(consumer):
+    _, locks = consumer
+    ready, stop = asyncio.Event(), asyncio.Event()
+    owner = asyncio.create_task(hold(locks, (uuid4(), uuid4()), ready, stop))
+    waiter = None
+    try:
+        await asyncio.wait_for(ready.wait(), 5)
+        async with locks._serial:
+            waiter = asyncio.create_task(attempt(locks, (uuid4(), uuid4())))
+            await asyncio.sleep(0)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            assert not locks.failed and not owner.done()
+        stop.set()
+        await owner
+    finally:
+        stop.set()
+        await asyncio.gather(
+            owner, *([waiter] if waiter is not None else []), return_exceptions=True
+        )
+
+
+async def test_close_fences_claim_after_pg_success_before_local_registration(
+    consumer,
+    engine,
+    monkeypatch,
+):
+    ordinary, locks = consumer
+    identity = (uuid4(), uuid4())
+    claimed, proceed = asyncio.Event(), asyncio.Event()
+    original = advisory.try_advisory_lock
+
+    async def paused_claim(connection, key):
+        result = await original(connection, key)
+        assert result
+        claimed.set()
+        await proceed.wait()
+        return result
+
+    monkeypatch.setattr(advisory, "try_advisory_lock", paused_claim)
+    claimant = asyncio.create_task(attempt(locks, identity))
+    closing = None
+    try:
+        await asyncio.wait_for(claimed.wait(), 5)
+        closing = asyncio.create_task(locks.close())
+        await eventually(lambda: locks._session is not None and locks._session.closing)
+        proceed.set()
+        with pytest.raises(discord._DiscordGatewayConsumerLeaseLost):
+            await asyncio.wait_for(claimant, 5)
+        await asyncio.wait_for(closing, 5)
+        assert ordinary.pool.checkedout() == 0 and locks._session is None
+        monkeypatch.setattr(advisory, "try_advisory_lock", original)
+        assert await peer_claim(engine, identity)
+    finally:
+        proceed.set()
+        await asyncio.gather(
+            claimant, *([closing] if closing is not None else []), return_exceptions=True
+        )
+
+
+async def test_lease_owner_cannot_close_or_recover_its_own_session(consumer):
+    _, locks = consumer
+    identity = (uuid4(), uuid4())
+    async with lease(locks, identity) as acquired:
+        assert acquired
+        with pytest.raises(advisory.DiscordAdvisorySessionLost, match="owns no lease"):
+            await locks.close()
+        assert not locks._closed
+
+    # Failure recovery checks the real caller before acquiring the lifecycle
+    # gate, including when automatic retirement already waits for that owner.
+    async def owner():
+        async with lease(locks, identity):
+            session = locks._session
+            assert session is not None
+            try:
+                async with locks._connection(session) as connection:
+                    await connection.execute(text("SELECT 1 / 0"))
+            except advisory.DiscordAdvisorySessionLost:
+                with pytest.raises(advisory.DiscordAdvisorySessionLost, match="owns no lease"):
+                    await locks.claim(f"discord-agent-gateway:{uuid4()}:{uuid4()}")
+
+    with pytest.raises(discord._DiscordGatewayConsumerLeaseLost):
+        await asyncio.wait_for(asyncio.create_task(owner()), 5)

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -7,8 +7,9 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, text, update
+from sqlalchemy import text, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.schema import CreateSchema, DropSchema
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
@@ -82,9 +83,34 @@ class Network:
 
 
 @pytest_asyncio.fixture
+async def engine(engine):
+    """Isolate global account scans while retaining independent real PG observers."""
+    schema = f"discord_gateway_{uuid4().hex}"
+    async with engine.begin() as connection:
+        await connection.execute(CreateSchema(schema))
+    try:
+        async with engine.begin() as connection:
+            quoted_schema = connection.dialect.identifier_preparer.quote(schema)
+            # These probes use only platform-owned accounts and no tenant FKs.
+            # Clone the migrated table's columns, checks, defaults and indexes.
+            await connection.execute(
+                text(
+                    f"CREATE TABLE {quoted_schema}.channel_accounts "
+                    "(LIKE public.channel_accounts INCLUDING ALL)"
+                )
+            )
+        yield engine.execution_options(schema_translate_map={None: schema})
+    finally:
+        async with engine.begin() as connection:
+            await connection.execute(DropSchema(schema, cascade=True))
+
+
+@pytest_asyncio.fixture
 async def provider(engine, monkeypatch):
     monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
-    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    ordinary = _create_engine(pool_size=2, max_overflow=0).execution_options(
+        schema_translate_map=engine.get_execution_options()["schema_translate_map"]
+    )
     accounts = [uuid4() for _ in range(4)]
     async with async_sessionmaker(engine)() as db:
         for account_id in accounts:
@@ -118,9 +144,6 @@ async def provider(engine, monkeypatch):
         yield ordinary, accounts, network, worker
     finally:
         await worker.stop()
-        async with async_sessionmaker(engine)() as db:
-            await db.execute(delete(ChannelAccount).where(ChannelAccount.id.in_(accounts)))
-            await db.commit()
         await ordinary.dispose()
 
 

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -1,0 +1,428 @@
+"""Real PostgreSQL ownership and pool boundaries with an isolated provider transport."""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, text, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from app.core.config import settings
+from app.core.database import _create_engine
+from app.models.channel import ChannelAccount
+from app.services import discord_gateway_worker as gateway
+from app.services.vault_crypto import encrypt
+from app.workers import channels
+
+
+async def eventually(predicate):
+    async with asyncio.timeout(5):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+class Transport:
+    def __init__(self):
+        self.frames = asyncio.Queue()
+        self.frames.put_nowait(json.dumps({"op": 10, "d": {"heartbeat_interval": 100}}))
+        self.sent = []
+        self.closed = False
+        self.account_id = None
+
+    async def recv(self):
+        frame = await self.frames.get()
+        if isinstance(frame, Exception):
+            raise frame
+        return frame
+
+    async def send(self, message):
+        frame = json.loads(message)
+        self.sent.append(frame)
+        if frame["op"] in {2, 6}:
+            self.account_id = UUID(frame["d"]["token"])
+            self.frames.put_nowait(
+                json.dumps(
+                    {
+                        "op": 0,
+                        "t": "READY" if frame["op"] == 2 else "RESUMED",
+                        "s": 17,
+                        "d": {
+                            "session_id": str(self.account_id),
+                            "resume_gateway_url": "wss://gateway.discord.gg/resume",
+                        },
+                    }
+                )
+            )
+        elif frame["op"] == 1:
+            self.frames.put_nowait('{"op":11}')
+
+    async def close(self, *, code, reason):
+        self.closed = True
+
+
+class Network:
+    def __init__(self):
+        self.transports = []
+
+    @asynccontextmanager
+    async def connect(self, uri, **kwargs):
+        assert uri.startswith("wss://gateway.discord.gg/")
+        transport = Transport()
+        self.transports.append(transport)
+        try:
+            yield transport
+        finally:
+            transport.closed = True
+
+
+@pytest_asyncio.fixture
+async def provider(engine, monkeypatch):
+    monkeypatch.setattr(settings, "db_pool_timeout", 0.1)
+    ordinary = _create_engine(pool_size=2, max_overflow=0)
+    accounts = [uuid4() for _ in range(4)]
+    async with async_sessionmaker(engine)() as db:
+        for account_id in accounts:
+            ciphertext, nonce = encrypt(str(account_id))
+            db.add(
+                ChannelAccount(
+                    id=account_id,
+                    provider="discord",
+                    name=f"resource-boundary-{account_id}",
+                    user_id=None,
+                    visibility="public",
+                    status="active",
+                    encrypted_provider_token=ciphertext,
+                    provider_token_nonce=nonce,
+                    webhook_secret_hash="test-only",
+                    config={"gateway_enabled": True},
+                )
+            )
+        await db.commit()
+    network = Network()
+    worker = gateway.DiscordGatewayWorker(
+        async_sessionmaker(ordinary, expire_on_commit=False),
+        scan_interval_seconds=0.02,
+        reconnect_initial_seconds=0.02,
+        reconnect_max_seconds=0.1,
+        lock_liveness_interval_seconds=0.02,
+        lock_liveness_timeout_seconds=0.2,
+        connect_factory=network.connect,
+    )
+    try:
+        yield ordinary, accounts, network, worker
+    finally:
+        await worker.stop()
+        async with async_sessionmaker(engine)() as db:
+            await db.execute(delete(ChannelAccount).where(ChannelAccount.id.in_(accounts)))
+            await db.commit()
+        await ordinary.dispose()
+
+
+async def lock_pid(engine, account_id):
+    key = gateway.discord_gateway_advisory_lock_key(account_id)
+    async with engine.connect() as db:
+        return await db.scalar(
+            text("""
+            SELECT pid FROM pg_locks WHERE locktype = 'advisory' AND granted
+              AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+              AND classid::bigint = :high AND objid::bigint = :low AND objsubid = 1
+        """),
+            {"high": key >> 32, "low": key & 0xFFFFFFFF},
+        )
+
+
+async def legacy_can_claim(engine, account_id):
+    # Exactly the released per-account key and SQL, on another PG session.
+    key = gateway.discord_gateway_advisory_lock_key(account_id)
+    async with engine.connect() as db:
+        acquired = await gateway.try_advisory_lock(db, key)
+        if acquired:
+            assert await gateway.release_advisory_lock(db, key)
+        return acquired
+
+
+async def archive(engine, account_id):
+    async with engine.begin() as db:
+        await db.execute(
+            update(ChannelAccount).where(ChannelAccount.id == account_id).values(status="inactive")
+        )
+
+
+async def connected(network, count=4):
+    await eventually(
+        lambda: (
+            len(network.transports) == count
+            and all(
+                any(frame == {"op": 1, "d": 17} for frame in transport.sent)
+                for transport in network.transports
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize("shutdown", ["stop", "event", "cancel"])
+async def test_more_accounts_than_pool_and_no_reentrant_scan_locks(provider, engine, shutdown):
+    ordinary, accounts, network, worker = provider
+    stop = asyncio.Event()
+    runner = None
+    try:
+        assert await worker.run_once(stop) == 4
+        await connected(network)
+        assert ordinary.pool.checkedout() == 1
+        pids = {await lock_pid(engine, account_id) for account_id in accounts}
+        assert len(pids) == 1 and None not in pids
+        async with ordinary.connect() as db:
+            assert await db.scalar(text("SELECT 1")) == 1
+        for _ in range(4):
+            assert await worker.run_once(stop) == 4
+        for account_id in accounts:
+            assert not await legacy_can_claim(engine, account_id)
+
+        await archive(engine, accounts[0])
+        await worker.run_once(stop)
+        removed = next(t for t in network.transports if t.account_id == accounts[0])
+        await eventually(lambda: removed.closed and worker._tasks[accounts[0]].done())
+        # A single release must suffice after repeated scans, while the same
+        # session still owns the other three keys (not a disconnect shortcut).
+        assert await legacy_can_claim(engine, accounts[0])
+        assert {await lock_pid(engine, account_id) for account_id in accounts[1:]} == pids
+        if shutdown == "stop":
+            await worker.stop()
+        else:
+            runner = asyncio.create_task(worker.run_forever(stop))
+            await asyncio.sleep(0.05)
+            if shutdown == "event":
+                stop.set()
+                await asyncio.wait_for(runner, 5)
+            else:
+                runner.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(runner, 5)
+        assert all(t.closed for t in network.transports)
+        for account_id in accounts:
+            assert await legacy_can_claim(engine, account_id)
+        async with ordinary.connect() as db:
+            assert await db.scalar(text("SELECT pg_backend_pid()")) not in pids
+    finally:
+        stop.set()
+        if runner is not None:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+
+async def test_lock_session_loss_stops_every_transport_and_reconnects_with_resume(provider, engine):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    old_transports = list(network.transports)
+    old_tasks = list(worker._tasks.values())
+    pid = await lock_pid(engine, accounts[0])
+    assert isinstance(pid, int)
+    async with engine.connect() as db:
+        # PID comes from this test's random key; never target a shared database.
+        assert await db.scalar(
+            text("""
+            SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+            WHERE pid = :pid AND datname = current_database() AND pid <> pg_backend_pid()
+        """),
+            {"pid": pid},
+        )
+    await eventually(
+        lambda: all(t.closed for t in old_transports) and all(t.done() for t in old_tasks)
+    )
+    for account_id in accounts:
+        assert await legacy_can_claim(engine, account_id)
+    assert await worker.run_once() == 4
+    await connected(network, 8)
+    for transport in network.transports[4:]:
+        authentication = next(frame for frame in transport.sent if frame["op"] in {2, 6})
+        assert authentication == {
+            "op": 6,
+            "d": {
+                "token": str(transport.account_id),
+                "session_id": str(transport.account_id),
+                "seq": 17,
+            },
+        }
+    replacement_pids = {await lock_pid(engine, account_id) for account_id in accounts}
+    assert (
+        len(replacement_pids) == 1 and None not in replacement_pids and pid not in replacement_pids
+    )
+
+
+async def test_real_scan_pool_timeout_recovers_without_cancelling_taskgroup(
+    provider,
+    engine,
+    monkeypatch,
+    caplog,
+):
+    ordinary, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    sibling_cancelled = asyncio.Event()
+
+    class Sibling:
+        async def run_forever(self, stop):
+            try:
+                await stop.wait()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+    async def no_listener():
+        pass
+
+    monkeypatch.setattr(channels, "build_channel_workers", lambda: (worker, Sibling()))
+    monkeypatch.setattr(channels, "start_postgres_listener", no_listener)
+    monkeypatch.setattr(channels, "stop_postgres_listener", no_listener)
+    stop = asyncio.Event()
+    runner = None
+    try:
+        async with ordinary.connect():
+            runner = asyncio.create_task(channels.run_channel_workers(stop))
+            await eventually(lambda: "discord gateway account scan failed" in caplog.text)
+            assert not runner.done() and not sibling_cancelled.is_set()
+            assert all(not t.closed for t in network.transports)
+            await archive(engine, accounts[0])
+        removed = next(t for t in network.transports if t.account_id == accounts[0])
+        await eventually(lambda: removed.closed)
+        assert not runner.done() and not sibling_cancelled.is_set()
+        stop.set()
+        await asyncio.wait_for(runner, 5)
+    finally:
+        stop.set()
+        if runner is not None:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+
+@pytest.mark.parametrize("fault", ["sql_error", "cancel"])
+async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
+    provider,
+    engine,
+    monkeypatch,
+    fault,
+):
+    ordinary, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    pid = await lock_pid(engine, accounts[0])
+    original_release = gateway.release_advisory_lock
+    releasing = asyncio.Event()
+
+    async def interrupted_release(connection, key):
+        if key == gateway.discord_gateway_advisory_lock_key(accounts[0]):
+            releasing.set()
+            if fault == "sql_error":
+                await connection.execute(text("SELECT 1 / 0"))
+            else:
+                await connection.execute(text("SELECT pg_sleep(10)"))
+        return await original_release(connection, key)
+
+    monkeypatch.setattr(gateway, "release_advisory_lock", interrupted_release)
+    await archive(engine, accounts[0])
+    await worker.run_once()
+    await asyncio.wait_for(releasing.wait(), 2)
+    if fault == "cancel":
+        worker._tasks[accounts[0]].cancel()
+    await eventually(
+        lambda: (
+            worker._lock_lost
+            and all(t.closed for t in network.transports)
+            and all(t.done() for t in worker._tasks.values())
+        )
+    )
+    await worker.stop()
+    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    for account_id in accounts:
+        assert await legacy_can_claim(engine, account_id)
+    async with ordinary.connect() as db:
+        assert await db.scalar(text("SELECT pg_backend_pid()")) != pid
+
+
+async def test_cancelled_claim_waiter_does_not_invalidate_sibling_ownership(provider, engine):
+    _, accounts, network, worker = provider
+    async with worker._lock_serial:
+        await worker.run_once()
+        task = worker._tasks[accounts[0]]
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not worker._lock_lost
+        assert all(not task.done() for key, task in worker._tasks.items() if key != accounts[0])
+    await worker.run_once()
+    await connected(network)
+    assert len({await lock_pid(engine, account_id) for account_id in accounts}) == 1
+
+
+async def test_ping_deadline_includes_serial_wait_and_stops_transports(provider):
+    _, _, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    async with worker._lock_serial:
+        await eventually(lambda: worker._lock_lost and all(t.closed for t in network.transports))
+    await worker.stop()
+
+
+async def test_repeated_stop_cancellation_finishes_session_cleanup(provider, engine, monkeypatch):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    started, release = asyncio.Event(), asyncio.Event()
+    original_close = worker._close_lock_session
+
+    async def delayed_close():
+        started.set()
+        await release.wait()
+        await original_close()
+
+    monkeypatch.setattr(worker, "_close_lock_session", delayed_close)
+    stopping = asyncio.create_task(worker.stop())
+    try:
+        await started.wait()
+        stopping.cancel()
+        await asyncio.sleep(0)
+        stopping.cancel()
+        await asyncio.sleep(0)
+        assert not stopping.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(stopping, 5)
+        assert all(t.closed for t in network.transports)
+        for account_id in accounts:
+            assert await legacy_can_claim(engine, account_id)
+    finally:
+        release.set()
+        await asyncio.gather(stopping, return_exceptions=True)
+
+
+async def test_terminal_close_survives_unlock_failure_and_session_recovery(provider, monkeypatch):
+    _, accounts, network, worker = provider
+    await worker.run_once()
+    await connected(network)
+    account_id = accounts[0]
+    original_release = gateway.release_advisory_lock
+
+    async def failed_unlock(connection, key):
+        if key == gateway.discord_gateway_advisory_lock_key(account_id):
+            await connection.execute(text("SELECT 1 / 0"))
+        return await original_release(connection, key)
+
+    monkeypatch.setattr(gateway, "release_advisory_lock", failed_unlock)
+    transport = next(t for t in network.transports if t.account_id == account_id)
+    transport.frames.put_nowait(
+        ConnectionClosedError(Close(4004, "test invalid token"), None, None)
+    )
+    await eventually(lambda: all(t.done() for t in worker._tasks.values()))
+    assert account_id in worker._terminal_account_revisions
+    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    await worker.run_once()
+    await connected(network, 7)
+    assert all(t.account_id != account_id for t in network.transports[4:])
+    assert all(t.closed for t in network.transports[:4])

--- a/backend/tests/test_discord_gateway_resource_boundary.py
+++ b/backend/tests/test_discord_gateway_resource_boundary.py
@@ -15,6 +15,7 @@ from websockets.frames import Close
 from app.core.config import settings
 from app.core.database import _create_engine
 from app.models.channel import ChannelAccount
+from app.services import discord_advisory_session as locks
 from app.services import discord_gateway_worker as gateway
 from app.services.vault_crypto import encrypt
 from app.workers import channels
@@ -312,8 +313,10 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
     await worker.run_once()
     await connected(network)
     pid = await lock_pid(engine, accounts[0])
-    original_release = gateway.release_advisory_lock
+    original_release = locks.release_advisory_lock
     releasing = asyncio.Event()
+    session = worker._locks._session
+    assert session is not None
 
     async def interrupted_release(connection, key):
         if key == gateway.discord_gateway_advisory_lock_key(accounts[0]):
@@ -324,7 +327,7 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
                 await connection.execute(text("SELECT pg_sleep(10)"))
         return await original_release(connection, key)
 
-    monkeypatch.setattr(gateway, "release_advisory_lock", interrupted_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", interrupted_release)
     await archive(engine, accounts[0])
     await worker.run_once()
     await asyncio.wait_for(releasing.wait(), 2)
@@ -332,13 +335,13 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
         worker._tasks[accounts[0]].cancel()
     await eventually(
         lambda: (
-            worker._lock_lost
+            session.failure is not None
             and all(t.closed for t in network.transports)
             and all(t.done() for t in worker._tasks.values())
         )
     )
     await worker.stop()
-    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", original_release)
     for account_id in accounts:
         assert await legacy_can_claim(engine, account_id)
     async with ordinary.connect() as db:
@@ -347,14 +350,14 @@ async def test_uncertain_unlock_fences_siblings_and_never_pools_session(
 
 async def test_cancelled_claim_waiter_does_not_invalidate_sibling_ownership(provider, engine):
     _, accounts, network, worker = provider
-    async with worker._lock_serial:
+    async with worker._locks._serial:
         await worker.run_once()
         task = worker._tasks[accounts[0]]
         await asyncio.sleep(0)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        assert not worker._lock_lost
+        assert not worker._locks.failed
         assert all(not task.done() for key, task in worker._tasks.items() if key != accounts[0])
     await worker.run_once()
     await connected(network)
@@ -365,8 +368,8 @@ async def test_ping_deadline_includes_serial_wait_and_stops_transports(provider)
     _, _, network, worker = provider
     await worker.run_once()
     await connected(network)
-    async with worker._lock_serial:
-        await eventually(lambda: worker._lock_lost and all(t.closed for t in network.transports))
+    async with worker._locks._serial:
+        await eventually(lambda: worker._locks.failed and all(t.closed for t in network.transports))
     await worker.stop()
 
 
@@ -407,21 +410,21 @@ async def test_terminal_close_survives_unlock_failure_and_session_recovery(provi
     await worker.run_once()
     await connected(network)
     account_id = accounts[0]
-    original_release = gateway.release_advisory_lock
+    original_release = locks.release_advisory_lock
 
     async def failed_unlock(connection, key):
         if key == gateway.discord_gateway_advisory_lock_key(account_id):
             await connection.execute(text("SELECT 1 / 0"))
         return await original_release(connection, key)
 
-    monkeypatch.setattr(gateway, "release_advisory_lock", failed_unlock)
+    monkeypatch.setattr(locks, "release_advisory_lock", failed_unlock)
     transport = next(t for t in network.transports if t.account_id == account_id)
     transport.frames.put_nowait(
         ConnectionClosedError(Close(4004, "test invalid token"), None, None)
     )
     await eventually(lambda: all(t.done() for t in worker._tasks.values()))
     assert account_id in worker._terminal_account_revisions
-    monkeypatch.setattr(gateway, "release_advisory_lock", original_release)
+    monkeypatch.setattr(locks, "release_advisory_lock", original_release)
     await worker.run_once()
     await connected(network, 7)
     assert all(t.account_id != account_id for t in network.transports[4:])

--- a/backend/tests/test_discord_gateway_websockets.py
+++ b/backend/tests/test_discord_gateway_websockets.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlsplit
 from uuid import UUID, uuid4
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from websockets.asyncio.server import ServerConnection, serve
@@ -14,6 +15,7 @@ from websockets.exceptions import ConnectionClosedError
 
 import app.services.discord_gateway_worker as discord_gateway_worker_module
 from app.routes.channel_routers import discord as discord_router
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.discord_gateway_worker import (
     DiscordGatewayWorker,
     GatewayFrame,
@@ -22,6 +24,17 @@ from app.services.discord_gateway_worker import (
     discord_gateway_uri,
     parse_gateway_frame,
 )
+
+
+@pytest_asyncio.fixture
+async def consumer_locks(engine, request):
+    locks = DiscordAdvisorySession(
+        engine, liveness_interval_seconds=getattr(request, "param", 60.0)
+    )
+    try:
+        yield locks
+    finally:
+        await locks.close()
 
 
 @dataclass
@@ -78,6 +91,7 @@ async def _legacy_consumer_lease_lock_key(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_transaction(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000910")
     link_id = UUID("00000000-0000-4000-8000-000000000911")
@@ -86,8 +100,7 @@ async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_tra
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as acquired:
         assert acquired is True
         backend_pid = await _consumer_lease_backend_pid(engine, legacy_lock_key)
@@ -106,6 +119,7 @@ async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_tra
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000912")
     link_id = UUID("00000000-0000-4000-8000-000000000913")
@@ -113,14 +127,12 @@ async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as first_acquired:
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=60,
+            lock_session=consumer_locks,
         ) as second_acquired:
             assert first_acquired is True
             assert second_acquired is False
@@ -129,6 +141,7 @@ async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000914")
     link_id = UUID("00000000-0000-4000-8000-000000000915")
@@ -136,16 +149,14 @@ async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as acquired:
         assert acquired is True
 
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as reacquired:
         assert reacquired is True
 
@@ -153,6 +164,7 @@ async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
 @pytest.mark.asyncio
 async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000916")
     link_id = UUID("00000000-0000-4000-8000-000000000917")
@@ -162,8 +174,7 @@ async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=60,
+            lock_session=consumer_locks,
         ) as acquired:
             assert acquired is True
             entered.set()
@@ -178,15 +189,16 @@ async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
     async with discord_router._discord_gateway_consumer_lease(
         account_id=account_id,
         bot_agent_link_id=link_id,
-        lock_engine=engine,
-        liveness_interval_seconds=60,
+        lock_session=consumer_locks,
     ) as reacquired:
         assert reacquired is True
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("consumer_locks", [0.01], indirect=True)
 async def test_synthetic_gateway_consumer_stops_when_lease_connection_is_lost(
     engine: AsyncEngine,
+    consumer_locks: DiscordAdvisorySession,
 ) -> None:
     account_id = UUID("00000000-0000-4000-8000-000000000918")
     link_id = UUID("00000000-0000-4000-8000-000000000919")
@@ -197,8 +209,7 @@ async def test_synthetic_gateway_consumer_stops_when_lease_connection_is_lost(
         async with discord_router._discord_gateway_consumer_lease(
             account_id=account_id,
             bot_agent_link_id=link_id,
-            lock_engine=engine,
-            liveness_interval_seconds=0.01,
+            lock_session=consumer_locks,
         ) as acquired:
             assert acquired is True
             entered.set()

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -41,6 +41,7 @@ from app.routes import admin as admin_route
 from app.routes import sync as sync_route
 from app.routes.channel_routers.discord import _discord_gateway_consumer_lease
 from app.services import platform_workload_auth, runtime_source_authority
+from app.services.discord_advisory_session import DiscordAdvisorySession
 from app.services.platform_workload_auth import (
     PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
     PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
@@ -276,6 +277,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
     """Real pool contention must not strand token issuance or deployment recovery."""
     monkeypatch.setattr(settings, "db_pool_timeout", 1.0)
     ordinary = database._create_engine(pool_size=2, max_overflow=0)
+    gateway_locks = DiscordAdvisorySession(ordinary)
     control = database._create_engine(pool_size=database.CONTROL_POOL_SIZE, max_overflow=0)
     snapshot = database._create_engine(pool_size=1, max_overflow=0)
     ordinary_sessions = async_sessionmaker(
@@ -318,7 +320,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
         # A gateway lease and a channel transaction awaiting provider I/O consume
         # both ordinary slots. Only the external provider call is stubbed.
         async with _discord_gateway_consumer_lease(
-            account_id=uuid.uuid4(), bot_agent_link_id=uuid.uuid4(), lock_engine=ordinary
+            account_id=uuid.uuid4(), bot_agent_link_id=uuid.uuid4(), lock_session=gateway_locks
         ) as acquired:
             assert acquired
             pressure = asyncio.create_task(
@@ -380,6 +382,7 @@ async def test_deployment_control_survives_slow_admin_and_gateway_pressure(
                 await asyncio.gather(pressure, return_exceptions=True)
         assert (await client.get("/ready")).status_code == 200
     finally:
+        await gateway_locks.close()
         await ordinary.dispose()
         await control.dispose()
         await snapshot.dispose()

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -137,3 +137,138 @@ async def test_request_timing_does_not_warn_for_successful_long_request(
     )
 
     assert caplog.text == ""
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_event", "expected_stages"),
+    [
+        ("slow", "request_slow", (11, 23, 37)),
+        ("fast", None, (11, 23, 37)),
+        ("auth_error", "request_error", (11, None, None)),
+        ("validation_failure", "request_failed", (11, 23, None)),
+        ("provider_error", "request_error", (11, 23, 37)),
+        ("cancel", None, (11, 23, 37)),
+    ],
+)
+async def test_telegram_route_stage_timings(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    outcome: str,
+    expected_event: str | None,
+    expected_stages: tuple[int | None, ...],
+):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    import httpx
+    from fastapi import FastAPI, HTTPException
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.core.database import get_session
+    from app.middleware import request_timing
+    from app.routes.channel_routers import telegram
+
+    elapsed = 0.0
+    monkeypatch.setattr(request_timing.time, "perf_counter", lambda: elapsed)
+    db = AsyncMock(spec=AsyncSession)
+    account = SimpleNamespace(
+        id=uuid4(), encrypted_provider_token="encrypted", provider_token_nonce="nonce"
+    )
+
+    async def resolve(*_args, **_kwargs):
+        nonlocal elapsed
+        elapsed += 0.011
+        if outcome == "auth_error":
+            raise HTTPException(500, "test auth failure")
+        return SimpleNamespace(account=account, link=SimpleNamespace(id=uuid4())), "token"
+
+    async def validate(_url):
+        nonlocal elapsed
+        elapsed += 0.023
+        if outcome == "validation_failure":
+            raise RuntimeError("test validation failure")
+
+    async def provider(request: httpx.Request) -> httpx.Response:
+        nonlocal elapsed
+        db.rollback.assert_awaited_once()
+        elapsed += 0.037
+        if outcome == "provider_error":
+            raise httpx.ConnectError("test connection failure")
+        if outcome == "cancel":
+            raise asyncio.CancelledError
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    monkeypatch.setattr(telegram, "_resolve_telegram_agent", resolve)
+    monkeypatch.setattr(telegram, "_validate_telegram_provider_base_url", validate)
+    monkeypatch.setattr(telegram, "decrypt_provider_token", lambda _account: "provider-secret")
+    app = FastAPI()
+    app.include_router(telegram.router, prefix="/v1")
+    app.dependency_overrides[get_session] = lambda: db
+    scope = _scope(path="/v1/channels/telegram/botrouting-secret/getMe")
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(provider)) as upstream:
+        monkeypatch.setattr(telegram, "get_channel_provider_http_client", lambda: upstream)
+        timed = RequestTimingMiddleware(app, slow_ms=100 if outcome == "fast" else 50)
+        if outcome == "validation_failure":
+            with pytest.raises(RuntimeError, match="test validation failure"):
+                await _collect(timed, scope)
+        elif outcome == "cancel":
+            with pytest.raises(asyncio.CancelledError):
+                await _collect(timed, scope)
+        else:
+            messages = await _collect(timed, scope)
+            assert messages[0]["status"] == (
+                500 if outcome == "auth_error" else 502 if outcome == "provider_error" else 200
+            )
+
+    stages = ("channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms")
+    timings = scope["state"]["_channel_stage_timings"]
+    assert timings == pytest.approx(
+        {stage: value for stage, value in zip(stages, expected_stages) if value is not None}
+    )
+    records = [r.getMessage() for r in caplog.records if r.name == request_timing.__name__]
+    if expected_event is None:
+        assert records == []
+    else:
+        assert len(records) == 1
+        assert records[0].startswith(expected_event + " ")
+        for stage, value in zip(stages, expected_stages):
+            if value is None:
+                assert stage not in records[0]
+            else:
+                assert f"{stage}={value:.1f}" in records[0]
+        assert "bot[redacted]/getMe" in records[0]
+    assert "routing-secret" not in caplog.text
+    assert "provider-secret" not in caplog.text
+    assert "secret=value" not in caplog.text
+
+
+async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
+    from app.middleware.request_timing import _CHANNEL_TIMING_STATE
+
+    inherited = {"channel_auth_ms": 999.0}
+    scope = _scope()
+    scope["state"][_CHANNEL_TIMING_STATE] = inherited
+
+    async def inner(scope: Scope, _receive: Receive, send: Send) -> None:
+        timings = scope["state"][_CHANNEL_TIMING_STATE]
+        assert timings == {}
+        assert timings is not inherited
+        timings.update(
+            channel_auth_ms=float("nan"),
+            channel_url_validation_ms=float("inf"),
+            channel_provider_ms="secret",
+            unknown="secret",
+        )
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    await _collect(RequestTimingMiddleware(inner, slow_ms=750), scope)
+    assert "request_error" in caplog.text
+    assert "channel_" not in caplog.text
+    assert "unknown" not in caplog.text
+    assert "secret" not in caplog.text
+    assert inherited == {"channel_auth_ms": 999.0}

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -84,8 +84,8 @@ async def test_request_timing_logs_errors_without_query_string(caplog: pytest.Lo
     ("path", "expected_path"),
     [
         (
-            "/v1/channels/telegram/bot123456:secret/getUpdates",
-            "/v1/channels/telegram/bot[redacted]/getUpdates",
+            "/v1/channels/telegram/bot123456:secret/getMe",
+            "/v1/channels/telegram/bot[redacted]/getMe",
         ),
         (
             "/api/channels/telegram/bot/123456:secret/sendMessage",
@@ -95,19 +95,59 @@ async def test_request_timing_logs_errors_without_query_string(caplog: pytest.Lo
             "/v1/channels/telegram/file/bot123456:secret/documents/file.txt",
             "/v1/channels/telegram/file/bot[redacted]/documents/file.txt",
         ),
+        (
+            "/v1/channels/discord/v10/interactions/123/123456:secret/callback",
+            "/v1/channels/discord/v10/interactions/123/[redacted]/callback",
+        ),
+        (
+            "/api/channels/discord/api/v10/webhooks/123/123456:secret/messages/@original",
+            "/api/channels/discord/api/v10/webhooks/123/[redacted]/messages/@original",
+        ),
+        (
+            "/v1/channels/discord/api/v10/webhooks/123/123456:secret",
+            "/v1/channels/discord/api/v10/webhooks/123/[redacted]",
+        ),
+        (
+            "/api/channels/discord/v10/interactions/123/123456:secret/callback",
+            "/api/channels/discord/v10/interactions/123/[redacted]/callback",
+        ),
+        (
+            "/v1/channels/discord/gateway/123456:secret",
+            "/v1/channels/discord/gateway/[redacted]",
+        ),
+        (
+            "/v1/channels/discord/v10/channels/123/messages",
+            "/v1/channels/discord/v10/channels/123/messages",
+        ),
     ],
 )
-async def test_request_timing_redacts_telegram_routing_credentials(
+@pytest.mark.parametrize("outcome", ["slow", "error", "exception"])
+async def test_request_timing_redacts_channel_routing_credentials(
     caplog: pytest.LogCaptureFixture,
     path: str,
     expected_path: str,
+    outcome: str,
 ):
     async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 500, "headers": []})
+        assert _scope["path"] == path
+        if outcome == "exception":
+            raise RuntimeError("synthetic failure")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200 if outcome == "slow" else 500,
+                "headers": [],
+            }
+        )
         await send({"type": "http.response.body", "body": b"error"})
 
     caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
-    await _collect(RequestTimingMiddleware(inner, slow_ms=750), _scope(path=path))
+    app = RequestTimingMiddleware(inner, slow_ms=0.000_001)
+    if outcome == "exception":
+        with pytest.raises(RuntimeError, match="synthetic failure"):
+            await _collect(app, _scope(path=path))
+    else:
+        await _collect(app, _scope(path=path))
 
     assert f"path={expected_path}" in caplog.text
     assert "123456:secret" not in caplog.text

--- a/backend/tests/test_telegram_update_wait.py
+++ b/backend/tests/test_telegram_update_wait.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.config import settings
+from app.models.channel import ChannelBinding, ChannelMessage
+from app.services import channels
+from app.services.channel_wakeups import (
+    ChannelInboxPage,
+    ChannelWakeup,
+    wait_for_channel_inbound_messages,
+)
+from tests.test_channel_inbox import _add_message, _create_account_and_binding
+from tests.test_channels import (
+    _create_paired_telegram_channel,
+    _telegram_agent_headers,
+    _telegram_bot_path,
+)
+
+pytestmark = pytest.mark.committed_db
+
+
+@pytest.mark.parametrize("limit", [1, 100])
+@pytest.mark.parametrize("discard", ["filter", "offset"])
+async def test_get_updates_reaches_ready_message_behind_discarded_page(
+    client, db_session, channel_agent, monkeypatch, limit, discard
+):
+    monkeypatch.setattr(settings, "channel_long_poll_interval_seconds", 5.0)
+    monkeypatch.setattr(settings, "channel_long_poll_max_seconds", 30.0)
+    # All rows predate the request. No later notification should be needed to
+    # reach a ready row behind the first page of filtered/acknowledged updates.
+    wakeup = ChannelWakeup()
+    monkeypatch.setattr(channels, "channel_inbound_messages_enqueued", wakeup)
+    created = await _create_paired_telegram_channel(
+        client, name="filtered-page-latency", provider_token=None, agent_id=channel_agent.id
+    )
+    binding = await db_session.scalar(
+        select(ChannelBinding).where(ChannelBinding.account_id == UUID(created["id"]))
+    )
+    assert binding is not None
+    dropped = 4 * limit + 1
+    for index in range(dropped + 1):
+        ready = index == dropped
+        kind = "message" if ready or discard == "offset" else "edited_message"
+        db_session.add(
+            ChannelMessage(
+                account_id=binding.account_id,
+                bot_agent_link_id=binding.bot_agent_link_id,
+                binding_id=binding.id,
+                user_id=binding.user_id,
+                direction="inbound",
+                external_chat_id=binding.external_chat_id,
+                text="ready" if ready else "discard",
+                payload={
+                    "update_id": 1000 + index,
+                    kind: {"message_id": index, "chat": {"id": 42, "type": "private"}},
+                },
+            )
+        )
+        # Keep the provider update order explicit; bulk RETURNING may reorder inserts.
+        await db_session.flush()
+    await db_session.commit()
+    started = time.perf_counter()
+    response = await client.post(
+        _telegram_bot_path(created, "getUpdates"),
+        headers=_telegram_agent_headers(created),
+        json={
+            "limit": limit,
+            "timeout": 10,
+            "offset": 1000 + dropped if discard == "offset" else None,
+            "allowed_updates": ["message"],
+        },
+    )
+    elapsed = time.perf_counter() - started
+    assert response.status_code == 200, response.text
+    assert [item["update_id"] for item in response.json()["result"]] == [1000 + dropped]
+    print(f"telegram_page_latency discard={discard} limit={limit} seconds={elapsed:.6f}")
+    assert not wakeup._waiters
+    # Leave ample room for DB work while detecting the old unconditional 5s wait.
+    assert elapsed < 2.5
+
+
+@pytest.mark.parametrize("timeout", [0, 0.02])
+async def test_channel_inbound_progress_obeys_wait_budget(timeout):
+    calls = 0
+    source = ChannelWakeup()
+
+    async def fetch():
+        nonlocal calls
+        calls += 1
+        return ChannelInboxPage([], progressed=True)
+
+    result = await asyncio.wait_for(
+        wait_for_channel_inbound_messages(
+            fetch, account_id="budget", timeout_seconds=timeout, wakeup=source
+        ),
+        1,
+    )
+    assert result == []
+    if timeout == 0:
+        assert calls == 1
+    else:
+        assert calls > 1
+    assert not source._waiters
+
+
+async def test_channel_inbound_progress_yields_for_cancellation():
+    fetched = asyncio.Event()
+    source = ChannelWakeup()
+
+    async def fetch():
+        fetched.set()
+        return ChannelInboxPage([], progressed=True)
+
+    pending = asyncio.create_task(
+        wait_for_channel_inbound_messages(
+            fetch, account_id="cancel", timeout_seconds=30, wakeup=source
+        )
+    )
+    try:
+        await asyncio.wait_for(fetched.wait(), 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(pending, 1)
+        assert not source._waiters
+    finally:
+        pending.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+
+
+async def test_telegram_page_progress_commits_and_releases_binding_lock(
+    db_session, engine, seed_user, channel_agent, monkeypatch
+):
+    account, binding = await _create_account_and_binding(
+        db_session, user=seed_user, agent=channel_agent, provider="telegram", chat_id="progress"
+    )
+    account_id, binding_id = account.id, binding.id
+    for index in range(6):
+        await _add_message(
+            db_session,
+            account=account,
+            binding=binding,
+            text="page",
+            payload={"update_id": index, "message" if index == 5 else "edited_message": {}},
+        )
+    await db_session.commit()
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    original = channels.dequeue_telegram_updates
+    calls = 0
+
+    async def observe(db, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            async with sessions() as observer:
+                await observer.execute(
+                    select(ChannelBinding.id)
+                    .where(ChannelBinding.id == binding_id)
+                    .with_for_update(nowait=True)
+                )
+                consumed = await observer.scalar(
+                    select(func.count(ChannelMessage.id)).where(
+                        ChannelMessage.binding_id == binding_id,
+                        ChannelMessage.delivered_at.is_not(None),
+                    )
+                )
+                assert consumed == 4
+        return await original(db, **kwargs)
+
+    monkeypatch.setattr(channels, "dequeue_telegram_updates", observe)
+    updates = await channels.wait_for_telegram_updates(
+        sessions,
+        account_id=account_id,
+        offset=None,
+        limit=1,
+        allowed_updates={"message"},
+        timeout_seconds=1,
+    )
+    assert [update["update_id"] for update in updates] == [5]
+    assert calls == 2

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -95,6 +95,12 @@ Claim, unlock, and liveness SQL share a serial gate. Discovery does not claim
 keys already held by account tasks. Ordinary account/dispatch queries continue
 to use the ordinary pool.
 
+Agent-facing Gateway delivery subscribes to the existing account-scoped inbound
+commit notification. The socket reader survives notifications and fallback
+timeouts so heartbeat frames are not discarded. The polling interval remains
+a notification-loss fallback. Another Link's notification may cause one empty
+filtered query; it does not grant that Link's message authority.
+
 The default liveness interval is one second, with a five-second probe deadline
 including serial-gate waiting. Lock SQL also has a five-second deadline. These
 are application cancellation deadlines, not guarantees about TCP blackhole or

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -445,6 +445,11 @@ must retain its ordinary connection for the consumer lifetime; releasing it woul
 duplicate consumers. Delivery transactions that fence authority across sends
 also retain their locks deliberately.
 
+Telegram long polls immediately fetch another page after consuming acknowledged
+or filtered updates. Each page commits before the next scan, releasing its
+Binding locks. The request deadline bounds repeated scans, and cancellation
+remains observable between pages. A zero-timeout request still scans one page.
+
 All three runtime engines use the asyncpg dialect in
 `backend/app/core/asyncpg_dialect.py`. It shields only driver termination from
 [AnyIO level cancellation](https://github.com/agronholm/anyio/blob/4.14.2/docs/cancellation.rst).

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -81,29 +81,43 @@ uv run ruff format --check .
 uv run python -m compileall app scripts tests alembic
 ```
 
-## Discord provider Gateway ownership
+## Discord Gateway ownership
 
-Each `DiscordGatewayWorker` holds one PostgreSQL connection for its account
-advisory locks. Account tasks claim the existing per-account key once per
-transport attempt and release it after the transport closes; discovery scans
-do not reacquire held keys. Lock SQL and liveness probes share a serial gate.
-Ordinary account/dispatch queries continue to use the ordinary pool.
+[`DiscordAdvisorySession`](../backend/app/services/discord_advisory_session.py)
+shares one PostgreSQL connection across a role's Gateway locks. The provider
+worker owns one instance; ASGI lifespan owns the agent-facing consumer instance
+in application state. Tests inject an explicit shared instance. There is no
+engine-keyed global cache or per-lease connection. Existing provider account
+keys and consumer Account/Link keys remain unchanged. A local ownership table
+rejects duplicate keys before PostgreSQL's reentrant lock can admit them.
+
+Claim, unlock, and liveness SQL share a serial gate. Discovery does not claim
+keys already held by account tasks. Ordinary account/dispatch queries continue
+to use the ordinary pool.
 
 The default liveness interval is one second, with a five-second probe deadline
 including serial-gate waiting. Lock SQL also has a five-second deadline. These
 are application cancellation deadlines, not guarantees about TCP blackhole or
 driver/transport cleanup latency. A failed or uncertain lock operation fences
-the shared session and cancels its Gateway tasks. The worker joins those tasks
-before invalidating the connection; it never returns that ownership session
-to the pool on shutdown or recovery. Recovery acquires fresh locks and keeps
-the existing Gateway resume state and last durably admitted sequence.
+the session and cancels its owners. One observed retirement task joins owners
+and invalidates the connection without waiting for another request or scan.
+The account whose unlock failed exits through its original transport exception;
+failure retirement does not cancel it again. Normal shutdown cancels owners,
+joins them outside the SQL gate, then invalidates the connection. Cleanup uses
+`finish_cleanup`, including repeated cancellation. Closing or recovering one's
+own active lease is rejected before entering cleanup; lifespan and worker
+supervisors own those operations.
+
+Recovery obtains new locks without carrying ownership across sessions. Provider
+resume state, consumer LeaseLost/4008 behavior, and durable sequence acknowledgements
+remain at their existing protocol boundaries.
 
 Account discovery errors retry with bounded backoff without ending the channel
 worker TaskGroup. Account terminal close codes still require a credential or
 configuration revision before retrying.
 
-Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py`
-starts its own disposable PostgreSQL and reports passing ownership tests.
+Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py tests/test_discord_consumer_resource_boundary.py`
+starts disposable PostgreSQL and reports passing ownership tests.
 
 ## Python type governance
 

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -81,6 +81,30 @@ uv run ruff format --check .
 uv run python -m compileall app scripts tests alembic
 ```
 
+## Discord provider Gateway ownership
+
+Each `DiscordGatewayWorker` holds one PostgreSQL connection for its account
+advisory locks. Account tasks claim the existing per-account key once per
+transport attempt and release it after the transport closes; discovery scans
+do not reacquire held keys. Lock SQL and liveness probes share a serial gate.
+Ordinary account/dispatch queries continue to use the ordinary pool.
+
+The default liveness interval is one second, with a five-second probe deadline
+including serial-gate waiting. Lock SQL also has a five-second deadline. These
+are application cancellation deadlines, not guarantees about TCP blackhole or
+driver/transport cleanup latency. A failed or uncertain lock operation fences
+the shared session and cancels its Gateway tasks. The worker joins those tasks
+before invalidating the connection; it never returns that ownership session
+to the pool on shutdown or recovery. Recovery acquires fresh locks and keeps
+the existing Gateway resume state and last durably admitted sequence.
+
+Account discovery errors retry with bounded backoff without ending the channel
+worker TaskGroup. Account terminal close codes still require a credential or
+configuration revision before retrying.
+
+Done: `scripts/test.sh backend tests/test_discord_gateway_resource_boundary.py`
+starts its own disposable PostgreSQL and reports passing ownership tests.
+
 ## Python type governance
 
 BasedPyright runs from the uv development environment. The owned gate covers

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -505,9 +505,18 @@ Required behavior:
   `.local`/`.localhost` names, private DNS results, and unresolved DNS names
   are rejected.
 - Telegram webhook delivery only acknowledges messages after a successful
-  `2xx` or `3xx` response. Telegram makes one inline delivery attempt and
+  `2xx` response. Telegram makes one inline delivery attempt and
   leaves `5xx`, network, `4xx`, and DNS failures pending for
-  `ChannelWebhookDeliveryWorker` retry or TTL drop.
+  `ChannelWebhookDeliveryWorker` retry or TTL drop. Fallback failures defer only
+  their Binding using persisted retry steps (1, 2, 4, 8, 16, 32, then 60 seconds).
+  Other due Bindings remain eligible after the failed HTTP attempt returns;
+  delivery remains serial, so an in-flight request can still delay them.
+  Success, TTL/authority consumption, retirement, and reactivation clear retry
+  state. Inline ingress still attempts
+  delivery separately; this does not guarantee ordering across both paths.
+  `setWebhook`/`deleteWebhook` do not reset Binding cooldowns: a replacement URL
+  may inherit up to 60 seconds of the previous cooldown, plus the worker's
+  polling interval. Configuration updates do not wait for Binding delivery locks.
 
 ## Message Routing Model
 


### PR DESCRIPTION
Discord agent connections waited for the next polling tick after messages were committed. Telegram long polls could also wait another five seconds after consuming an entire page of acknowledged or filtered updates, even with a deliverable update behind it. Wake Discord consumers through existing PostgreSQL notifications and report Telegram page progress so the next committed page is read immediately within the request budget.

Matched isolated PG/ASGI/TCP measurements: Discord commit-to-receive p50/p95 fell from 523/974 ms to 24/40 ms in the cumulative candidate; Telegram filtered/offset page cases fell from about 5.1 seconds to 36–148 ms. These measure Clawdi's internal delivery path, excluding public-provider latency and agent inference. Polling remains a notification-loss fallback, and other Links on the same Account can cause one additional empty query per consumed notification.

This cumulative release also includes the reviewed changes in #1449, #1450, #1453, #1454 and #1455: request-local stage timings, per-Binding webhook retry backoff, request-path credential redaction, Discord interaction/profile isolation, and one monitored advisory-lock session per Gateway role. It preserves existing lock keys, authorization fences, receipt/Resume semantics and bounded cleanup. Failed ownership sessions retire without requiring a new request.

Migration `a6d9c2e4f7b1` adds nullable webhook retry time and a default-zero retry step to Binding, with a nonnegative constraint and reversible downgrade. No CLI package version, database pool size, accessory configuration or public API schema changes are intended.

Validation at head `8b2553bc28ba1aa81c382f3d9c275764188bce73`: complete cumulative backend CI passed 2,860 tests (12 skips, one expected failure); changed-production typing, Ruff, governance and generated-client checks passed. JS check, all five package typechecks and 2,973 JS tests passed (four default artifact-dependent skips). Subsequent non-backend changes are limited to two reviewed human Markdown files; JS program, test, tool and lockfile inputs are unchanged. Tests used isolated environments with pinned tooling. Root and Fable reviewed the runtime changes, including the resolved import overlaps. The release intends one backend rollout and no CLI publication.
