### PR TITLE
perf(cli): reduce session synchronization work in 0.14.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.65 reduces local processing during session synchronization and avoids
+  repeated session-list scans when pushing large local histories.
+
 - Discord messages reach connected agents sooner, especially after idle periods.
 - Telegram agents receive available updates sooner when earlier updates have
   already been acknowledged or excluded by their requested update types.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.64",
+      "version": "0.14.65",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,11 +24,11 @@
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",
-		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' --define 'process.env.CLAWDI_DEFAULT_DEPLOY_API_URL=\"https://api.clawdi.ai\"'",
+		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --splitting --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' --define 'process.env.CLAWDI_DEFAULT_DEPLOY_API_URL=\"https://api.clawdi.ai\"'",
 		"build:native": "bun run scripts/build-native.mjs",
 		"build:native-release": "bun run scripts/build-native-release.mjs",
 		"package:native-release": "bun run scripts/package-native-release.mjs",
-		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node",
+		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node --splitting",
 		"check:publish-manifest": "node scripts/check-publish-manifest.mjs",
 		"check:native-release": "bun run scripts/check-native-release.mjs",
 		"typecheck": "tsc --noEmit",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.64",
+	"version": "0.14.65",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",
@@ -24,11 +24,11 @@
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",
-		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --splitting --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' --define 'process.env.CLAWDI_DEFAULT_DEPLOY_API_URL=\"https://api.clawdi.ai\"'",
+		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' --define 'process.env.CLAWDI_DEFAULT_DEPLOY_API_URL=\"https://api.clawdi.ai\"'",
 		"build:native": "bun run scripts/build-native.mjs",
 		"build:native-release": "bun run scripts/build-native-release.mjs",
 		"package:native-release": "bun run scripts/package-native-release.mjs",
-		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node --splitting",
+		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node",
 		"check:publish-manifest": "node scripts/check-publish-manifest.mjs",
 		"check:native-release": "bun run scripts/check-native-release.mjs",
 		"typecheck": "tsc --noEmit",

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -491,8 +491,9 @@ async function scanOneAgent(
 			);
 		});
 		sessionsCacheSkipped = before - sessions.length - sessionsBlocked;
+		const retainedSessionIds = new Set(sessions.map((session) => session.localSessionId));
 		for (const id of [...sessionPlans.keys()]) {
-			if (!sessions.some((session) => session.localSessionId === id)) sessionPlans.delete(id);
+			if (!retainedSessionIds.has(id)) sessionPlans.delete(id);
 		}
 	}
 

--- a/packages/cli/src/lib/session-upload.test.ts
+++ b/packages/cli/src/lib/session-upload.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RawSession, SessionEvent } from "../adapters/base";
 import { PiAdapter } from "../adapters/pi";
