### PR TITLE
perf(observability): attribute upload and connector request stages

### DIFF
--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -28,7 +28,7 @@ _SYNC_EVENTS_PATHS = frozenset(("/v1/sync/events", "/api/sync/events"))
 # breakdown. Connector route fetch includes SDK/cache waits and normalization,
 # not only vendor HTTP. Response building excludes FastAPI wire serialization.
 # Telegram provider time includes pool waits, TCP/TLS and RTT.
-type ChannelStage = Literal[
+type RequestStage = Literal[
     "channel_auth_ms",
     "channel_url_validation_ms",
     "channel_provider_ms",
@@ -43,7 +43,7 @@ type ChannelStage = Literal[
     "connector_invalidation_ms",
     "connector_response_build_ms",
 ]
-_CHANNEL_STAGES: tuple[ChannelStage, ...] = (
+_REQUEST_STAGES: tuple[RequestStage, ...] = (
     "channel_auth_ms",
     "channel_url_validation_ms",
     "channel_provider_ms",
@@ -58,17 +58,17 @@ _CHANNEL_STAGES: tuple[ChannelStage, ...] = (
     "connector_invalidation_ms",
     "connector_response_build_ms",
 )
-_CHANNEL_TIMING_STATE = "_channel_stage_timings"
+_REQUEST_TIMING_STATE = "_request_stage_timings"
 _REQUEST_STARTED_STATE = "_request_timing_started"
 
 
 @contextmanager
-def channel_stage(scope: Scope, stage: ChannelStage) -> Generator[None]:
+def request_stage(scope: Scope, stage: RequestStage) -> Generator[None]:
     started = time.perf_counter()
     try:
         yield
     finally:
-        scope.setdefault("state", {}).setdefault(_CHANNEL_TIMING_STATE, {})[stage] = _elapsed_ms(
+        scope.setdefault("state", {}).setdefault(_REQUEST_TIMING_STATE, {})[stage] = _elapsed_ms(
             started
         )
 
@@ -81,16 +81,16 @@ def record_pre_handler(scope: Scope) -> None:
     """
     started: object = scope.get("state", {}).get(_REQUEST_STARTED_STATE)
     if isinstance(started, float):
-        scope["state"][_CHANNEL_TIMING_STATE]["pre_handler_ms"] = _elapsed_ms(started)
+        scope["state"][_REQUEST_TIMING_STATE]["pre_handler_ms"] = _elapsed_ms(started)
 
 
-def _channel_stage_log_fields(scope: Scope) -> str:
-    timings: object = scope.get("state", {}).get(_CHANNEL_TIMING_STATE)
+def _request_stage_log_fields(scope: Scope) -> str:
+    timings: object = scope.get("state", {}).get(_REQUEST_TIMING_STATE)
     if not isinstance(timings, dict):
         return ""
     values = cast(dict[object, object], timings)
     fields: list[str] = []
-    for stage in _CHANNEL_STAGES:
+    for stage in _REQUEST_STAGES:
         value = values.get(stage)
         if isinstance(value, float) and math.isfinite(value) and value >= 0:
             fields.append(f" {stage}={value:.1f}")
@@ -108,7 +108,7 @@ class RequestTimingMiddleware:
             return
 
         # ASGI lifespan state is shallow-copied; replace the nested dict per request.
-        scope.setdefault("state", {})[_CHANNEL_TIMING_STATE] = {}
+        scope.setdefault("state", {})[_REQUEST_TIMING_STATE] = {}
         started = time.perf_counter()
         scope["state"][_REQUEST_STARTED_STATE] = started
         raw_method: object = scope.get("method", "GET")
@@ -139,7 +139,7 @@ class RequestTimingMiddleware:
                 path,
                 duration_ms,
                 _request_id(scope),
-                _channel_stage_log_fields(scope),
+                _request_stage_log_fields(scope),
             )
             raise
 
@@ -152,7 +152,7 @@ class RequestTimingMiddleware:
                 status_code,
                 duration_ms,
                 _request_id(scope),
-                _channel_stage_log_fields(scope),
+                _request_stage_log_fields(scope),
             )
         elif not _is_expected_long_request(raw_path) and _is_slow(
             duration_ms=duration_ms,
@@ -165,7 +165,7 @@ class RequestTimingMiddleware:
                 status_code,
                 duration_ms,
                 _request_id(scope),
-                _channel_stage_log_fields(scope),
+                _request_stage_log_fields(scope),
             )
 
 

--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -2,7 +2,7 @@
 
 Adds a cheap per-request process-time response header and logs only slow
 requests or server errors. Logs intentionally include method/path/status/time
-and request id, plus fixed channel stage timings; query strings, headers, bodies,
+and request id, plus fixed route stage timings; query strings, headers, bodies,
 and user identity stay out of application logs.
 """
 
@@ -24,18 +24,42 @@ _PROCESS_TIME_HEADER = b"x-process-time-ms"
 _SYNC_EVENTS_PATHS = frozenset(("/v1/sync/events", "/api/sync/events"))
 
 
-# Wall-clock stages include event-loop waits. Initially instrumented only on the
-# Telegram Bot API proxy. Provider time includes pool waits, TCP/TLS and RTT,
-# not just provider processing. Request body arrival/parsing, response parsing
-# and result reference writes remain unattributed: the stage sum is not the
-# whole request duration.
-type ChannelStage = Literal["channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms"]
+# Wall-clock stages include event-loop waits and are not a complete request
+# breakdown. Connector route fetch includes SDK/cache waits and normalization,
+# not only vendor HTTP. Response building excludes FastAPI wire serialization.
+# Telegram provider time includes pool waits, TCP/TLS and RTT.
+type ChannelStage = Literal[
+    "channel_auth_ms",
+    "channel_url_validation_ms",
+    "channel_provider_ms",
+    "pre_handler_ms",
+    "upload_lookup_lock_ms",
+    "upload_spooled_read_ms",
+    "upload_analysis_ms",
+    "upload_storage_ms",
+    "upload_index_ms",
+    "upload_commit_ms",
+    "connector_route_fetch_ms",
+    "connector_invalidation_ms",
+    "connector_response_build_ms",
+]
 _CHANNEL_STAGES: tuple[ChannelStage, ...] = (
     "channel_auth_ms",
     "channel_url_validation_ms",
     "channel_provider_ms",
+    "pre_handler_ms",
+    "upload_lookup_lock_ms",
+    "upload_spooled_read_ms",
+    "upload_analysis_ms",
+    "upload_storage_ms",
+    "upload_index_ms",
+    "upload_commit_ms",
+    "connector_route_fetch_ms",
+    "connector_invalidation_ms",
+    "connector_response_build_ms",
 )
 _CHANNEL_TIMING_STATE = "_channel_stage_timings"
+_REQUEST_STARTED_STATE = "_request_timing_started"
 
 
 @contextmanager
@@ -47,6 +71,17 @@ def channel_stage(scope: Scope, stage: ChannelStage) -> Generator[None]:
         scope.setdefault("state", {}).setdefault(_CHANNEL_TIMING_STATE, {})[stage] = _elapsed_ms(
             started
         )
+
+
+def record_pre_handler(scope: Scope) -> None:
+    """Middleware entry to handler: body arrival/parsing, auth and dependencies.
+
+    Only reached handlers record this interval; rejected dependencies do not.
+    This does not measure time before ASGI middleware entry or pure auth time.
+    """
+    started: object = scope.get("state", {}).get(_REQUEST_STARTED_STATE)
+    if isinstance(started, float):
+        scope["state"][_CHANNEL_TIMING_STATE]["pre_handler_ms"] = _elapsed_ms(started)
 
 
 def _channel_stage_log_fields(scope: Scope) -> str:
@@ -75,6 +110,7 @@ class RequestTimingMiddleware:
         # ASGI lifespan state is shallow-copied; replace the nested dict per request.
         scope.setdefault("state", {})[_CHANNEL_TIMING_STATE] = {}
         started = time.perf_counter()
+        scope["state"][_REQUEST_STARTED_STATE] = started
         raw_method: object = scope.get("method", "GET")
         method = raw_method if isinstance(raw_method, str) else "GET"
         raw_path_value: object = scope.get("path", "")

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -29,7 +29,7 @@ from starlette.datastructures import UploadFile
 
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
-from app.middleware.request_timing import channel_stage
+from app.middleware.request_timing import request_stage
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
@@ -388,7 +388,7 @@ async def telegram_bot_api(
     # Read the bounded request body before checking out an auth connection.
     raw_body = await request.body()
     params = await _telegram_request_params(request)
-    with channel_stage(request.scope, "channel_auth_ms"):
+    with request_stage(request.scope, "channel_auth_ms"):
         agent, _agent_token = await _resolve_telegram_agent(
             db,
             routing_id=routing_id,
@@ -2659,7 +2659,7 @@ async def _telegram_provider_response(
     translate_direct_topic: bool = False,
 ) -> httpx.Response:
     base_url = settings.channel_telegram_api_base_url.strip()
-    with channel_stage(request.scope, "channel_url_validation_ms"):
+    with request_stage(request.scope, "channel_url_validation_ms"):
         await _validate_telegram_provider_base_url(base_url)
     url = httpx.URL(f"{base_url.rstrip('/')}/bot{provider_token}/{method}")
     headers: dict[str, str] = {}
@@ -2679,7 +2679,7 @@ async def _telegram_provider_response(
     try:
         with (
             track_proxy_latency("telegram", method),
-            channel_stage(request.scope, "channel_provider_ms"),
+            request_stage(request.scope, "channel_provider_ms"),
         ):
             response = await get_channel_provider_http_client().request(
                 request.method,

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from app.core.auth import AuthContext, require_clerk_id, require_user_auth_short_session
 from app.core.config import settings
-from app.middleware.request_timing import channel_stage, record_pre_handler
+from app.middleware.request_timing import record_pre_handler, request_stage
 from app.schemas.common import Paginated
 from app.schemas.connector import (
     ConnectorAuthFieldsResponse,
@@ -129,7 +129,7 @@ async def list_connections(
         return []
     clerk_id = require_clerk_id(auth)
     try:
-        with channel_stage(request.scope, "connector_route_fetch_ms"):
+        with request_stage(request.scope, "connector_route_fetch_ms"):
             accounts = await get_all_connected_accounts(clerk_id)
     except ComposioRouteError as exc:
         if _is_composio_auth_error(exc):
@@ -140,9 +140,9 @@ async def list_connections(
     # Composio Tool Router sessions capture the active account set, so
     # observing the latest connected-account state should force the next
     # MCP bridge call to create a fresh session.
-    with channel_stage(request.scope, "connector_invalidation_ms"):
+    with request_stage(request.scope, "connector_invalidation_ms"):
         await invalidate_tool_router_mcp_session(clerk_id)
-    with channel_stage(request.scope, "connector_response_build_ms"):
+    with request_stage(request.scope, "connector_response_build_ms"):
         return [ConnectorConnectionResponse.model_validate(account) for account in accounts]
 
 
@@ -179,7 +179,7 @@ async def list_available_apps(
             items=[], total=0, page=page, page_size=page_size
         )
     try:
-        with channel_stage(request.scope, "connector_route_fetch_ms"):
+        with request_stage(request.scope, "connector_route_fetch_ms"):
             page_data = await get_available_apps(search=search, page=page, page_size=page_size)
     except ComposioRouteError as exc:
         if _is_composio_auth_error(exc):
@@ -188,7 +188,7 @@ async def list_available_apps(
                 items=[], total=0, page=page, page_size=page_size
             )
         raise map_composio_error(exc) from exc
-    with channel_stage(request.scope, "connector_response_build_ms"):
+    with request_stage(request.scope, "connector_response_build_ms"):
         return Paginated[ConnectorAvailableAppResponse](
             items=page_data["items"],
             total=page_data["total"],
@@ -210,7 +210,7 @@ async def get_available_app(
     if not settings.composio_api_key:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
     try:
-        with channel_stage(request.scope, "connector_route_fetch_ms"):
+        with request_stage(request.scope, "connector_route_fetch_ms"):
             app = await get_app_by_name(app_name)
     except ComposioRouteError as exc:
         raise map_composio_error(exc) from exc

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -1,9 +1,10 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from app.core.auth import AuthContext, require_clerk_id, require_user_auth_short_session
 from app.core.config import settings
+from app.middleware.request_timing import channel_stage, record_pre_handler
 from app.schemas.common import Paginated
 from app.schemas.connector import (
     ConnectorAuthFieldsResponse,
@@ -119,14 +120,17 @@ def map_composio_error(exc: ComposioRouteError) -> HTTPException:
 
 @router.get("")
 async def list_connections(
+    request: Request,
     auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> list[ConnectorConnectionResponse]:
     """List user's connected services."""
+    record_pre_handler(request.scope)
     if not settings.composio_api_key:
         return []
     clerk_id = require_clerk_id(auth)
     try:
-        accounts = await get_all_connected_accounts(clerk_id)
+        with channel_stage(request.scope, "connector_route_fetch_ms"):
+            accounts = await get_all_connected_accounts(clerk_id)
     except ComposioRouteError as exc:
         if _is_composio_auth_error(exc):
             log.warning("composio_key_invalid path=connectors_list")
@@ -136,8 +140,10 @@ async def list_connections(
     # Composio Tool Router sessions capture the active account set, so
     # observing the latest connected-account state should force the next
     # MCP bridge call to create a fresh session.
-    await invalidate_tool_router_mcp_session(clerk_id)
-    return [ConnectorConnectionResponse.model_validate(account) for account in accounts]
+    with channel_stage(request.scope, "connector_invalidation_ms"):
+        await invalidate_tool_router_mcp_session(clerk_id)
+    with channel_stage(request.scope, "connector_response_build_ms"):
+        return [ConnectorConnectionResponse.model_validate(account) for account in accounts]
 
 
 @router.post("/metadata:batchRead", response_model=ConnectorMetadataBatchResponse)
@@ -156,6 +162,7 @@ async def read_connector_metadata(
 
 @router.get("/available")
 async def list_available_apps(
+    request: Request,
     auth: AuthContext = Depends(require_user_auth_short_session),
     search: str | None = Query(default=None, max_length=100),
     page: int = Query(default=1, ge=1),
@@ -166,12 +173,14 @@ async def list_available_apps(
     cost a Composio roundtrip per page and the browser only ships one
     page at a time. Search is substring across slug, display name, and
     description (server-side, before pagination)."""
+    record_pre_handler(request.scope)
     if not settings.composio_api_key:
         return Paginated[ConnectorAvailableAppResponse](
             items=[], total=0, page=page, page_size=page_size
         )
     try:
-        page_data = await get_available_apps(search=search, page=page, page_size=page_size)
+        with channel_stage(request.scope, "connector_route_fetch_ms"):
+            page_data = await get_available_apps(search=search, page=page, page_size=page_size)
     except ComposioRouteError as exc:
         if _is_composio_auth_error(exc):
             log.warning("composio_key_invalid path=connectors_available")
@@ -179,26 +188,30 @@ async def list_available_apps(
                 items=[], total=0, page=page, page_size=page_size
             )
         raise map_composio_error(exc) from exc
-    return Paginated[ConnectorAvailableAppResponse](
-        items=page_data["items"],
-        total=page_data["total"],
-        page=page_data["page"],
-        page_size=page_data["page_size"],
-    )
+    with channel_stage(request.scope, "connector_response_build_ms"):
+        return Paginated[ConnectorAvailableAppResponse](
+            items=page_data["items"],
+            total=page_data["total"],
+            page=page_data["page"],
+            page_size=page_data["page_size"],
+        )
 
 
 @router.get("/available/{app_name}")
 async def get_available_app(
+    request: Request,
     app_name: str,
     auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorAvailableAppResponse:
     """Single-app metadata lookup — used by the detail page so it doesn't
     have to page through the whole catalog to find one app's display name.
     Re-uses the cache that `/available` populates."""
+    record_pre_handler(request.scope)
     if not settings.composio_api_key:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
     try:
-        app = await get_app_by_name(app_name)
+        with channel_stage(request.scope, "connector_route_fetch_ms"):
+            app = await get_app_by_name(app_name)
     except ComposioRouteError as exc:
         raise map_composio_error(exc) from exc
     if app is None:

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -41,6 +41,7 @@ from app.core.auth import (
 from app.core.config import settings
 from app.core.database import get_session
 from app.core.query_utils import SearchQuery
+from app.middleware.request_timing import channel_stage, record_pre_handler
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
@@ -3088,6 +3089,7 @@ async def delete_session(
 
 @router.post("/sessions/{local_session_id}/upload")
 async def upload_session_content(
+    request: Request,
     # Constrained to safe filename chars so the legacy object key remains
     # inside the user's Session prefix.
     local_session_id: str = Path(..., pattern=_SESSION_LOCAL_ID_PATTERN),
@@ -3099,63 +3101,65 @@ async def upload_session_content(
     db: AsyncSession = Depends(get_session),
 ) -> SessionUploadResponse:
     """Upload session messages JSON to FileStore."""
-    bound_env = _bound_env_id(auth)
-    stmt = select(Session).where(
-        Session.user_id == auth.user_id,
-        Session.local_session_id == local_session_id,
-    )
-    if bound_env is not None:
-        # Bound api_keys can only write within their env. A NULL
-        # `environment_id` (orphan from a since-deleted env) is
-        # treated as "not yours" — without this an orphaned
-        # session would be a silent shared write target.
-        stmt = stmt.where(Session.origin_environment_id == bound_env)
-    elif environment_id is not None:
-        stmt = stmt.where(Session.origin_environment_id == environment_id)
-    sessions = list((await db.execute(stmt)).scalars())
-    if not sessions:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
-    if len(sessions) != 1:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "code": "session_origin_required",
-                "message": (
-                    "More than one Agent owns this local_session_id; "
-                    "use an environment-bound credential."
-                ),
-            },
+    record_pre_handler(request.scope)
+    with channel_stage(request.scope, "upload_lookup_lock_ms"):
+        bound_env = _bound_env_id(auth)
+        stmt = select(Session).where(
+            Session.user_id == auth.user_id,
+            Session.local_session_id == local_session_id,
         )
-    session = sessions[0]
-    if session.origin_environment_id is not None:
-        await require_connected_agent_fence(
-            db,
-            auth=auth,
-            agent_ids={session.origin_environment_id},
-            headers=fence_headers,
-            lock=True,
-        )
-    sessions = list((await db.execute(stmt.with_for_update())).scalars())
-    if not sessions:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
-    if len(sessions) != 1:
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "code": "session_origin_required",
-                "message": (
-                    "More than one Agent owns this local_session_id; "
-                    "use an environment-bound credential."
-                ),
-            },
-        )
-    session = sessions[0]
+        if bound_env is not None:
+            # Bound api_keys can only write within their env. A NULL
+            # `environment_id` (orphan from a since-deleted env) is
+            # treated as "not yours" — without this an orphaned
+            # session would be a silent shared write target.
+            stmt = stmt.where(Session.origin_environment_id == bound_env)
+        elif environment_id is not None:
+            stmt = stmt.where(Session.origin_environment_id == environment_id)
+        sessions = list((await db.execute(stmt)).scalars())
+        if not sessions:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+        if len(sessions) != 1:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "session_origin_required",
+                    "message": (
+                        "More than one Agent owns this local_session_id; "
+                        "use an environment-bound credential."
+                    ),
+                },
+            )
+        session = sessions[0]
+        if session.origin_environment_id is not None:
+            await require_connected_agent_fence(
+                db,
+                auth=auth,
+                agent_ids={session.origin_environment_id},
+                headers=fence_headers,
+                lock=True,
+            )
+        sessions = list((await db.execute(stmt.with_for_update())).scalars())
+        if not sessions:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+        if len(sessions) != 1:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "session_origin_required",
+                    "message": (
+                        "More than one Agent owns this local_session_id; "
+                        "use an environment-bound credential."
+                    ),
+                },
+            )
+        session = sessions[0]
 
-    if session.content_protocol == "events-v1":
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            "Session has been upgraded to events-v1",
-        )
+        if session.content_protocol == "events-v1":
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Session has been upgraded to events-v1",
+            )
 
     # Stream the upload in bounded chunks, refusing once total
     # bytes cross the cap. The global `BodySizeLimitMiddleware`
@@ -3164,26 +3168,28 @@ async def upload_session_content(
     # streamed uploads (no Content-Length header) where the
     # middleware can't decide. `await file.read()` without bound
     # would pull arbitrarily large bodies into memory first.
-    _MAX_SESSION_CONTENT_BYTES = 50 * 1024 * 1024  # 50 MB
-    chunks: list[bytes] = []
-    total = 0
-    chunk_size = 1024 * 1024  # 1 MB
-    while True:
-        chunk = await file.read(chunk_size)
-        if not chunk:
-            break
-        total += len(chunk)
-        if total > _MAX_SESSION_CONTENT_BYTES:
-            raise HTTPException(
-                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                f"Session content exceeds {_MAX_SESSION_CONTENT_BYTES} bytes",
-            )
-        chunks.append(chunk)
-    data = b"".join(chunks)
+    with channel_stage(request.scope, "upload_spooled_read_ms"):
+        _MAX_SESSION_CONTENT_BYTES = 50 * 1024 * 1024  # 50 MB
+        chunks: list[bytes] = []
+        total = 0
+        chunk_size = 1024 * 1024  # 1 MB
+        while True:
+            chunk = await file.read(chunk_size)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > _MAX_SESSION_CONTENT_BYTES:
+                raise HTTPException(
+                    status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    f"Session content exceeds {_MAX_SESSION_CONTENT_BYTES} bytes",
+                )
+            chunks.append(chunk)
+        data = b"".join(chunks)
     # Hash, JSON validation, and reference extraction are CPU-bound for large
     # snapshots. Keep them together off the event loop so other requests can
     # continue while this upload is analyzed.
-    analysis = await _analyze_session_upload(data)
+    with channel_stage(request.scope, "upload_analysis_ms"):
+        analysis = await _analyze_session_upload(data)
     content_hash = analysis.content_hash
 
     # New clients submit the hash announced in the preceding batch as a CAS
@@ -3202,7 +3208,8 @@ async def upload_session_content(
         )
 
     fk = _session_content_key(session)
-    await file_store.put(fk, data)
+    with channel_stage(request.scope, "upload_storage_ms"):
+        await file_store.put(fk, data)
 
     session.file_key = fk
     session.content_hash = content_hash
@@ -3215,12 +3222,13 @@ async def upload_session_content(
     # we'd rather have a session with NULL related_refs than a
     # half-committed upload).
     session.related_refs = analysis.related_refs
-    await replace_snapshot_search_index(
-        db,
-        session,
-        content_hash,
-        analysis.search_messages,
-    )
+    with channel_stage(request.scope, "upload_index_ms"):
+        await replace_snapshot_search_index(
+            db,
+            session,
+            content_hash,
+            analysis.search_messages,
+        )
     if analysis.parse_error is not None:
         # Preserve the worker-thread traceback for diagnosing malformed
         # snapshots without failing their best-effort upload.
@@ -3231,7 +3239,8 @@ async def upload_session_content(
             exc_info=(type(error), error, error.__traceback__),
         )
 
-    await db.commit()
+    with channel_stage(request.scope, "upload_commit_ms"):
+        await db.commit()
 
     return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -41,7 +41,7 @@ from app.core.auth import (
 from app.core.config import settings
 from app.core.database import get_session
 from app.core.query_utils import SearchQuery
-from app.middleware.request_timing import channel_stage, record_pre_handler
+from app.middleware.request_timing import record_pre_handler, request_stage
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
@@ -3102,7 +3102,7 @@ async def upload_session_content(
 ) -> SessionUploadResponse:
     """Upload session messages JSON to FileStore."""
     record_pre_handler(request.scope)
-    with channel_stage(request.scope, "upload_lookup_lock_ms"):
+    with request_stage(request.scope, "upload_lookup_lock_ms"):
         bound_env = _bound_env_id(auth)
         stmt = select(Session).where(
             Session.user_id == auth.user_id,
@@ -3168,7 +3168,7 @@ async def upload_session_content(
     # streamed uploads (no Content-Length header) where the
     # middleware can't decide. `await file.read()` without bound
     # would pull arbitrarily large bodies into memory first.
-    with channel_stage(request.scope, "upload_spooled_read_ms"):
+    with request_stage(request.scope, "upload_spooled_read_ms"):
         _MAX_SESSION_CONTENT_BYTES = 50 * 1024 * 1024  # 50 MB
         chunks: list[bytes] = []
         total = 0
@@ -3188,7 +3188,7 @@ async def upload_session_content(
     # Hash, JSON validation, and reference extraction are CPU-bound for large
     # snapshots. Keep them together off the event loop so other requests can
     # continue while this upload is analyzed.
-    with channel_stage(request.scope, "upload_analysis_ms"):
+    with request_stage(request.scope, "upload_analysis_ms"):
         analysis = await _analyze_session_upload(data)
     content_hash = analysis.content_hash
 
@@ -3208,7 +3208,7 @@ async def upload_session_content(
         )
 
     fk = _session_content_key(session)
-    with channel_stage(request.scope, "upload_storage_ms"):
+    with request_stage(request.scope, "upload_storage_ms"):
         await file_store.put(fk, data)
 
     session.file_key = fk
@@ -3222,7 +3222,7 @@ async def upload_session_content(
     # we'd rather have a session with NULL related_refs than a
     # half-committed upload).
     session.related_refs = analysis.related_refs
-    with channel_stage(request.scope, "upload_index_ms"):
+    with request_stage(request.scope, "upload_index_ms"):
         await replace_snapshot_search_index(
             db,
             session,
@@ -3239,7 +3239,7 @@ async def upload_session_content(
             exc_info=(type(error), error, error.__traceback__),
         )
 
-    with channel_stage(request.scope, "upload_commit_ms"):
+    with request_stage(request.scope, "upload_commit_ms"):
         await db.commit()
 
     return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import httpx
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from starlette.requests import Request
 
 from app.core.auth import AuthContext
 from app.core.config import settings
@@ -1227,7 +1228,9 @@ async def test_list_connections_invalidates_tool_router_session(
         expires_at=datetime.now(UTC) + timedelta(minutes=30),
     )
 
-    result = await connectors.list_connections(AuthContext(user=User(clerk_id="clerk_user_123")))
+    result = await connectors.list_connections(
+        Request({"type": "http"}), AuthContext(user=User(clerk_id="clerk_user_123"))
+    )
 
     assert result == []
     assert "clerk_user_123" not in composio._tool_router_session_cache

--- a/backend/tests/test_request_stage_routes.py
+++ b/backend/tests/test_request_stage_routes.py
@@ -95,7 +95,7 @@ async def test_upload_stages_real_auth_pg(
         try:
             await timed(scope, delayed_receive, send)
         finally:
-            captured.update(scope["state"]["_channel_stage_timings"])
+            captured.update(scope["state"]["_request_stage_timings"])
 
     caplog.set_level(logging.WARNING, logger=request_timing.__name__)
     data = {"expected_content_hash": "0" * 64} if failure == "cas" else {}

--- a/backend/tests/test_request_stage_routes.py
+++ b/backend/tests/test_request_stage_routes.py
@@ -1,0 +1,243 @@
+"""Actual ASGI routes; upload uses real API-key auth/PG/local storage.
+
+Connector auth and route-facing adapter calls are mocked explicitly; these
+contracts measure attribution, not vendor HTTP or performance improvement.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.core.auth import AuthContext, require_user_auth_short_session
+from app.core.database import get_session
+from app.middleware import request_timing
+from app.models.session import Session
+from app.models.user import User
+from app.routes import connectors, sessions
+from app.schemas.connector import ConnectorAvailableAppResponse
+from app.services.api_key import mint_api_key
+from app.services.composio import ComposioProtocolError
+from app.services.file_store import LocalFileStore
+
+
+@pytest.mark.parametrize(
+    "failure", [None, "lookup", "analysis", "storage", "index", "commit", "cas", "auth"]
+)
+async def test_upload_stages_real_auth_pg(
+    db_session, seed_user, tmp_path, monkeypatch, caplog, failure
+):
+    elapsed = 0.0
+    body_elapsed = 0.0
+    monkeypatch.setattr(request_timing, "time", SimpleNamespace(perf_counter=lambda: elapsed))
+
+    async def database_dependency():
+        nonlocal elapsed
+        elapsed += 0.013
+        return db_session
+
+    app = FastAPI()
+    app.include_router(sessions.router, prefix="/v1")
+    app.dependency_overrides[get_session] = database_dependency
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="stage-test",
+        scopes=["sessions:read"] if failure == "auth" else ["sessions:write"],
+    )
+    row = Session(
+        user_id=seed_user.id, local_session_id="stage-upload", started_at=datetime.now(UTC)
+    )
+    db_session.add(row)
+    await db_session.commit()
+    store = LocalFileStore(str(tmp_path))
+    monkeypatch.setattr(sessions, "file_store", store)
+    # Fault injection only: successful operations below remain the real
+    # analyzer, filesystem, PostgreSQL index and transaction commit.
+    targets = {
+        "analysis": (sessions, "_analyze_session_upload"),
+        "storage": (store, "put"),
+        "index": (sessions, "replace_snapshot_search_index"),
+        "commit": (db_session, "commit"),
+    }
+    if failure in targets:
+        target, name = targets[failure]
+        original = getattr(target, name)
+
+        async def fail(*_args, **_kwargs):
+            nonlocal elapsed
+            # Authentication may commit last_used_at before handler entry.
+            if failure == "commit" and row.file_key is None:
+                return await original(*_args, **_kwargs)
+            elapsed += 0.019
+            raise RuntimeError("injected stage failure")
+
+        monkeypatch.setattr(target, name, fail)
+
+    captured = {}
+    timed = request_timing.RequestTimingMiddleware(app, slow_ms=0.000001)
+
+    async def capture(scope, receive, send):
+        async def delayed_receive():
+            nonlocal elapsed, body_elapsed
+            message = await receive()
+            if message["type"] == "http.request":
+                elapsed += 0.017
+                body_elapsed += 0.017
+            return message
+
+        try:
+            await timed(scope, delayed_receive, send)
+        finally:
+            captured.update(scope["state"]["_channel_stage_timings"])
+
+    caplog.set_level(logging.WARNING, logger=request_timing.__name__)
+    data = {"expected_content_hash": "0" * 64} if failure == "cas" else {}
+    path = (
+        "/v1/sessions/missing/upload" if failure == "lookup" else "/v1/sessions/stage-upload/upload"
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=capture), base_url="http://test"
+    ) as client:
+
+        async def upload():
+            return await client.post(
+                path,
+                headers={"Authorization": f"Bearer {minted.raw_key}"},
+                params={"unused": "query-secret"},
+                data=data,
+                files={
+                    "file": (
+                        "body-secret.json",
+                        b'[{"role":"user","content":"body-secret"}]',
+                        "application/json",
+                    )
+                },
+            )
+
+        if failure in targets:
+            with pytest.raises(RuntimeError, match="injected stage failure"):
+                await upload()
+        else:
+            response = await upload()
+            assert response.status_code == {"lookup": 404, "cas": 409, "auth": 403}.get(
+                failure, 200
+            )
+            if failure is None:
+                assert (
+                    await store.get(response.json()["file_key"])
+                    == b'[{"role":"user","content":"body-secret"}]'
+                )
+                await db_session.refresh(row)
+                assert row.content_hash == response.json()["content_hash"]
+                assert row.search_index_revision is not None
+                assert row.content_uploaded_at is not None
+
+    stages = [
+        "pre_handler_ms",
+        "upload_lookup_lock_ms",
+        "upload_spooled_read_ms",
+        "upload_analysis_ms",
+        "upload_storage_ms",
+        "upload_index_ms",
+        "upload_commit_ms",
+    ]
+    end = {"auth": 0, "lookup": 2, "analysis": 4, "cas": 4, "storage": 5, "index": 6}.get(
+        failure, 7
+    )
+    assert set(captured) == set(stages[:end])
+    if failure != "auth":
+        # Real multipart parsing consumes simulated body arrival before the
+        # dependency and handler; spooled reads must not count arrival twice.
+        assert body_elapsed > 0
+        assert captured["pre_handler_ms"] == pytest.approx((body_elapsed + 0.013) * 1000)
+        if "upload_spooled_read_ms" in captured:
+            assert captured["upload_spooled_read_ms"] == 0
+    if failure in targets:
+        assert captured[f"upload_{failure}_ms"] == pytest.approx(19)
+    assert all(
+        isinstance(value, float) and math.isfinite(value) and value >= 0
+        for value in captured.values()
+    )
+    records = [r.getMessage() for r in caplog.records if r.name == request_timing.__name__]
+    assert len(records) == 1
+    for stage in captured:
+        assert f"{stage}=" in records[0]
+    for secret in (minted.raw_key, str(seed_user.id), "query-secret", "body-secret"):
+        assert secret not in records[0]
+
+
+@pytest.mark.parametrize(
+    ("route", "failure"),
+    [
+        (route, failure)
+        for route in ("", "/available", "/available/example")
+        for failure in (None, "fetch")
+    ]
+    + [("", "invalidation"), ("", "response")],
+)
+async def test_connector_route_fetch_boundary(monkeypatch, caplog, route, failure):
+    """Real routing/response validation, mocked auth and adapter boundary."""
+    elapsed = 0.0
+    monkeypatch.setattr(request_timing, "time", SimpleNamespace(perf_counter=lambda: elapsed))
+    app = FastAPI()
+    app.include_router(connectors.router, prefix="/v1")
+
+    async def auth():
+        nonlocal elapsed
+        elapsed += 0.013
+        return AuthContext(user=User(clerk_id="identity-secret"))
+
+    app.dependency_overrides[require_user_auth_short_session] = auth
+    monkeypatch.setattr(connectors.settings, "composio_api_key", "config-secret")
+
+    async def fetch(*_args, **_kwargs):
+        nonlocal elapsed
+        elapsed += 0.023
+        if failure == "fetch":
+            raise ComposioProtocolError("injected adapter failure")
+        if route == "":
+            return [{}] if failure == "response" else []
+        if route == "/available":
+            return {"items": [], "total": 0, "page": 1, "page_size": 24}
+        return ConnectorAvailableAppResponse(
+            name="example", display_name="Example", logo="", description="", auth_type="none"
+        )
+
+    async def invalidate(_user):
+        nonlocal elapsed
+        elapsed += 0.037
+        if failure == "invalidation":
+            raise RuntimeError("injected invalidation failure")
+
+    name = {
+        "": "get_all_connected_accounts",
+        "/available": "get_available_apps",
+        "/available/example": "get_app_by_name",
+    }[route]
+    monkeypatch.setattr(connectors, name, fetch)
+    monkeypatch.setattr(connectors, "invalidate_tool_router_mcp_session", invalidate)
+    caplog.set_level(logging.WARNING, logger=request_timing.__name__)
+    timed = request_timing.RequestTimingMiddleware(app, slow_ms=1)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=timed, raise_app_exceptions=False), base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/connectors" + route, params={"search": "query-secret"})
+    assert response.status_code == (502 if failure == "fetch" else 500 if failure else 200)
+    records = [r.getMessage() for r in caplog.records if r.name == request_timing.__name__]
+    assert len(records) == 1
+    assert "pre_handler_ms=13.0" in records[0]
+    assert "connector_route_fetch_ms=23.0" in records[0]
+    assert ("connector_invalidation_ms=37.0" in records[0]) == (route == "" and failure != "fetch")
+    assert ("connector_response_build_ms=0.0" in records[0]) == (
+        route != "/available/example" and failure not in ("fetch", "invalidation")
+    )
+    assert all(
+        secret not in records[0] for secret in ("identity-secret", "config-secret", "query-secret")
+    )

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -300,6 +300,9 @@ async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
             channel_auth_ms=float("nan"),
             channel_url_validation_ms=float("inf"),
             channel_provider_ms="secret",
+            upload_storage_ms=-1.0,
+            connector_route_fetch_ms=True,
+            connector_invalidation_ms=float("inf"),
             unknown="secret",
         )
         await send({"type": "http.response.start", "status": 500, "headers": []})
@@ -309,6 +312,53 @@ async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
     await _collect(RequestTimingMiddleware(inner, slow_ms=750), scope)
     assert "request_error" in caplog.text
     assert "channel_" not in caplog.text
+    assert "upload_storage_ms" not in caplog.text
+    assert "connector_" not in caplog.text
     assert "unknown" not in caplog.text
     assert "secret" not in caplog.text
     assert inherited == {"channel_auth_ms": 999.0}
+
+
+async def test_overlapping_requests_do_not_share_lifespan_stage_timings(caplog):
+    import asyncio
+
+    from app.middleware.request_timing import channel_stage, record_pre_handler
+
+    inherited = {"_channel_stage_timings": {"upload_storage_ms": 999.0}}
+    first, second = _scope(), _scope()
+    first["state"] = inherited.copy()
+    second["state"] = inherited.copy()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def inner(scope, _receive, send):
+        record_pre_handler(scope)
+        if scope is first:
+            with channel_stage(scope, "upload_storage_ms"):
+                entered.set()
+                await release.wait()
+                raise RuntimeError("storage failed")
+        await entered.wait()
+        with channel_stage(scope, "connector_route_fetch_ms"):
+            await asyncio.sleep(0)
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+        release.set()
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    timed = RequestTimingMiddleware(inner, slow_ms=750)
+    results = await asyncio.gather(
+        _collect(timed, first), _collect(timed, second), return_exceptions=True
+    )
+    assert isinstance(results[0], RuntimeError)
+    assert not isinstance(results[1], BaseException)
+    assert set(first["state"]["_channel_stage_timings"]) == {"pre_handler_ms", "upload_storage_ms"}
+    assert set(second["state"]["_channel_stage_timings"]) == {
+        "pre_handler_ms",
+        "connector_route_fetch_ms",
+    }
+    assert inherited == {"_channel_stage_timings": {"upload_storage_ms": 999.0}}
+    records = [r.getMessage() for r in caplog.records if r.name == "app.middleware.request_timing"]
+    assert len(records) == 2
+    assert "connector_route_fetch_ms=" in records[0] and "upload_storage_ms=" not in records[0]
+    assert "upload_storage_ms=" in records[1] and "connector_route_fetch_ms=" not in records[1]

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -264,7 +264,7 @@ async def test_telegram_route_stage_timings(
             )
 
     stages = ("channel_auth_ms", "channel_url_validation_ms", "channel_provider_ms")
-    timings = scope["state"]["_channel_stage_timings"]
+    timings = scope["state"]["_request_stage_timings"]
     assert timings == pytest.approx(
         {stage: value for stage, value in zip(stages, expected_stages) if value is not None}
     )
@@ -286,14 +286,14 @@ async def test_telegram_route_stage_timings(
 
 
 async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
-    from app.middleware.request_timing import _CHANNEL_TIMING_STATE
+    from app.middleware.request_timing import _REQUEST_TIMING_STATE
 
     inherited = {"channel_auth_ms": 999.0}
     scope = _scope()
-    scope["state"][_CHANNEL_TIMING_STATE] = inherited
+    scope["state"][_REQUEST_TIMING_STATE] = inherited
 
     async def inner(scope: Scope, _receive: Receive, send: Send) -> None:
-        timings = scope["state"][_CHANNEL_TIMING_STATE]
+        timings = scope["state"][_REQUEST_TIMING_STATE]
         assert timings == {}
         assert timings is not inherited
         timings.update(
@@ -322,9 +322,9 @@ async def test_request_timing_isolates_stage_state_and_filters_fields(caplog):
 async def test_overlapping_requests_do_not_share_lifespan_stage_timings(caplog):
     import asyncio
 
-    from app.middleware.request_timing import channel_stage, record_pre_handler
+    from app.middleware.request_timing import record_pre_handler, request_stage
 
-    inherited = {"_channel_stage_timings": {"upload_storage_ms": 999.0}}
+    inherited = {"_request_stage_timings": {"upload_storage_ms": 999.0}}
     first, second = _scope(), _scope()
     first["state"] = inherited.copy()
     second["state"] = inherited.copy()
@@ -334,12 +334,12 @@ async def test_overlapping_requests_do_not_share_lifespan_stage_timings(caplog):
     async def inner(scope, _receive, send):
         record_pre_handler(scope)
         if scope is first:
-            with channel_stage(scope, "upload_storage_ms"):
+            with request_stage(scope, "upload_storage_ms"):
                 entered.set()
                 await release.wait()
                 raise RuntimeError("storage failed")
         await entered.wait()
-        with channel_stage(scope, "connector_route_fetch_ms"):
+        with request_stage(scope, "connector_route_fetch_ms"):
             await asyncio.sleep(0)
         await send({"type": "http.response.start", "status": 500, "headers": []})
         await send({"type": "http.response.body", "body": b""})
@@ -352,12 +352,12 @@ async def test_overlapping_requests_do_not_share_lifespan_stage_timings(caplog):
     )
     assert isinstance(results[0], RuntimeError)
     assert not isinstance(results[1], BaseException)
-    assert set(first["state"]["_channel_stage_timings"]) == {"pre_handler_ms", "upload_storage_ms"}
-    assert set(second["state"]["_channel_stage_timings"]) == {
+    assert set(first["state"]["_request_stage_timings"]) == {"pre_handler_ms", "upload_storage_ms"}
+    assert set(second["state"]["_request_stage_timings"]) == {
         "pre_handler_ms",
         "connector_route_fetch_ms",
     }
-    assert inherited == {"_channel_stage_timings": {"upload_storage_ms": 999.0}}
+    assert inherited == {"_request_stage_timings": {"upload_storage_ms": 999.0}}
     records = [r.getMessage() for r in caplog.records if r.name == "app.middleware.request_timing"]
     assert len(records) == 2
     assert "connector_route_fetch_ms=" in records[0] and "upload_storage_ms=" not in records[0]

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -859,7 +859,7 @@ Done: timing contracts pass with real PostgreSQL/API-key authentication and
 local storage for snapshot uploads; connector attribution tests explicitly mock
 authentication and the route-facing adapter calls.
 
-Slow/error request logs reuse the fixed, request-local `channel_stage` fields:
+Slow/error request logs reuse the fixed, request-local `request_stage` fields:
 
 - `pre_handler_ms`: timing middleware entry to handler entry, including body
   arrival, multipart parsing, authentication and dependencies. It is not pure

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -848,3 +848,38 @@ followed by another wait on the original operation in
 [`AsyncConnection.wait()`](https://github.com/psycopg/psycopg/blob/3.3.5/psycopg/psycopg/connection_async.py).
 No driver migration is included without an independently verified ownership and
 network-stall contract.
+
+## Request stage attribution
+
+```bash
+scripts/test.sh backend tests/test_request_timing.py tests/test_request_stage_routes.py
+```
+
+Done: timing contracts pass with real PostgreSQL/API-key authentication and
+local storage for snapshot uploads; connector attribution tests explicitly mock
+authentication and the route-facing adapter calls.
+
+Slow/error request logs reuse the fixed, request-local `channel_stage` fields:
+
+- `pre_handler_ms`: timing middleware entry to handler entry, including body
+  arrival, multipart parsing, authentication and dependencies. It is not pure
+  authentication or time before ASGI entry; rejected dependencies never reach
+  the marker.
+- `upload_lookup_lock_ms`, `upload_spooled_read_ms`, `upload_analysis_ms`,
+  `upload_storage_ms`, `upload_index_ms`, `upload_commit_ms`: snapshot upload
+  lookup/fencing/row locks, already-parsed file reads, analysis, FileStore put,
+  search replacement and commit respectively. Index timing includes its SQL
+  and any autoflush; commit is the remaining transaction commit operation.
+- `connector_route_fetch_ms`: connected-list, available-catalog or single-item
+  adapter call, including cache/lock waits, SDK pagination, normalization and
+  any extra detail/auth-config calls. This is not vendor HTTP time.
+  `connector_invalidation_ms` covers connected-list MCP session invalidation;
+  `connector_response_build_ms` covers route response model construction,
+  excluding FastAPI wire serialization. Single-item models are built in fetch.
+
+Stages record elapsed wall time even when their block raises. Unreached stages
+are absent, not zero. They do not sum to end-to-end latency: middleware outside
+the timer, response serialization/sending and dependency cleanup are not all
+attributed. Existing slow/error-only logging, credential redaction and expected
+long-poll suppression remain in effect. Instrumentation establishes attribution,
+not a performance gain.


### PR DESCRIPTION
Slow Session uploads and connector reads currently expose only total request duration, leaving body/dependency waits, storage, index writes and SDK/cache work indistinguishable. Add fixed request-local stage timings to the existing slow/error logs so those waits can be attributed without capturing request content.

Upload stages cover middleware-to-handler time, lookup/fencing/row locks, spooled file reads, analysis, storage, search index replacement and commit. Connector stages cover the aggregate route adapter fetch, MCP session invalidation and response construction. Pre-handler time includes body parsing and dependencies; connector fetch includes SDK/cache/pagination work and is not vendor processing time. These stages are not a complete sum of response serialization, sending and cleanup.

Reuse the existing timing helper under a general request-stage name; preserve Telegram field names, finite numeric allowlisting, per-request isolation, credential path redaction, slow/error-only logging and expected long-poll suppression. No auth, CAS, transaction, cache, response schema or dependency changes. Instrumentation itself is not a latency improvement.

Validation: 16 route attribution cases and 155 related regressions passed initially; the final naming-only follow-up passed 58 focused cases, Ruff and strict typing of four production files. Upload tests use real API-key authentication/PostgreSQL/local storage; connector tests explicitly mock authentication and adapter responses. Full OpenAPI remained identical. Tests ran in isolated Python 3.14.7 / PG18.4 containers. Local lefthook is unavailable; checks were executed explicitly. Full Backend CI run34449923680 passed: 2,886 tests, 20 skipped and one expected failure, plus lint, strict typing, governance and generated-client checks. Fable reviewed final headfcb455118eec868261b423e8981c8f91cedec168 without blocking findings.
