### PR TITLE
perf(channels): reuse provider connections across short idle gaps

### DIFF
--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -100,7 +100,13 @@ def get_channel_provider_http_client() -> httpx.AsyncClient:
     """Return the process-wide client for Telegram and Discord APIs."""
     global _channel_provider_http_client
     if _channel_provider_http_client is None:
-        _channel_provider_http_client = httpx.AsyncClient(timeout=30.0)
+        # Explicit Limits must retain httpx's client caps; bare Limits is unbounded.
+        _channel_provider_http_client = httpx.AsyncClient(
+            timeout=30.0,
+            limits=httpx.Limits(
+                max_connections=100, max_keepalive_connections=20, keepalive_expiry=30.0
+            ),
+        )
     return _channel_provider_http_client
 
 

--- a/backend/tests/test_channel_provider_http.py
+++ b/backend/tests/test_channel_provider_http.py
@@ -12,7 +12,7 @@ async def test_channel_provider_http_client_is_reused_and_closed(monkeypatch):
     clients: list[Any] = []
 
     class FakeClient:
-        def __init__(self, *, timeout: float):
+        def __init__(self, *, timeout: float, limits):
             self.timeout = timeout
             self.closed = False
             clients.append(self)

--- a/backend/tests/test_channel_provider_keepalive.py
+++ b/backend/tests/test_channel_provider_keepalive.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ssl
+from types import SimpleNamespace
+
+import httpcore._async.http11 as http11
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.services import channels
+from tests.test_safe_public_http import _write_local_tls_certificate
+
+
+@pytest_asyncio.fixture
+async def tls_provider(tmp_path, monkeypatch):
+    certificate, key = _write_local_tls_certificate(tmp_path, "localhost")
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certificate, key)
+    monkeypatch.setenv("SSL_CERT_FILE", str(certificate))
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"):
+        monkeypatch.delenv(name, raising=False)
+    await channels.close_channel_provider_http_client()
+    original_client = httpx.AsyncClient
+
+    def bounded_client(**kwargs):
+        limits = kwargs.get("limits")
+        if limits is not None:
+            # Guard the opt-in Limits constructor's otherwise-unbounded defaults.
+            assert limits.max_connections == 100
+            assert limits.max_keepalive_connections == 20
+        return original_client(**kwargs)
+
+    monkeypatch.setattr(channels.httpx, "AsyncClient", bounded_client)
+    state = SimpleNamespace(connections=0, requests=0, mode="keep")
+    close_peer, peer_closed = asyncio.Event(), asyncio.Event()
+    tasks = set()
+
+    async def handle(reader, writer):
+        task = asyncio.current_task()
+        tasks.add(task)
+        state.connections += 1
+        try:
+            while True:
+                headers = await reader.readuntil(b"\r\n\r\n")
+                length = 0
+                for line in headers.split(b"\r\n"):
+                    if line.lower().startswith(b"content-length:"):
+                        length = int(line.split(b":", 1)[1])
+                if length:
+                    await reader.readexactly(length)
+                state.requests += 1
+                if state.mode == "stall":
+                    await asyncio.Event().wait()
+                writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                await writer.drain()
+                if state.mode == "close":
+                    await close_peer.wait()
+                    return
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+            with contextlib.suppress(ConnectionError, TimeoutError):
+                await writer.wait_closed()
+            peer_closed.set()
+            tasks.discard(task)
+
+    server = await asyncio.start_server(
+        handle, "127.0.0.1", 0, ssl=context, ssl_shutdown_timeout=0.1
+    )
+    address = server.sockets[0].getsockname()
+    try:
+        yield (
+            channels.get_channel_provider_http_client(),
+            f"https://localhost:{address[1]}/",
+            state,
+            close_peer,
+            peer_closed,
+        )
+    finally:
+        await channels.close_channel_provider_http_client()
+        server.close()
+        await server.wait_closed()
+        remaining = list(tasks)
+        for task in remaining:
+            task.cancel()
+        await asyncio.gather(*remaining, return_exceptions=True)
+
+
+async def test_provider_tls_connection_survives_short_idle_gap_but_expires(
+    tls_provider, monkeypatch
+):
+    client, url, state, _, _ = tls_provider
+    clock = [100.0]
+    # Change only httpcore's expiry clock, not asyncio's timeout/scheduling clock.
+    monkeypatch.setattr(http11, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+    assert (await client.get(url)).status_code == 200
+    clock[0] += 6
+    assert (await client.get(url)).status_code == 200
+    assert state.connections == 1
+    clock[0] += 31
+    assert (await client.get(url)).status_code == 200
+    assert state.connections == 2
+    assert state.requests == 3
+
+
+async def test_provider_reconnects_when_server_closes_idle_tls(tls_provider):
+    client, url, state, close_peer, peer_closed = tls_provider
+    state.mode = "close"
+    assert (await client.get(url)).status_code == 200
+    close_peer.set()
+    await asyncio.wait_for(peer_closed.wait(), 1)
+    state.mode = "keep"
+    assert (await client.get(url)).status_code == 200
+    assert state.connections == 2
+
+
+async def test_provider_does_not_retry_a_timed_out_mutation(tls_provider):
+    client, url, state, _, _ = tls_provider
+    state.mode = "stall"
+    with pytest.raises(httpx.ReadTimeout):
+        await client.post(url, json={"message": "test"}, timeout=0.1)
+    assert state.connections == 1
+    assert state.requests == 1

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -679,7 +679,7 @@ class _FakeProviderClient:
     response_content: bytes | None = None
     response_headers: dict[str, str] | None = None
 
-    def __init__(self, *, timeout):
+    def __init__(self, *, timeout, limits=None):
         self.timeout = timeout
 
     async def __aenter__(self):


### PR DESCRIPTION
Telegram and Discord API requests currently discard idle HTTP connections after five seconds. Retain them for 30 seconds so requests after short idle gaps can reuse TCP/TLS connections, while explicitly preserving the existing 100 total / 20 idle connection limits.

A read-only Telegram getMe probe from the web network namespace measured 415–425 ms after 6/12/20-second gaps with the old expiry, versus 136–138 ms with 30-second expiry. Trace events attribute roughly 280 ms to avoided TCP/TLS setup in these controlled samples. This is an idle-gap benefit, not a claim about overall averages or production tail latency. The probe used serial clients and does not model production pool capacity.

Validation:
- Real local TLS regression tests cover reuse and expiry, server-closed idle connections, and no automatic retry after a POST read timeout.
- Updated existing HTTP client doubles to accept the explicit limits argument.
- 445 affected tests passed on Python 3.14.7 / PG18.4 (runner 2 CPU / 3 GiB, PG 0.5 CPU / 512 MiB). Ruff and changed-production strict typing passed. Full Backend CI run34406845117 passed: 2,863 tests, 12 skipped, 1 expected failure; lint, strict typing, governance and generated-client checks passed for head 3dec83b43f186466dfa9ad4f8cc5db0faf0c6b3f. Local lefthook is unavailable; checks were run explicitly in Docker.

Only Telegram/Discord use this client. No schema, timeout, retry, URL validation, CLI, or infrastructure configuration changes. Longer retention still permits half-open network connections to fail at the existing timeout; mutations are not retried.