-import { ApiClient } from "./api-client";
+import { ApiClient, ApiError } from "./api-client";
 import {
 	advanceEventHead,
 	EMPTY_EVENT_HEAD,
@@ -170,6 +170,76 @@ describe("session upload negotiation and integrity", () => {
 });
 
 describe("events-v1 incremental upload", () => {
+	it.each([-1, 0, 1])(
+		"preserves canonical Unicode bytes at chunk budget boundary %i",
+		async (boundary) => {
+			const api = eventApi();
+			const first = event("one", "中文😀\ud800\n");
+			const content = [first, { ...first, seq: 1 }];
+			// Python json.dumps(ensure_ascii=True, sort_keys=True, separators=(",", ":")) golden.
+			const firstLine =
+				String.raw`{"event_id":"08e6ec3d75bc565a77dac73f766e3e985424d16fbb24077be436e230f09b3527","parts":[{"text":"\u4e2d\u6587\ud83d\ude00\ud800\n","type":"text"}],"role":"assistant","seq":0,"source":{"adapter":"pi","record_id":"one","session_key":"fixture"},"type":"message"}` +
+				"\n";
+			const secondLine = firstLine.replace('"seq":0', '"seq":1');
+			const finalHead = "c27463ce4d853bf824e5016c5a9393fa61ca18775e0aef99ea29cca185cab1c4";
+			const maxBytes = boundary === 1 ? firstLine.length * 2 : firstLine.length + boundary;
+			api.getSessionUploadCapabilities = async () => ({
+				protocols: ["events-v1"],
+				event_chunk_target_bytes: 1024 * 1024,
+				event_chunk_max_bytes: maxBytes,
+			});
+			api.getSessionEventHead = async () => ({
+				protocol: "events-v1",
+				generation: "11111111-1111-4111-8111-111111111111",
+				revision: 1,
+				count: 0,
+				head_hash: EMPTY_EVENT_HEAD,
+			});
+			const uploaded: Buffer[] = [];
+			api.appendSessionEvents = async (input) => {
+				uploaded.push(input.file);
+				expect(input.file.length).toBeLessThanOrEqual(maxBytes);
+				return {
+					generation: input.generation,
+					revision: input.baseRevision + 1,
+					count: input.finalCount,
+					head_hash: advanceEventHead(EMPTY_EVENT_HEAD, content.slice(0, input.finalCount)),
+				};
+			};
+			const session = rawSession(content);
+			const plan = planSessionUpload(session, "events-v1");
+			expect(plan.finalEventHead).toBe(finalHead);
+			const fence = sessionFence(api, {
+				environmentId: "agent-pi",
+				adapter: "pi",
+				sourceSessionKey: session.localSessionId,
+			});
+			const result = await syncSessionContent({
+				api,
+				fence,
+				session,
+				plan,
+				needsSnapshotContent: false,
+			});
+			const entry = readFencedSessionEntry(readSessionsLock(), fence);
+			if (boundary === -1) {
+				expect(result.status).toBe("blocked");
+				expect(uploaded).toHaveLength(0);
+				expect(entry?.blocked).toMatchObject({
+					code: "event_too_large",
+					size_bytes: firstLine.length,
+				});
+			} else {
+				expect(result.status).toBe("synced");
+				expect(uploaded).toHaveLength(boundary === 0 ? 2 : 1);
+				expect(Buffer.concat(uploaded).equals(Buffer.from(firstLine + secondLine, "ascii"))).toBe(
+					true,
+				);
+				expect(entry?.event_head_hash).toBe(finalHead);
+			}
+		},
+	);
+
 	it("does not mark a multi-chunk append complete before the final chunk", async () => {
 		const api = eventApi();
 		const content = events(["one", "a".repeat(700_000)], ["two", "b".repeat(700_000)]);
@@ -223,7 +293,7 @@ describe("events-v1 incremental upload", () => {
 		});
 	});
 
-	it("reuses the durable append id after a retry", async () => {
+	it("reuses the durable append id after a conflict and transport retry", async () => {
 		const api = eventApi();
 		const content = events(["one", "first"], ["two", "second"]);
 		const prefixHead = advanceEventHead(EMPTY_EVENT_HEAD, content.slice(0, 1));
@@ -239,6 +309,9 @@ describe("events-v1 incremental upload", () => {
 		let fail = true;
 		api.appendSessionEvents = async (input) => {
 			appendIds.push(input.appendId);
+			if (appendIds.length === 1) {
+				throw new ApiError({ status: 409, body: "conflict", hint: "retry" });
+			}
 			if (fail) throw new Error("connection reset after request");
 			return {
 				generation: input.generation,
@@ -271,11 +344,11 @@ describe("events-v1 incremental upload", () => {
 			needsSnapshotContent: false,
 		});
 		expect(result).toMatchObject({ status: "synced", localHash: finalHead });
-		expect(appendIds).toEqual([pendingAppendId, pendingAppendId]);
+		expect(appendIds).toEqual([pendingAppendId, pendingAppendId, pendingAppendId]);
 		expect(readFencedSessionEntry(readSessionsLock(), fence)?.pending).toBeUndefined();
 	});
 
-	it("rewrites a generation when the source is truncated", async () => {
+	it("rejects a mismatched rewrite receipt and resumes the staged generation", async () => {
 		const api = eventApi();
 		const remote = events(["old-one", "old first"], ["old-two", "old second"]);
 		const replacement = events(["new-one", "rewritten"]);
@@ -295,13 +368,14 @@ describe("events-v1 incremental upload", () => {
 			stagedGeneration = body.generation;
 			return { generation: body.generation, status: "staging" };
 		};
+		let corruptReceipt = true;
 		api.uploadSessionEventGenerationChunk = async (input) => ({
 			generation: input.generation,
 			start_seq: input.startSeq,
 			end_seq: input.startSeq,
 			count: 1,
 			content_hash: input.contentHash,
-			result_head_hash: finalHead,
+			result_head_hash: corruptReceipt ? "f".repeat(64) : finalHead,
 		});
 		api.commitSessionEventGeneration = async (_localSessionId, generation, body) => ({
 			generation,
@@ -317,6 +391,16 @@ describe("events-v1 incremental upload", () => {
 			sourceSessionKey: session.localSessionId,
 		});
 
+		await expect(
+			syncSessionContent({ api, fence, session, plan, needsSnapshotContent: false }),
+		).rejects.toThrow("server event chunk receipt does not match uploaded bytes");
+		const pendingGeneration = readFencedSessionEntry(readSessionsLock(), fence)?.pending
+			?.generation;
+		if (!pendingGeneration) throw new Error("expected a durable pending generation");
+		expect(pendingGeneration).toBe(stagedGeneration);
+		expect(readFencedSessionEntry(readSessionsLock(), fence)?.event_head_hash).toBeUndefined();
+		corruptReceipt = false;
+
 		const result = await syncSessionContent({
 			api,
 			fence,
@@ -324,6 +408,7 @@ describe("events-v1 incremental upload", () => {
 			plan,
 			needsSnapshotContent: false,
 		});
+		expect(stagedGeneration).toBe(pendingGeneration);
 		expect(result).toMatchObject({ status: "synced", localHash: finalHead });
 		expect(readFencedSessionEntry(readSessionsLock(), fence)).toMatchObject({
 			event_generation: stagedGeneration,

--- a/packages/cli/src/lib/session-upload.ts
+++ b/packages/cli/src/lib/session-upload.ts
@@ -2,12 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { RawSession, SessionEvent, SessionModule } from "../adapters/base";
 import { type ApiClient, ApiError } from "./api-client";
 import { canonicalApiOrigin } from "./api-origin";
-import {
-	advanceEventHead,
-	canonicalJson,
-	EMPTY_EVENT_HEAD,
-	encodeEventNdjson,
-} from "./session-events";
+import { advanceEventHead, canonicalJson, EMPTY_EVENT_HEAD } from "./session-events";
 import {
 	type PendingEventUpload,
 	persistFencedSessionEntry,
@@ -220,7 +215,7 @@ async function syncEventSession(input: {
 	if (capabilities === null) {
 		throw new Error("events-v1 capability disappeared after session negotiation");
 	}
-	const heads = eventHeads(events);
+	let heads: readonly string[] | undefined;
 	let uploaded = false;
 	for (let attempt = 0; attempt < EVENT_RETRY_LIMIT; attempt++) {
 		const remote = await input.api.getSessionEventHead(
@@ -239,6 +234,7 @@ async function syncEventSession(input: {
 			return { status: "synced", uploaded, localHash: finalHead };
 		}
 		try {
+			heads ??= eventHeads(events);
 			if (
 				head.protocol === "events-v1" &&
 				head.generation !== null &&
@@ -250,7 +246,7 @@ async function syncEventSession(input: {
 				persistEventSuccess(input, appendResult.head);
 				return { status: "synced", uploaded, localHash: finalHead };
 			}
-			const rewriteResult = await replaceEventGeneration(input, head, events, capabilities);
+			const rewriteResult = await replaceEventGeneration(input, head, events, heads, capabilities);
 			uploaded = uploaded || rewriteResult.uploaded;
 			persistEventSuccess(input, rewriteResult.head);
 			return { status: "synced", uploaded, localHash: finalHead };
@@ -336,6 +332,7 @@ async function replaceEventGeneration(
 	},
 	base: EventHead,
 	events: readonly SessionEvent[],
+	heads: readonly string[],
 	limits: { targetBytes: number; maxBytes: number },
 ): Promise<{ head: EventHead; uploaded: boolean }> {
 	const finalHead = input.plan.finalEventHead;
@@ -404,7 +401,6 @@ async function replaceEventGeneration(
 			uploaded: false,
 		};
 	}
-	const heads = eventHeads(events);
 	const chunks = chunkEvents(events, 0, limits, heads);
 	for (const chunk of chunks) {
 		const response = await input.api.uploadSessionEventGenerationChunk({
@@ -460,18 +456,21 @@ function chunkEvents(
 	while (index < events.length) {
 		const chunkStartIndex = index;
 		let size = 0;
+		const lines: string[] = [];
 		while (index < events.length) {
-			const lineSize = Buffer.byteLength(`${canonicalJson(events[index])}\n`, "ascii");
+			const line = `${canonicalJson(events[index])}\n`;
+			const lineSize = Buffer.byteLength(line, "ascii");
 			if (lineSize > limits.maxBytes) {
 				throw new EventTooLargeError(startSeq + index, lineSize, limits.maxBytes);
 			}
 			if (index > chunkStartIndex && size + lineSize > limits.targetBytes) break;
+			lines.push(line);
 			size += lineSize;
 			index += 1;
 		}
 		const chunkStart = startSeq + chunkStartIndex;
 		const selected = events.slice(chunkStartIndex, index);
-		const bytes = encodeEventNdjson(selected);
+		const bytes = Buffer.from(lines.join(""), "ascii");
 		if (bytes.length > limits.maxBytes) {
 			throw new EventTooLargeError(chunkStart, bytes.length, limits.maxBytes);
 		}


### PR DESCRIPTION
CLI session synchronization repeated prefix-hash calculation and canonical serialization, while large `clawdi push` inventories repeatedly scanned the retained session list. Version 0.14.65 computes prefix heads only when remote content differs, reuses those heads during rewriting/retries and canonical text within each chunk, and cleans retained plans using one ID set.

Upload eligibility, canonical bytes, hash chains, chunk limits, receipts, fenced persistence and concurrency are preserved. Planning retains no extra cache; package layout and build behavior stay the same.

Validation: final integrated CLI typecheck and all 158 focused tests passed in the canonical isolated Docker runner (2 CPU / 3 GiB). Byte/head comparisons also matched the backend canonicalization, including Unicode and surrogate cases. Full repository CI runs on this PR.

Controlled real-client/loopback content-sync measurements at 4,000 events: remote-unchanged 288→152 ms and rewrite 840→534 ms; short-tail append has no reliable material gain. Extracted plan-cleanup measurements at 20,000 retained sessions: Node 1933→4.8 ms, Bun 1092→6.1 ms. These are local synthetic measurements, not complete CLI or production latency. Cleanup adds O(n) temporary Set storage; no general memory reduction is claimed.
