### PR TITLE
perf(sessions): reuse safe projections and close rejected storage streams

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -3383,13 +3383,13 @@ async def get_session_messages(
         projected_items = projection.messages
         source_positions = projection.source_positions
     else:
-        filtered_timeline = [
-            (item, position)
-            for item, position in zip(
-                projection.timeline,
-                projection.timeline_source_positions,
-                strict=True,
-            )
+        projected_items = []
+        filtered_positions: list[int] = []
+        for item, position in zip(
+            projection.timeline,
+            projection.timeline_source_positions,
+            strict=True,
+        ):
             if (
                 (item.get("role") == "user" and "user" in included_categories)
                 or (item.get("role") == "assistant" and "assistant" in included_categories)
@@ -3397,10 +3397,10 @@ async def get_session_messages(
                     "tools" in included_categories
                     and item.get("kind") in ("tool_call", "tool_result")
                 )
-            )
-        ]
-        projected_items = [item for item, _ in filtered_timeline]
-        source_positions = tuple(position for _, position in filtered_timeline)
+            ):
+                projected_items.append(item)
+                filtered_positions.append(position)
+        source_positions = tuple(filtered_positions)
 
     total = len(projected_items)
     page_offset = offset

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -140,6 +140,7 @@ from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
     SessionContentUnavailable,
+    SessionMessageValue,
     load_session_content_projection,
     load_session_messages,
     session_has_uploaded_content,
@@ -3379,6 +3380,7 @@ async def get_session_messages(
     else:
         included_categories = frozenset((view,))
 
+    projected_items: list[SessionMessageValue]
     if included_categories is None:
         projected_items = projection.messages
         source_positions = projection.source_positions

--- a/backend/app/services/file_store_s3.py
+++ b/backend/app/services/file_store_s3.py
@@ -63,7 +63,6 @@ class _S3GetObjectResponse(BaseModel):
     )
 
     body: StreamingBody = Field(alias="Body")
-    response_metadata: _S3ResponseMetadata = Field(alias="ResponseMetadata")
 
 
 class _Boto3S3ObjectStoreClient:
@@ -126,11 +125,16 @@ class _Boto3S3ObjectStoreClient:
             raise S3ObjectStoreError("S3 object read failed") from exc
         except BotoCoreError as exc:
             raise S3ObjectStoreError("S3 object read failed") from exc
+        # Own the stream before validating metadata so rejection also closes it.
         try:
             body = _S3GetObjectResponse.model_validate(response).body
         except ValidationError:
-            raise S3ObjectStoreError("S3 returned an invalid object body")
+            raise S3ObjectStoreError("S3 returned an invalid object body") from None
         try:
+            try:
+                _S3OperationResponse.model_validate(response)
+            except ValidationError:
+                raise S3ObjectStoreError("S3 returned an invalid object body") from None
             try:
                 raw_data: object = body.read()
             except BotoCoreError as exc:

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -29,9 +29,7 @@ from app.models.session import Session, SessionEventChunk, SessionEventGeneratio
 from app.schemas.session_events import SessionEvent
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
-    project_safe_messages,
     project_safe_timeline,
-    project_visible_messages,
     validate_event_chunk_async,
 )
 
@@ -241,11 +239,21 @@ async def load_event_generation_projection(
         file_store=file_store,
         db=db,
     )
-    visible = project_visible_messages(events)
     timeline = project_safe_timeline(events)
+    # Reuse the sanitized text projection, retaining an explicit public-field allowlist.
+    messages = [item for item in timeline if item.kind == "message"]
     projection = SessionContentProjection(
-        messages=_SESSION_MESSAGES_ADAPTER.validate_python(project_safe_messages(events)),
-        source_positions=tuple(message.position for message in visible),
+        messages=_SESSION_MESSAGES_ADAPTER.validate_python(
+            [
+                {
+                    key: value
+                    for key, value in item.value.items()
+                    if key in ("role", "content", "model", "timestamp")
+                }
+                for item in messages
+            ]
+        ),
+        source_positions=tuple(item.position for item in messages),
         timeline=[item.value for item in timeline],
         timeline_source_positions=tuple(item.position for item in timeline),
     )

--- a/backend/tests/test_file_store_s3.py
+++ b/backend/tests/test_file_store_s3.py
@@ -7,9 +7,14 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import unquote, urlsplit
 
 import pytest
+from botocore.response import StreamingBody
 
 from app.services.file_store import S3FileStore
-from app.services.file_store_s3 import S3ObjectStoreError, _validate_operation_response
+from app.services.file_store_s3 import (
+    S3ObjectStoreError,
+    _Boto3S3ObjectStoreClient,
+    _validate_operation_response,
+)
 
 
 class _S3CompatibleHandler(BaseHTTPRequestHandler):
