### PR TITLE
perf(backend): precompile Python imports in runtime images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,10 @@ RUN groupadd --gid "${APP_GID}" app \
 WORKDIR /app/backend
 
 COPY backend/pyproject.toml backend/uv.lock backend/alembic.ini ./
-RUN uv sync --frozen --no-dev --no-install-project --extra mem0
+# Health probes repeatedly start a fresh interpreter. Compile imports
+# at build time because runtime bytecode writes are disabled.
+RUN uv sync --frozen --no-dev --no-install-project --extra mem0 --compile-bytecode \
+    && python -m compileall -q /usr/local/lib/python3.14
 
 COPY --chown=app:app backend/ /app/backend/
 COPY --chown=app:app packages/shared/src/native-ai-providers.json /app/packages/shared/src/native-ai-providers.json


### PR DESCRIPTION
The embedding Docker healthcheck starts a fresh Python interpreter every five seconds after the preceding check completes. Runtime bytecode writes are disabled, so uncached imports repeatedly compile source. Two read-only production checks each used about 1.83 CPU seconds; a no-inference window consumed roughly 24% of one core outside the persistent inference process.

Compile locked dependencies and the Python 3.14 standard library when building the runtime image. This retains the exact health command, Settings/.env/path validation, instance identity, HTTPX timeout behavior and Docker health timings. No application code, dependency versions, inference settings or database schema changes.

Complete baseline and candidate runtime images were built from the same resolved Python 3.14.7 base. With native cache paths and default non-root user, four alternating pairs after two warmups measured median healthcheck CPU 2726.880 → 744.568 ms (−72.7%), wall time 2731.841 → 746.972 ms, and peak RSS 67.0 → 50.875 MiB. No inference or production-latency improvement is claimed.

Actual OCI gzip layers grow by 34,177,030 bytes (32.6 MiB); uncompressed layer tar delta is 97.3 MiB. The dependency installation/compilation build step increases from 9.8 to 49.4 seconds. All 6,531 dependency/stdlib caches remain valid and readable after final COPY. Runtime configuration and health contracts match between full images.

Validation so far: seven existing embedding worker tests; non-root healthy/stale-instance/malformed-response/socket/environment/.env/timeout contract probes. Backend CI run34437624345 passed (2,869 tests, 20 skips, one expected failure), including lint/type/governance/generated-client gates. Fable reviewed the exact Dockerfile diff without a source-level blocker. Full native-cache image comparison, both-image health/identity/configuration checks and exact OCI size accounting passed. Full base digest: sha256:810da6270e43d30a1f3e0e1eabbeb6fbd9d78ad9dd2e754d5297a3d6cb42df46. Task build/benchmark resources were cleaned. No new permanent tests or framework were added.