@@ -54,10 +59,12 @@ class _S3CompatibleHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         path = self._record()
-        if path.endswith("/truncated"):
+        if path.endswith(("/truncated", "/bad-checksum")):
             payload = b"short"
+            length = len(payload) + 1 if path.endswith("/truncated") else len(payload)
             self.send_response(HTTPStatus.OK)
-            self.send_header("Content-Length", str(len(payload) + 1))
+            self.send_header("Content-Length", str(length))
+            self.send_header("x-amz-checksum-crc32", "AAAAAA==")
             self.end_headers()
             self.wfile.write(payload)
             self.close_connection = True
@@ -197,13 +204,26 @@ def test_operation_response_metadata_fails_closed() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("key", ["truncated", "bad-checksum"])
 async def test_streaming_body_closes_after_read_failure(
     s3_store: tuple[S3FileStore, type[_S3CompatibleHandler]],
+    key: str,
 ) -> None:
     store, handler = s3_store
+    assert isinstance(store.client, _Boto3S3ObjectStoreClient)
+    bodies: list[StreamingBody] = []
+
+    def capture_body(parsed: dict[str, object], **kwargs: object) -> None:
+        body = parsed["Body"]
+        assert isinstance(body, StreamingBody)
+        bodies.append(body)
+
+    store.client._client.meta.events.register("after-call.s3.GetObject", capture_body)
 
     with pytest.raises(S3ObjectStoreError, match="S3 object stream failed"):
-        await store.get("truncated")
+        await store.get(key)
+    assert len(bodies) == 1
+    assert bodies[0]._raw_stream.closed
 
     await store.put("after-truncated", b"ok")
     assert await store.exists("after-truncated") is True
@@ -235,3 +255,27 @@ async def test_default_credential_chain(
     assert path == "/contract-bucket/default-chain"
     assert authorization is not None
     assert authorization.startswith("AWS4-HMAC-SHA256 Credential=chain-access-key/")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("metadata", [None, {"HTTPStatusCode": 500}, {"HTTPStatusCode": "200"}])
+async def test_stream_closes_when_response_metadata_is_rejected(
+    s3_store: tuple[S3FileStore, type[_S3CompatibleHandler]],
+    metadata: object,
+) -> None:
+    store, _ = s3_store
+    assert isinstance(store.client, _Boto3S3ObjectStoreClient)
+    bodies: list[StreamingBody] = []
+
+    def invalidate_metadata(parsed: dict[str, object], **kwargs: object) -> None:
+        body = parsed["Body"]
+        assert isinstance(body, StreamingBody)
+        bodies.append(body)
+        parsed["ResponseMetadata"] = metadata
+
+    await store.put("invalid-metadata", b"unread response body")
+    store.client._client.meta.events.register("after-call.s3.GetObject", invalidate_metadata)
+    with pytest.raises(S3ObjectStoreError, match="S3 returned an invalid object body"):
+        await store.get("invalid-metadata")
+    assert len(bodies) == 1
+    assert bodies[0]._raw_stream.closed


### PR DESCRIPTION
Session reads rebuild visible message text multiple times and allocate an intermediate tuple list on each filtered page. Reuse the already sanitized timeline text through an explicit public-field allowlist and build filtered items/positions in one pass. No new cache or worker is introduced; revision keys, source positions, privacy and pagination behavior remain.

Synthetic route-function measurements showed warm filtering 3.97→2.84 ms for long snapshots, 2.92→2.43 ms for nested snapshots, and 2.84→2.15 ms for event/tool content. Event retained allocation fell by 7.81 MiB through immutable string reuse. All 648 response comparisons matched. These fixtures exclude actual auth, SQL/network and wire serialization, so the percentages are not whole-page or production latency claims.

Also close an acquired S3 StreamingBody when strict response-metadata validation fails. Three SDK-hook regressions failed before and pass after the fix; ordinary SDK parsing normally supplies valid metadata, and no production incidence or speed gain is claimed. Checksums, retries, signing, endpoint settings and normal connection reuse are untouched.

Validation: 102 existing Session/privacy/search/share cases and 40 S3/URL cases passed in isolated Python 3.14.7 containers; Ruff/strict typing passed. An independent read-only review found no blockers in either final source diff. Root combined exact non-overlapping file changes into this four-file PR; raw measurement artifacts are archived separately. Combined focused verification passed 142 cases in 20.26 seconds; the two warnings are existing deprecated HTTP 422 constants. The final explicit list annotation uses the existing SessionMessageValue alias and passes the CI-equivalent strict exception and changed-production gates without relaxing diagnostics. Final Backend CI run34492273252 passed: 2,907 tests, 20 skips and one expected failure, plus lint, strict exception/changed/owned typing, governance and generated-client checks at ae9f3384a3d72e8e3a5ccb7c521526ca298d4eeb. Local lefthook is unavailable; checks were executed explicitly.
