### PR TITLE
fix(web): separate server auth admission from private data readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Signing in keeps the dashboard frame visible while account data loads, instead
+  of replacing the page with a full-screen loading indicator.
 - CLI 0.14.64 allows more time for Hermes version checks so slow native update
   checks do not interrupt agent setup or reconnection.
 - CLI 0.14.63 lets Hermes wait up to 20 minutes for Clawdi AI Responses calls,

--- a/apps/web/e2e/auth/clerk-fixture.ts
+++ b/apps/web/e2e/auth/clerk-fixture.ts
@@ -1,17 +1,35 @@
 import type { ClerkProvider as NativeClerkProvider } from "@clerk/tanstack-react-start";
+import { useRouter } from "@tanstack/react-router";
 import { type ComponentProps, useSyncExternalStore } from "react";
 
-let providerOptions: ComponentProps<typeof NativeClerkProvider> | undefined;
-
+let navigate: ((to: string) => Promise<void>) | undefined;
 export function ClerkProvider(props: ComponentProps<typeof NativeClerkProvider>) {
-	providerOptions = props;
+	const router = useRouter();
+	navigate = async (to) => {
+		if (props.routerPush) await props.routerPush(to);
+		else await router.navigate({ href: to });
+	};
 	return props.children;
 }
 
-export function navigateFromClerk(to: string, replace: boolean) {
-	const navigate = replace ? providerOptions?.routerReplace : providerOptions?.routerPush;
-	if (!navigate) throw new Error("Missing Clerk navigation override");
-	return navigate(to);
+// setActive updates the cookie before its transitive resource emission and
+// awaits framework navigation before publishing the newly active session.
+let serverState = { userId: "user-a", sessionId: "session-a" };
+export function serverAuth() {
+	return serverState;
+}
+let activation: ReturnType<typeof Promise.withResolvers<void>> | undefined;
+export function releaseActivation() {
+	activation?.resolve();
+}
+export async function activateSession(to: string) {
+	activation = Promise.withResolvers<void>();
+	serverState = { userId: "user-a", sessionId: "session-a" };
+	emitSdk({ isLoaded: false });
+	if (!navigate) throw new Error("Missing native navigation");
+	await navigate(to);
+	await activation.promise;
+	emitSdk({ isLoaded: true, ...serverState });
 }
 
 // SDK contract fixture: resource emissions and status events are independent.
@@ -23,6 +41,7 @@ export type SdkState = {
 	sessionId: string | null;
 	pending: boolean;
 	tokenFailure: boolean;
+	nullToken: boolean;
 };
 const initial: SdkState = {
 	status: "ready",
@@ -31,6 +50,7 @@ const initial: SdkState = {
 	sessionId: "session-a",
 	pending: false,
 	tokenFailure: false,
+	nullToken: false,
 };
 let state = initial;
 const resources = new Set<() => void>();
@@ -39,6 +59,11 @@ export let signOutCalls = 0;
 
 export function emitSdk(update: Partial<SdkState>) {
 	state = { ...state, ...update };
+	if (state.isLoaded)
+		serverState = {
+			userId: state.pending ? "" : (state.userId ?? ""),
+			sessionId: state.pending ? "" : (state.sessionId ?? ""),
+		};
 	if (Object.keys(update).some((key) => key !== "status")) {
 		for (const listener of resources) listener();
 	}
@@ -75,7 +100,37 @@ export function useAuth({ treatPendingAsSignedOut = true } = {}) {
 	};
 }
 
+const sessionResources = new Map<
+	string,
+	{ id: string; user: { id: string | null }; getToken: () => Promise<string | null> }
+>();
+export function useSession() {
+	const auth = useAuth();
+	const resourceReady = useSyncExternalStore(
+		subscribe,
+		() => state.status !== "loading" && state.isLoaded,
+		() => false,
+	);
+	const sessionId = resourceReady ? auth.sessionId : null;
+	let session = sessionId ? sessionResources.get(sessionId) : undefined;
+	if (sessionId && !session) {
+		const token = `${auth.userId}:${auth.sessionId}`;
+		session = {
+			id: sessionId,
+			user: { id: auth.userId },
+			getToken: async () => {
+				if (state.tokenFailure) throw new TypeError("Token refresh unavailable");
+				return state.nullToken ? null : token;
+			},
+		};
+		sessionResources.set(sessionId, session);
+	}
+	return { isLoaded: resourceReady, session };
+}
 const clerk = {
+	get session() {
+		return state.isLoaded && state.sessionId ? { id: state.sessionId } : undefined;
+	},
 	get status() {
 		return state.status;
 	},

--- a/apps/web/e2e/auth/clerk-fixture.ts
+++ b/apps/web/e2e/auth/clerk-fixture.ts
@@ -1,4 +1,18 @@
-import { useSyncExternalStore } from "react";
+import type { ClerkProvider as NativeClerkProvider } from "@clerk/tanstack-react-start";
+import { type ComponentProps, useSyncExternalStore } from "react";
+
+let providerOptions: ComponentProps<typeof NativeClerkProvider> | undefined;
+
+export function ClerkProvider(props: ComponentProps<typeof NativeClerkProvider>) {
+	providerOptions = props;
+	return props.children;
+}
+
+export function navigateFromClerk(to: string, replace: boolean) {
+	const navigate = replace ? providerOptions?.routerReplace : providerOptions?.routerPush;
+	if (!navigate) throw new Error("Missing Clerk navigation override");
+	return navigate(to);
+}
 
 // SDK contract fixture: resource emissions and status events are independent.
 // No credentials or Clerk network requests are used by this browser suite.

--- a/apps/web/e2e/auth/hydration.browser.tsx
+++ b/apps/web/e2e/auth/hydration.browser.tsx
@@ -1,86 +1,75 @@
-import { useQueryClient } from "@tanstack/react-query";
 import {
 	createMemoryHistory,
-	createRootRouteWithContext,
+	createRootRoute,
 	createRoute,
 	createRouter,
 	Outlet,
 	RouterProvider,
 } from "@tanstack/react-router";
 import { hydrate } from "@tanstack/react-router/ssr/client";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useLayoutEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
+import { AccountDataBoundary } from "@/components/account-suspension-boundary";
 import { AuthRouterBridge } from "@/components/auth-router-bridge";
 import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
-import { useRouteAuth } from "@/lib/auth-client";
-import { type AppRouterContext, type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
+import { type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
 import { useHydrated } from "@/lib/use-hydrated";
-import { emitSdk } from "./clerk-fixture";
+import { emitSdk, serverAuth as readServerAuth } from "./clerk-fixture";
 
 const serverAuth: RouteAuth = { status: "signed-in", userId: "user-a", sessionId: "session-a" };
-const observations: { status: RouteAuth["status"]; sameClient: boolean; cached: boolean }[] = [];
 const errors: string[] = [];
-let mounts = 0;
-let unmounts = 0;
 let hydrated = false;
-let originalClient: ReturnType<typeof useQueryClient> | undefined;
 
-function CacheProbe() {
-	const client = useQueryClient();
-	const auth = useRouteAuth();
+function HydrationProbe() {
 	const isHydrated = useHydrated();
-	const [firstClient] = useState(() => {
-		client.setQueryData(["hydration-probe"], "fixture-cache");
-		originalClient = client;
-		return client;
-	});
 	useLayoutEffect(() => {
 		hydrated = isHydrated;
-		observations.push({
-			status: auth.status,
-			sameClient: client === firstClient,
-			cached: client.getQueryData(["hydration-probe"]) === "fixture-cache",
-		});
 	});
 	return <Outlet />;
 }
 
 function DocumentProbe() {
-	useEffect(() => {
-		mounts += 1;
-		return () => {
-			unmounts += 1;
-		};
-	}, []);
 	return (
-		<main data-hydration-private>
-			<h1>Server-admitted document</h1>
-			<iframe
-				title="SSR runtime"
-				srcDoc="<!doctype html><textarea aria-label='Runtime draft'></textarea>"
-			/>
-		</main>
+		<iframe
+			title="SSR runtime"
+			srcDoc="<!doctype html><textarea aria-label='Runtime draft'></textarea>"
+		/>
 	);
 }
 
 function createProbeRouter(isServer: boolean) {
-	const root = createRootRouteWithContext<AppRouterContext>()({
+	const root = createRootRoute({
 		component: () => (
 			<AuthRouterBridge>
-				<CacheProbe />
+				<HydrationProbe />
 			</AuthRouterBridge>
 		),
 	});
 	const protectedRoute = createRoute({
 		getParentRoute: () => root,
 		id: "_protected",
-		beforeLoad: ({ context, location }) => ({
-			authIdentity: requireRouteIdentity(context.auth, location.href),
-		}),
+		beforeLoad: ({ location }) => {
+			const { userId, sessionId } = readServerAuth();
+			return {
+				authIdentity: requireRouteIdentity(
+					isServer
+						? serverAuth
+						: userId && sessionId
+							? { status: "signed-in", userId, sessionId }
+							: { status: "signed-out" },
+					location.href,
+				),
+			};
+		},
 		errorComponent: ProtectedRouteError,
 		component: () => (
 			<ProtectedAuthBoundary identity={protectedRoute.useRouteContext().authIdentity}>
-				<Outlet />
+				<header>
+					<h1>Server-admitted document</h1>
+				</header>
+				<AccountDataBoundary>
+					<Outlet />
+				</AccountDataBoundary>
 			</ProtectedAuthBoundary>
 		),
 	});
@@ -98,7 +87,6 @@ function createProbeRouter(isServer: boolean) {
 		routeTree: root.addChildren([protectedRoute.addChildren([index]), signIn]),
 		history: createMemoryHistory({ initialEntries: ["/"] }),
 		isServer,
-		context: { auth: isServer ? serverAuth : undefined },
 	});
 	return router;
 }
@@ -125,20 +113,10 @@ if (typeof document !== "undefined") {
 	const element = document.getElementById("app");
 	if (!element) throw new Error("Missing hydration root");
 	window.hydrationTest = {
-		observations,
 		errors,
 		emitSdk,
 		get hydrated() {
 			return hydrated;
-		},
-		get originalCached() {
-			return originalClient?.getQueryData(["hydration-probe"]) === "fixture-cache";
-		},
-		get mounts() {
-			return mounts;
-		},
-		get unmounts() {
-			return unmounts;
 		},
 	};
 	if (new URLSearchParams(location.search).get("sdk") === "loading") emitSdk({ status: "loading" });
@@ -157,11 +135,7 @@ declare global {
 	interface Window {
 		hydrationTest: {
 			hydrated: boolean;
-			originalCached: boolean;
-			observations: typeof observations;
 			errors: string[];
-			mounts: number;
-			unmounts: number;
 			emitSdk: typeof emitSdk;
 		};
 	}

--- a/apps/web/e2e/auth/hydration.pw.ts
+++ b/apps/web/e2e/auth/hydration.pw.ts
@@ -1,98 +1,53 @@
 import { expect, test } from "@playwright/test";
-import type { SdkState } from "./clerk-fixture";
 import type {} from "./hydration.browser";
 
-const scenarios: { sdk: "ready" | "loading"; update?: Partial<SdkState> }[] = [
-	{ sdk: "ready" },
-	{ sdk: "loading" },
-	{ sdk: "loading", update: { userId: null, sessionId: null } },
-	{ sdk: "loading", update: { pending: true } },
-	{ sdk: "loading", update: { userId: "user-b", sessionId: "session-b" } },
-	{ sdk: "loading", update: { sessionId: "session-b" } },
-];
-
-for (const { sdk, update } of scenarios) {
-	test(`SSR hydration retains SDK ${sdk} until ${JSON.stringify(update) ?? "ready"}`, async ({
+for (const signedOut of [false, true]) {
+	test(`SSR frame hydrates without session resources, then ${signedOut ? "signs out" : "activates"}`, async ({
 		page,
-	}, info) => {
+	}) => {
+		const requests: string[] = [];
+		await page.route("http://127.0.0.1:8000/**", (route) => {
+			requests.push(route.request().headers().authorization ?? "missing");
+			return route.fulfill({ contentType: "application/json", body: "{}" });
+		});
 		const entry = Promise.withResolvers<void>();
 		await page.route("**/e2e/auth/hydration.browser.tsx", async (route) => {
 			await entry.promise;
 			await route.continue();
 		});
 		try {
-			await page.goto(`/__auth-hydration?sdk=${sdk}`, { waitUntil: "commit" });
+			await page.goto("/__auth-hydration?sdk=loading", { waitUntil: "commit" });
 			await expect(page.getByRole("heading")).toHaveText("Server-admitted document");
-			await page.frameLocator("iframe").getByRole("textbox").fill("before hydration");
-			const frame = await page.locator("iframe").elementHandle();
-			if (!frame) throw new Error("Missing SSR iframe");
+			const header = await page.locator("header").elementHandle();
+			if (!header) throw new Error("Missing SSR header");
+			await expect(page.locator("iframe")).toHaveCount(0);
 			entry.resolve();
-			await expect
-				.poll(() => page.evaluate(() => window.hydrationTest?.observations.length ?? 0))
-				.toBeGreaterThan(0);
-			await expect.poll(() => page.evaluate(() => window.hydrationTest.mounts)).toBe(1);
-			// Wait for the post-hydration client snapshot, not just getServerSnapshot.
-			await expect.poll(() => page.evaluate(() => window.hydrationTest.hydrated)).toBe(true);
-			await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue(
-				"before hydration",
-			);
-			expect(await frame.evaluate((node) => node === document.querySelector("iframe"))).toBe(true);
-			const retained = await page.evaluate(() => ({ ...window.hydrationTest, emitSdk: undefined }));
-			expect(retained.errors).toEqual([]);
-			expect(retained.unmounts).toBe(0);
-			expect(
-				retained.observations.every(
-					(row) => row.sameClient && row.cached && row.status === "signed-in",
-				),
-			).toBe(true);
+			await expect.poll(() => page.evaluate(() => window.hydrationTest?.hydrated)).toBe(true);
+			expect(await page.evaluate(() => window.hydrationTest.errors)).toEqual([]);
+			expect(await header.evaluate((node) => node === document.querySelector("header"))).toBe(true);
+			expect(requests).toEqual([]);
 			await page.evaluate(
-				(update) => window.hydrationTest.emitSdk({ status: "ready", ...update }),
-				update,
+				(signedOut) =>
+					window.hydrationTest.emitSdk({
+						status: "ready",
+						...(signedOut ? { userId: null, sessionId: null } : {}),
+					}),
+				signedOut,
 			);
-			if (update) {
-				await expect.poll(() => page.evaluate(() => window.hydrationTest.unmounts)).toBe(1);
-				expect(await frame.evaluate((node) => node.isConnected)).toBe(false);
-				await expect
-					.poll(() => page.evaluate(() => window.hydrationTest.originalCached))
-					.toBe(false);
-				if (update.pending || update.userId === null) {
-					await expect(page.locator("iframe")).toHaveCount(0);
-					await expect(page.getByRole("heading")).toHaveText("Sign in");
-				} else {
-					await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue("");
-					expect(
-						await page.evaluate(() =>
-							window.hydrationTest.observations.some((row) => !row.sameClient && !row.cached),
-						),
-					).toBe(true);
-				}
+			if (signedOut) {
+				await expect(page.getByRole("heading")).toHaveText("Sign in");
+				await expect(page.locator("iframe")).toHaveCount(0);
+				expect(requests).toEqual([]);
 			} else {
-				await expect(page.frameLocator("iframe").getByRole("textbox")).toHaveValue(
-					"before hydration",
-				);
-				expect(await frame.evaluate((node) => node === document.querySelector("iframe"))).toBe(
+				await expect(page.locator("iframe")).toBeVisible();
+				expect(await header.evaluate((node) => node === document.querySelector("header"))).toBe(
 					true,
 				);
-				expect(await page.evaluate(() => window.hydrationTest.unmounts)).toBe(0);
+				await expect.poll(() => requests.length).toBeGreaterThan(0);
+				expect(requests.every((token) => token === "Bearer user-a:session-a")).toBe(true);
 			}
-			const result = await page.evaluate(() => ({ ...window.hydrationTest, emitSdk: undefined }));
-			expect(result.errors).toEqual([]);
-			await info.attach("hydration-observations", {
-				body: JSON.stringify(result, null, 2),
-				contentType: "application/json",
-			});
 		} finally {
 			entry.resolve();
-			await info.attach("hydration-diagnostics", {
-				body: JSON.stringify(
-					await page.evaluate(() =>
-						window.hydrationTest ? { ...window.hydrationTest, emitSdk: undefined } : null,
-					),
-					null,
-					2,
-				),
-				contentType: "application/json",
-			});
 		}
 	});
 }

--- a/apps/web/e2e/auth/lifecycle.browser.tsx
+++ b/apps/web/e2e/auth/lifecycle.browser.tsx
@@ -1,6 +1,6 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-	createRootRouteWithContext,
+	createRootRoute,
 	createRoute,
 	createRouter,
 	Link,
@@ -9,42 +9,55 @@ import {
 } from "@tanstack/react-router";
 import { useLayoutEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
 import { AuthProvider } from "@/components/auth-provider";
-import { AuthRouterBridge } from "@/components/auth-router-bridge";
 import { AuthStatus } from "@/components/auth-status";
 import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
+import { Providers } from "@/components/providers";
 import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
+import { useApi } from "@/lib/api";
 import { ApiError, normalizeApiError } from "@/lib/api-errors";
 import { useAuthToken, useRouteAuth } from "@/lib/auth-client";
+import { RouteAuthUnavailable, requireRouteIdentity } from "@/lib/route-auth";
+import DashboardLayout from "@/pages/dashboard/layout";
+import SharePage from "@/pages/share/project-share-page";
 import {
-	type AppRouterContext,
-	RouteAuthUnavailable,
-	requireRouteIdentity,
-} from "@/lib/route-auth";
-import { emitSdk, navigateFromClerk, signOutCalls } from "./clerk-fixture";
+	activateSession,
+	emitSdk,
+	releaseActivation,
+	serverAuth,
+	signOutCalls,
+} from "./clerk-fixture";
 import "@/styles/globals.css";
 
 const commits: { identity: string | null; data: string | undefined }[] = [];
 let currentClient: ReturnType<typeof useQueryClient> | undefined;
 let held: ReturnType<typeof Promise.withResolvers<string>> | undefined;
 let abortedPreload = false;
+let savedGetToken: (() => Promise<string>) | undefined;
+let currentGetToken: (() => Promise<string>) | undefined;
+let mutate: (() => Promise<unknown>) | undefined;
 
-const root = createRootRouteWithContext<AppRouterContext>()({
+const root = createRootRoute({
 	component: () => (
 		<AuthProvider>
-			<AuthRouterBridge>
+			<Providers>
 				<Outlet />
-			</AuthRouterBridge>
+			</Providers>
 		</AuthProvider>
 	),
 });
 const protectedRoute = createRoute({
 	getParentRoute: () => root,
 	id: "_protected",
-	beforeLoad: ({ context, location }) => ({
-		authIdentity: requireRouteIdentity(context.auth, location.href),
-	}),
+	beforeLoad: async ({ location }) => {
+		const { userId, sessionId } = serverAuth();
+		return {
+			authIdentity: requireRouteIdentity(
+				userId && sessionId ? { status: "signed-in", userId, sessionId } : { status: "signed-out" },
+				location.href,
+			),
+		};
+	},
 	errorComponent: ({ error }) =>
 		error instanceof RouteAuthUnavailable ? (
 			<AuthStatus status={error.status} />
@@ -55,20 +68,27 @@ const protectedRoute = createRoute({
 		const { authIdentity } = protectedRoute.useRouteContext();
 		return (
 			<ProtectedAuthBoundary identity={authIdentity}>
-				<AccountSuspensionBoundary>
-					<PrivatePane />
-				</AccountSuspensionBoundary>
+				<Outlet />
 			</ProtectedAuthBoundary>
 		);
 	},
 });
-const a = createRoute({
+const dashboard = createRoute({
 	getParentRoute: () => protectedRoute,
+	id: "_dashboard",
+	component: () => (
+		<DashboardLayout>
+			<PrivatePane />
+		</DashboardLayout>
+	),
+});
+const a = createRoute({
+	getParentRoute: () => dashboard,
 	path: "/private/a",
 	component: () => <h1>Destination A</h1>,
 });
 const b = createRoute({
-	getParentRoute: () => protectedRoute,
+	getParentRoute: () => dashboard,
 	path: "/private/b",
 	loader: async ({ abortController }) => {
 		const pending = held;
@@ -96,9 +116,18 @@ const publicRoute = createRoute({
 	path: "/public",
 	component: () => <h1>Public content</h1>,
 });
+const share = createRoute({
+	getParentRoute: () => root,
+	path: "/share/fixture",
+	component: () => <SharePage token="fixture" />,
+});
 const router = createRouter({
-	routeTree: root.addChildren([protectedRoute.addChildren([a, b]), signIn, publicRoute]),
-	context: { auth: undefined },
+	routeTree: root.addChildren([
+		protectedRoute.addChildren([dashboard.addChildren([a, b])]),
+		signIn,
+		publicRoute,
+		share,
+	]),
 	defaultPreload: "intent",
 });
 
@@ -106,6 +135,14 @@ function PrivatePane() {
 	const auth = useRouteAuth();
 	const { getToken } = useAuthToken();
 	const client = useQueryClient();
+	const api = useApi();
+	const mutation = useMutation({
+		mutationFn: () =>
+			api.POST("/v1/me/invitations/{invitation_id}/decline", {
+				params: { path: { invitation_id: "fixture" } },
+			}),
+		onSuccess: () => client.setQueryData(["old-mutation"], "old-account-result"),
+	});
 	const [draft, setDraft] = useState("");
 	const data = useQuery({
 		queryKey: ["private-destination"],
@@ -122,6 +159,8 @@ function PrivatePane() {
 	});
 	useLayoutEffect(() => {
 		currentClient = client;
+		currentGetToken = getToken;
+		mutate = mutation.mutateAsync;
 		commits.push({
 			identity: auth.status === "signed-in" ? `${auth.userId}:${auth.sessionId}` : null,
 			data: data.data,
@@ -152,7 +191,8 @@ function PrivatePane() {
 
 window.authTest = {
 	emitSdk,
-	navigateFromClerk,
+	activateSession,
+	releaseActivation,
 	commits,
 	navigate: (to) => router.navigate({ to }),
 	holdPreload: () => {
@@ -163,6 +203,20 @@ window.authTest = {
 	releasePreload: () => {
 		held?.resolve("old-generation");
 		held = undefined;
+	},
+	saveCredentials: () => {
+		savedGetToken = currentGetToken;
+	},
+	useSavedCredentials: async () => {
+		try {
+			return await savedGetToken?.();
+		} catch {
+			return "retired";
+		}
+	},
+	mutate: () => mutate?.(),
+	get oldMutationPublished() {
+		return currentClient?.getQueryData(["old-mutation"]) !== undefined;
 	},
 	get abortedPreload() {
 		return abortedPreload;
@@ -176,11 +230,16 @@ declare global {
 	interface Window {
 		authTest: {
 			emitSdk: typeof emitSdk;
-			navigateFromClerk: typeof navigateFromClerk;
+			activateSession: typeof activateSession;
+			releaseActivation: typeof releaseActivation;
 			commits: typeof commits;
 			navigate: (to: string) => Promise<void>;
 			holdPreload: () => void;
 			releasePreload: () => void;
+			saveCredentials: () => void;
+			useSavedCredentials: () => Promise<string | undefined>;
+			mutate: () => Promise<unknown> | undefined;
+			oldMutationPublished: boolean;
 			abortedPreload: boolean;
 			signOutCalls: number;
 			refetch: () => Promise<void> | undefined;

--- a/apps/web/e2e/auth/lifecycle.browser.tsx
+++ b/apps/web/e2e/auth/lifecycle.browser.tsx
@@ -10,6 +10,7 @@ import {
 import { useLayoutEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
+import { AuthProvider } from "@/components/auth-provider";
 import { AuthRouterBridge } from "@/components/auth-router-bridge";
 import { AuthStatus } from "@/components/auth-status";
 import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
@@ -21,7 +22,7 @@ import {
 	RouteAuthUnavailable,
 	requireRouteIdentity,
 } from "@/lib/route-auth";
-import { emitSdk, signOutCalls } from "./clerk-fixture";
+import { emitSdk, navigateFromClerk, signOutCalls } from "./clerk-fixture";
 import "@/styles/globals.css";
 
 const commits: { identity: string | null; data: string | undefined }[] = [];
@@ -31,9 +32,11 @@ let abortedPreload = false;
 
 const root = createRootRouteWithContext<AppRouterContext>()({
 	component: () => (
-		<AuthRouterBridge>
-			<Outlet />
-		</AuthRouterBridge>
+		<AuthProvider>
+			<AuthRouterBridge>
+				<Outlet />
+			</AuthRouterBridge>
+		</AuthProvider>
 	),
 });
 const protectedRoute = createRoute({
@@ -149,6 +152,7 @@ function PrivatePane() {
 
 window.authTest = {
 	emitSdk,
+	navigateFromClerk,
 	commits,
 	navigate: (to) => router.navigate({ to }),
 	holdPreload: () => {
@@ -172,6 +176,7 @@ declare global {
 	interface Window {
 		authTest: {
 			emitSdk: typeof emitSdk;
+			navigateFromClerk: typeof navigateFromClerk;
 			commits: typeof commits;
 			navigate: (to: string) => Promise<void>;
 			holdPreload: () => void;

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -1,65 +1,15 @@
 import { expect, type Page, test } from "@playwright/test";
 import type {} from "./lifecycle.browser";
 
-for (const replace of [false, true]) {
-	test(`Clerk ${replace ? "replace" : "push"} enters through a document request during activation`, async ({
-		page,
-	}) => {
-		await page.goto("/e2e/auth/");
-		await page.evaluate(() => window.authTest.navigate("/public"));
-		await page.evaluate(async () => {
-			window.authTest.emitSdk({ userId: null, sessionId: null });
-			await window.authTest.navigate("/sign-in");
-		});
-		await expect(page.getByRole("heading")).toHaveText("Sign in");
-		const response = Promise.withResolvers<void>();
-		const requested = Promise.withResolvers<void>();
-		const path = "/private/a?view=all&redirect_url=%2Fagents#details";
-		await page.route("**/private/a?*", async (route) => {
-			expect(route.request().isNavigationRequest()).toBe(true);
-			requested.resolve();
-			await response.promise;
-			await route.fulfill({ contentType: "text/html", body: "<h1>Document destination</h1>" });
-		});
-		try {
-			const retained = await page.evaluate(
-				({ path, replace }) => {
-					// Match setActive's transitive emission before invoking the actual
-					// AuthProvider callbacks. Clerk publishes the new session afterwards.
-					window.authTest.emitSdk({ isLoaded: false });
-					window.authTest.navigateFromClerk(
-						replace ? new URL(path, location.origin).href : path,
-						replace,
-					);
-					return {
-						heading: document.querySelector("h1")?.textContent,
-						loading: document.querySelector('[aria-label="Loading session"]') !== null,
-					};
-				},
-				{ path, replace },
-			);
-			await requested.promise;
-			expect(retained).toEqual({ heading: "Sign in", loading: false });
-			response.resolve();
-			await expect(page.getByRole("heading")).toHaveText("Document destination");
-			expect(
-				new URL(page.url()).pathname + new URL(page.url()).search + new URL(page.url()).hash,
-			).toBe(path);
-			await page.goBack();
-			await expect(page).toHaveURL(new RegExp(replace ? "/public$" : "/sign-in$"));
-		} finally {
-			response.resolve();
-		}
-	});
-}
-
 async function start(page: Page) {
 	await page.route("http://127.0.0.1:8000/**", (route) =>
 		route.fulfill({
 			contentType: "application/json",
 			body: route.request().url().endsWith("private-data")
 				? route.request().headers().authorization?.replace("Bearer ", "")
-				: "{}",
+				: route.request().url().endsWith("/v1/auth/me")
+					? "{}"
+					: "[]",
 		}),
 	);
 	await page.goto("/e2e/auth/");
@@ -74,11 +24,11 @@ test("same identity keeps cache, draft and iframe document across navigation and
 	const frame = page.frameLocator("iframe");
 	await frame.getByRole("textbox").fill("retained-runtime-draft");
 	await page.getByRole("link", { name: "B", exact: true }).click();
-	await expect(page.getByRole("heading")).toHaveText("Destination B");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Destination B");
 	await page.goBack();
-	await expect(page.getByRole("heading")).toHaveText("Destination A");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Destination A");
 	await page.goForward();
-	await expect(page.getByRole("heading")).toHaveText("Destination B");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Destination B");
 	await expect(frame.getByRole("textbox")).toHaveValue("retained-runtime-draft");
 	await page.getByRole("textbox", { name: "Draft", exact: true }).fill("unsaved");
 	await page.getByRole("link", { name: "A", exact: true }).click();
@@ -93,15 +43,15 @@ test("public routes stay available while loading and signed-out client navigatio
 	await page.goto("/e2e/auth/");
 	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: false }));
 	await page.evaluate(() => window.authTest.navigate("/private/a"));
-	await expect(page.locator("main")).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+	await expect(page.locator("[data-private]")).toHaveCount(0);
+	await expect(page.locator("iframe")).toHaveCount(0);
 	await page.evaluate(() => window.authTest.navigate("/public"));
-	await expect(page.getByRole("heading")).toHaveText("Public content");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Public content");
 	await page.evaluate(() =>
 		window.authTest.emitSdk({ isLoaded: true, userId: null, sessionId: null }),
 	);
 	await page.evaluate(() => window.authTest.navigate("/private/a"));
-	await expect(page.getByRole("heading")).toHaveText("Sign in");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sign in");
 	await expect(page.locator("[data-private]")).toHaveCount(0);
 });
 
@@ -138,11 +88,11 @@ for (const update of [{ userId: null, sessionId: null }, { pending: true }]) {
 		await page.evaluate(() => window.authTest.navigate("/private/b"));
 		await page.evaluate((update) => window.authTest.emitSdk(update), update);
 		await expect(page.locator("iframe")).toHaveCount(0);
-		await expect(page.getByRole("heading")).toHaveText("Sign in");
+		await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sign in");
 		await page.goBack();
 		await expect(page.locator("[data-private]")).toHaveCount(0);
 		await page.evaluate(() => window.authTest.navigate("/public"));
-		await expect(page.getByRole("heading")).toHaveText("Public content");
+		await expect(page.getByRole("heading", { level: 1 })).toHaveText("Public content");
 	});
 }
 
@@ -153,7 +103,7 @@ for (const status of ["degraded", "error"] as const) {
 		await start(page);
 		await page.evaluate((status) => window.authTest.emitSdk({ status }), status);
 		await expect(page.locator("iframe")).toHaveCount(0);
-		await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+		await expect(page.locator("iframe")).toHaveCount(0);
 		expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
 		await page.evaluate(() => window.authTest.emitSdk({ status: "ready" }));
 		await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
@@ -166,7 +116,7 @@ test("native unknown auth removes an admitted session independently of script st
 	await start(page);
 	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: false }));
 	await expect(page.locator("iframe")).toHaveCount(0);
-	await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
+	await expect(page.locator("iframe")).toHaveCount(0);
 	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
 	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: true }));
 	await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
@@ -230,6 +180,129 @@ test("401 account admission is denied; resource 403 and refresh/network failures
 	await expect(page.getByRole("button", { name: "Sign in again", exact: true })).toBeVisible();
 	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
 	await page.getByRole("button", { name: "Sign in again", exact: true }).click();
-	await expect(page.getByRole("heading")).toHaveText("Sign in");
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sign in");
 	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(1);
+});
+
+// Simulated SDK resource/cookie events, real production layout and Router.
+// The activation checkpoint represents setActive awaiting native SPA navigation.
+test("native SPA activation admits the real dashboard frame before private session resources", async ({
+	page,
+}, info) => {
+	const requests: string[] = [];
+	await page.route("http://127.0.0.1:50021/**", (route) => {
+		requests.push(route.request().headers().authorization ?? "missing");
+		return route.fulfill({ status: 503, body: "Unavailable" });
+	});
+	await page.route("http://127.0.0.1:8000/**", (route) => {
+		requests.push(route.request().headers().authorization ?? "missing");
+		return route.fulfill({
+			contentType: "application/json",
+			body: route.request().url().endsWith("private-data")
+				? "user-a:session-a"
+				: route.request().url().endsWith("/v1/auth/me")
+					? "{}"
+					: "[]",
+		});
+	});
+	await page.goto("/e2e/auth/");
+	await page.evaluate(async () => {
+		window.authTest.emitSdk({ userId: null, sessionId: null });
+		await window.authTest.navigate("/sign-in");
+		void window.authTest.activateSession("/private/a");
+	});
+	await expect(page.getByTestId("app-sidebar")).toBeVisible();
+	await expect(page.locator("header")).toBeVisible();
+	await expect(page.getByTestId("dashboard-page-content")).toBeVisible();
+	await expect(page.locator("iframe")).toHaveCount(0);
+	await expect(page.getByTestId("app-sidebar-user-menu-button")).toBeDisabled();
+	await page.keyboard.press("Control+k");
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+	expect(requests).toEqual([]);
+	await info.attach("activation-frame", {
+		body: await page.screenshot(),
+		contentType: "image/png",
+	});
+	await page.evaluate(() => window.authTest.releaseActivation());
+	await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
+	expect(requests.length).toBeGreaterThan(0);
+	expect(requests.every((token) => token === "Bearer user-a:session-a")).toBe(true);
+	await page.goBack();
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sign in");
+});
+
+test("null native session token never reaches the API", async ({ page }) => {
+	await start(page);
+	let requests = 0;
+	await page.route("http://127.0.0.1:8000/**", (route) => {
+		requests++;
+		return route.fallback();
+	});
+	await page.evaluate(() => window.authTest.emitSdk({ nullToken: true }));
+	await page.evaluate(() => window.authTest.refetch());
+	await expect(page.getByRole("button", { name: "Sign in again" })).toBeVisible();
+	expect(requests).toBe(0);
+});
+
+test("retired credentials and late mutation suspension cannot affect the next account", async ({
+	page,
+}) => {
+	await start(page);
+	const response = Promise.withResolvers<void>();
+	const requested = Promise.withResolvers<void>();
+	await page.route("**/v1/me/invitations/fixture/decline", async (route) => {
+		expect(route.request().headers().authorization).toBe("Bearer user-a:session-a");
+		requested.resolve();
+		await response.promise;
+		await route.fulfill({
+			status: 401,
+			contentType: "application/problem+json",
+			body: JSON.stringify({
+				type: "urn:clawdi:problem:account-suspended",
+				status: 401,
+				code: "account_suspended",
+				detail: "Suspended",
+			}),
+		});
+	});
+	try {
+		await page.evaluate(() => window.authTest.saveCredentials());
+		const mutation = page.evaluate(() => window.authTest.mutate());
+		await requested.promise;
+		await page.evaluate(() =>
+			window.authTest.emitSdk({ userId: "user-b", sessionId: "session-b" }),
+		);
+		await expect(page.locator("[data-private]")).toHaveText("user-b:session-b");
+		expect(await page.evaluate(() => window.authTest.useSavedCredentials())).toBe("retired");
+		response.resolve();
+		await mutation;
+		await expect(page.locator("[data-private]")).toHaveText("user-b:session-b");
+		await expect(page.getByText("Account suspended", { exact: true })).toHaveCount(0);
+		expect(await page.evaluate(() => window.authTest.oldMutationPublished)).toBe(false);
+	} finally {
+		response.resolve();
+	}
+});
+
+test("signed-out public invitations remain anonymous", async ({ page }) => {
+	await page.route("**/v1/share/fixture/preview", (route) => {
+		expect(route.request().headers().authorization).toBeUndefined();
+		return route.fulfill({
+			contentType: "application/json",
+			body: JSON.stringify({
+				project_name: "Shared project",
+				owner_display: "Owner",
+				owner_handle: "owner",
+				skill_count: 1,
+				vault_count: 0,
+			}),
+		});
+	});
+	await page.goto("/e2e/auth/");
+	await page.evaluate(async () => {
+		window.authTest.emitSdk({ userId: null, sessionId: null });
+		await window.authTest.navigate("/share/fixture");
+	});
+	await expect(page.getByText("Sign in to accept", { exact: true })).toBeVisible();
+	await expect(page.getByText("Shared project", { exact: true })).toBeVisible();
 });

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -103,7 +103,6 @@ for (const status of ["degraded", "error"] as const) {
 		await start(page);
 		await page.evaluate((status) => window.authTest.emitSdk({ status }), status);
 		await expect(page.locator("iframe")).toHaveCount(0);
-		await expect(page.locator("iframe")).toHaveCount(0);
 		expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
 		await page.evaluate(() => window.authTest.emitSdk({ status: "ready" }));
 		await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
@@ -115,7 +114,6 @@ test("native unknown auth removes an admitted session independently of script st
 }) => {
 	await start(page);
 	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: false }));
-	await expect(page.locator("iframe")).toHaveCount(0);
 	await expect(page.locator("iframe")).toHaveCount(0);
 	expect(await page.evaluate(() => window.authTest.signOutCalls)).toBe(0);
 	await page.evaluate(() => window.authTest.emitSdk({ isLoaded: true }));

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -1,6 +1,58 @@
 import { expect, type Page, test } from "@playwright/test";
 import type {} from "./lifecycle.browser";
 
+for (const replace of [false, true]) {
+	test(`Clerk ${replace ? "replace" : "push"} enters through a document request during activation`, async ({
+		page,
+	}) => {
+		await page.goto("/e2e/auth/");
+		await page.evaluate(() => window.authTest.navigate("/public"));
+		await page.evaluate(async () => {
+			window.authTest.emitSdk({ userId: null, sessionId: null });
+			await window.authTest.navigate("/sign-in");
+		});
+		await expect(page.getByRole("heading")).toHaveText("Sign in");
+		const response = Promise.withResolvers<void>();
+		const requested = Promise.withResolvers<void>();
+		const path = "/private/a?view=all&redirect_url=%2Fagents#details";
+		await page.route("**/private/a?*", async (route) => {
+			expect(route.request().isNavigationRequest()).toBe(true);
+			requested.resolve();
+			await response.promise;
+			await route.fulfill({ contentType: "text/html", body: "<h1>Document destination</h1>" });
+		});
+		try {
+			const retained = await page.evaluate(
+				({ path, replace }) => {
+					// Match setActive's transitive emission before invoking the actual
+					// AuthProvider callbacks. Clerk publishes the new session afterwards.
+					window.authTest.emitSdk({ isLoaded: false });
+					window.authTest.navigateFromClerk(
+						replace ? new URL(path, location.origin).href : path,
+						replace,
+					);
+					return {
+						heading: document.querySelector("h1")?.textContent,
+						loading: document.querySelector('[aria-label="Loading session"]') !== null,
+					};
+				},
+				{ path, replace },
+			);
+			await requested.promise;
+			expect(retained).toEqual({ heading: "Sign in", loading: false });
+			response.resolve();
+			await expect(page.getByRole("heading")).toHaveText("Document destination");
+			expect(
+				new URL(page.url()).pathname + new URL(page.url()).search + new URL(page.url()).hash,
+			).toBe(path);
+			await page.goBack();
+			await expect(page).toHaveURL(new RegExp(replace ? "/public$" : "/sign-in$"));
+		} finally {
+			response.resolve();
+		}
+	});
+}
+
 async function start(page: Page) {
 	await page.route("http://127.0.0.1:8000/**", (route) =>
 		route.fulfill({

--- a/apps/web/playwright.auth.config.ts
+++ b/apps/web/playwright.auth.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
 		url: "http://127.0.0.1:3111/e2e/auth/",
 		env: {
 			VITE_DEV_AUTH_BYPASS: "false",
+			VITE_CLAWDI_HOSTED: process.env.VITE_CLAWDI_HOSTED ?? "false",
+			VITE_CLAWDI_DEPLOY_API_URL: "http://127.0.0.1:50021",
 			VITE_CLERK_PUBLISHABLE_KEY: "pk_test_contract_fixture",
 			VITE_CLAWDI_API_URL: "http://127.0.0.1:8000",
 		},

--- a/apps/web/scripts/production-ssr.mjs
+++ b/apps/web/scripts/production-ssr.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { generateKeyPairSync, sign } from "node:crypto";
 import { after, mock, test } from "node:test";
 
 // Exercise the deployed bundle graph with real Clerk middleware and providers.
@@ -26,6 +27,8 @@ execFileSync("bun", ["run", "build"], {
 });
 
 process.env.CLERK_SECRET_KEY = "sk_test_ssr_fixture";
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+process.env.CLERK_JWT_KEY = publicKey.export({ type: "spki", format: "pem" });
 process.env.CLERK_TELEMETRY_DISABLED = "1";
 const network = mock.method(globalThis, "fetch", () => {
 	throw new Error("Public signed-out SSR must not need an external service");
@@ -61,6 +64,32 @@ for (const [path, title] of [
 }
 
 for (const path of ["/", "/agents"]) {
+	test(`production SSR renders signed-in ${path} without a session loading replacement`, async (t) => {
+		// Disabled dashboard queries still schedule cache GC; keep those timers
+		// scoped to this SSR request instead of retaining them in the test worker.
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const now = Math.floor(Date.now() / 1000);
+		const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+		const payload = `${encode({ alg: "RS256", typ: "JWT", kid: "ssr-fixture" })}.${encode({
+			iss: "https://ssr.clerk.accounts.dev",
+			sub: "user_ssr_fixture",
+			sid: "sess_ssr_fixture",
+			iat: now,
+			nbf: now - 5,
+			exp: now + 60,
+			v: 2,
+			sts: "active",
+		})}`;
+		const token = `${payload}.${sign("RSA-SHA256", Buffer.from(payload), privateKey).toString("base64url")}`;
+		const authenticated = request(path);
+		authenticated.headers.set("authorization", `Bearer ${token}`);
+		const response = await server.fetch(authenticated);
+		const html = await response.text();
+		assert.equal(response.status, 200, html);
+		assert.match(html, /data-testid="dashboard-page-content"/);
+		assert.doesNotMatch(html, /Loading session/);
+	});
+
 	test(`production SSR protects ${path} without auth bypass`, async () => {
 		const response = await server.fetch(request(path));
 		assert.equal(response.status, 307);

--- a/apps/web/src/components/account-suspension-boundary.tsx
+++ b/apps/web/src/components/account-suspension-boundary.tsx
@@ -1,46 +1,68 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { createContext, Fragment, useContext, useState, useSyncExternalStore } from "react";
 import { AccountSuspendedPage } from "@/components/account-suspended-page";
 import { AuthStatus } from "@/components/auth-status";
-import {
-	getAccountSuspendedServerSnapshot,
-	getAccountSuspendedSnapshot,
-	subscribeToAccountSuspension,
-} from "@/lib/account-suspension";
+import { RouteLoadingSkeleton } from "@/components/route-loading-skeleton";
+import { useAccountSuspension } from "@/lib/account-suspension";
 import { useOpenApi } from "@/lib/api";
 import { isAccountSuspendedError, isApiAuthError } from "@/lib/api-errors";
-import { useAuthActions, useCurrentUser } from "@/lib/auth-client";
-import { useHydrated } from "@/lib/use-hydrated";
+import { useAuthActions } from "@/lib/auth-client";
 
-export function AccountSuspensionBoundary({ children }: { children: React.ReactNode }) {
-	const hydrated = useHydrated();
-	const { isLoaded, isSignedIn } = useCurrentUser();
-	const suspended = useSyncExternalStore(
-		subscribeToAccountSuspension,
-		getAccountSuspendedSnapshot,
-		getAccountSuspendedServerSnapshot,
-	);
+const AccountDataContext = createContext<{
+	identity: string | null;
+	fallback: React.ReactNode;
+}>({ identity: null, fallback: <RouteLoadingSkeleton /> });
+
+export function useAccountDataIdentity() {
+	return useContext(AccountDataContext).identity;
+}
+
+export function AccountDataBoundary({ children }: { children: React.ReactNode }) {
+	const { identity, fallback } = useContext(AccountDataContext);
+	return identity ? <Fragment key={identity}>{children}</Fragment> : fallback;
+}
+
+// The admission result controls private regions, not the surrounding layout.
+export function AccountSuspensionBoundary({
+	identity,
+	status,
+	children,
+}: {
+	identity: string | null;
+	status: "loading" | "unavailable" | "signed-out";
+	children: React.ReactNode;
+}) {
+	const store = useAccountSuspension();
+	const suspended = useSyncExternalStore(store.subscribe, store.getSnapshot, () => false);
 	const api = useOpenApi();
-	const accessCheckEnabled = hydrated && isLoaded && Boolean(isSignedIn);
 	const access = api.useQuery(
 		"get",
 		"/v1/auth/me",
 		{},
 		{
-			enabled: accessCheckEnabled,
+			enabled: Boolean(identity),
 			retry: false,
 			staleTime: Number.POSITIVE_INFINITY,
 			refetchOnWindowFocus: false,
 		},
 	);
-
-	if (suspended || isAccountSuspendedError(access.error)) {
-		return <AccountAccessDeniedState suspended />;
+	let fallback: React.ReactNode =
+		status === "loading" ? <RouteLoadingSkeleton /> : <AuthStatus status={status} />;
+	let admitted = identity;
+	if (identity && (suspended || isAccountSuspendedError(access.error))) {
+		admitted = null;
+		fallback = <AccountAccessDeniedState suspended />;
+	} else if (identity && isApiAuthError(access.error)) {
+		admitted = null;
+		fallback = <AccountAccessDeniedState suspended={false} />;
+	} else if (identity && access.isError) {
+		admitted = null;
+		fallback = <AuthStatus status="unavailable" />;
 	}
-	if (isApiAuthError(access.error)) return <AccountAccessDeniedState suspended={false} />;
-	if (access.isError) return <AuthStatus status="unavailable" />;
-	return children;
+	return (
+		<AccountDataContext value={{ identity: admitted, fallback }}>{children}</AccountDataContext>
+	);
 }
 
 function AccountAccessDeniedState({ suspended }: { suspended: boolean }) {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -37,6 +37,7 @@ import {
 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useAccountDataIdentity } from "@/components/account-suspension-boundary";
 import { useSetBreadcrumbSegmentTitle } from "@/components/breadcrumb-title";
 import { useCommandPalette } from "@/components/command-palette";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -320,9 +321,11 @@ function SidebarNavSection({
 }
 
 function usePrefetchConnectorsCatalog() {
+	const ready = Boolean(useAccountDataIdentity());
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	return useCallback(() => {
+		if (!ready) return;
 		void queryClient.prefetchQuery(
 			availableAppsQueryOptions(api, {
 				page: 1,
@@ -330,7 +333,7 @@ function usePrefetchConnectorsCatalog() {
 			}),
 		);
 		void queryClient.prefetchQuery(connectionsQueryOptions(api));
-	}, [api, queryClient]);
+	}, [api, queryClient, ready]);
 }
 
 function ConsoleNavigationSections({
@@ -1109,7 +1112,7 @@ function FocusRailContent({
 						</SortableContext>
 					</DndContext>
 					{loading ? <AgentRailLoadingSlots /> : null}
-					<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
+					<ReadyNewAgentButton showTooltips={showTooltips} onNavigate={onNavigate} />
 				</SidebarMenu>
 			</SidebarContent>
 		</>
@@ -1614,6 +1617,18 @@ function SidebarGlobalControlsBar({
 	);
 }
 
+function ReadyNewAgentButton({
+	showTooltips,
+	onNavigate,
+}: {
+	showTooltips: boolean;
+	onNavigate?: () => void;
+}) {
+	return useAccountDataIdentity() ? (
+		<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
+	) : null;
+}
+
 export function AppSidebar({
 	className,
 	variant,
@@ -1623,12 +1638,14 @@ export function AppSidebar({
 	const router = useRouter();
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const routeSearch = useSearch({ from: "/_protected/_dashboard" });
-	const { user } = useCurrentUser();
+	const ready = Boolean(useAccountDataIdentity());
+	const { user: currentUser } = useCurrentUser();
+	const user = ready ? currentUser : null;
 	const { setOpen: setPaletteOpen } = useCommandPalette();
 	const { isMobile, setOpenMobile, state: sidebarState } = useSidebar();
 	const $api = useOpenApi();
 	const hostedAccess = useProductAccess();
-	const hydrated = useHydrated();
+	const hydrated = useHydrated() && ready;
 	const [hostedAgentTiles, setHostedAgentTiles] = useState<AgentTile[] | null>(null);
 	const [hostedMembershipResolved, setHostedMembershipResolved] = useState(false);
 	const [hostedInventoryFetching, setHostedInventoryFetching] = useState(false);
@@ -1648,6 +1665,7 @@ export function AppSidebar({
 		"/v1/agents",
 		{},
 		{
+			enabled: ready,
 			refetchInterval: activeAgentId ? 10_000 : false,
 			refetchIntervalInBackground: false,
 		},
@@ -1845,17 +1863,19 @@ export function AppSidebar({
 					collapsed={sidebarState === "collapsed"}
 				/>
 			) : null}
-			<SettingsDialog
-				open={settingsOpen}
-				section={activeSettingsSection}
-				agentTiles={agents}
-				hasExistingCloudAgents={
-					hostedAgentTiles?.some((tile) => tile.source === "on-clawdi") ?? false
-				}
-				cloudInventoryResolved={agentsLoaded}
-				onSectionChange={changeSettingsSection}
-				onOpenChange={setSettingsOpen}
-			/>
+			{ready ? (
+				<SettingsDialog
+					open={settingsOpen}
+					section={activeSettingsSection}
+					agentTiles={agents}
+					hasExistingCloudAgents={
+						hostedAgentTiles?.some((tile) => tile.source === "on-clawdi") ?? false
+					}
+					cloudInventoryResolved={agentsLoaded}
+					onSectionChange={changeSettingsSection}
+					onOpenChange={setSettingsOpen}
+				/>
+			) : null}
 		</>
 	);
 }

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -11,6 +11,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		<ClerkProvider
 			appearance={shadcn}
 			publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}
+			// Clerk clears its session while awaiting post-login navigation. Enter
+			// through SSR so that transient state cannot replace the dashboard.
+			routerPush={(to) => window.location.assign(to)}
+			routerReplace={(to) => window.location.replace(to)}
 			signInFallbackRedirectUrl="/"
 			signInUrl="/sign-in"
 			signUpFallbackRedirectUrl="/"

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -11,10 +11,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		<ClerkProvider
 			appearance={shadcn}
 			publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}
-			// Clerk clears its session while awaiting post-login navigation. Enter
-			// through SSR so that transient state cannot replace the dashboard.
-			routerPush={(to) => window.location.assign(to)}
-			routerReplace={(to) => window.location.replace(to)}
 			signInFallbackRedirectUrl="/"
 			signInUrl="/sign-in"
 			signUpFallbackRedirectUrl="/"

--- a/apps/web/src/components/auth-router-bridge.tsx
+++ b/apps/web/src/components/auth-router-bridge.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { RouterContextProvider, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { clearAccountSuspension } from "@/lib/account-suspension";
+import { AccountSuspensionContext, createAccountSuspensionStore } from "@/lib/account-suspension";
 import { useRouteAuth } from "@/lib/auth-client";
 import { createAppQueryClient } from "@/lib/query-client";
 import { routeAuthIdentity } from "@/lib/route-auth";
@@ -14,17 +14,25 @@ export function AuthRouterBridge({ children }: { children: React.ReactNode }) {
 	const identity = routeAuthIdentity(auth);
 	const authKey = identity ?? auth.status;
 	const previousAuthKey = useRef<string | undefined>(undefined);
-	const [scope, setScope] = useState(() => ({ identity, queryClient: createAppQueryClient() }));
+	const [scope, setScope] = useState(() => ({
+		identity,
+		queryClient: createAppQueryClient(),
+		suspension: createAccountSuspensionStore(),
+	}));
 	if (scope.identity !== identity) {
 		// React retries this render before children commit. Old requests and
 		// mutation callbacks retain their old client, never the next session's.
-		setScope({ identity, queryClient: createAppQueryClient() });
+		setScope({
+			identity,
+			queryClient: createAppQueryClient(),
+			suspension: createAccountSuspensionStore(),
+		});
 	}
 	useEffect(() => () => scope.queryClient.clear(), [scope.queryClient]);
 	useLayoutEffect(() => {
+		if (auth.status === "loading" || auth.status === "unavailable") return;
 		if (previousAuthKey.current === authKey) return;
 		previousAuthKey.current = authKey;
-		clearAccountSuspension();
 		router.clearCache({ filter: isProtectedMatch });
 		if (
 			![...router.state.matches, ...router.matchRoutes(router.state.location)].some(
@@ -36,11 +44,11 @@ export function AuthRouterBridge({ children }: { children: React.ReactNode }) {
 		void router
 			.invalidate({ filter: isProtectedMatch })
 			.catch(() => console.error("Failed to refresh authenticated routes"));
-	}, [authKey, router]);
+	}, [authKey, auth.status, router]);
 
 	return (
-		<RouterContextProvider router={router} context={{ auth }}>
+		<AccountSuspensionContext value={scope.suspension}>
 			<QueryClientProvider client={scope.queryClient}>{children}</QueryClientProvider>
-		</RouterContextProvider>
+		</AccountSuspensionContext>
 	);
 }

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -18,6 +18,7 @@ import {
 	Sparkles,
 } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useAccountDataIdentity } from "@/components/account-suspension-boundary";
 import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
 import { TruncatedText } from "@/components/truncated-text";
@@ -87,6 +88,7 @@ export function useCommandPalette() {
 }
 
 export function CommandPaletteProvider({ children }: { children: React.ReactNode }) {
+	const ready = Boolean(useAccountDataIdentity());
 	const [open, setOpenInternal] = useState(false);
 
 	const setOpen = useCallback((next: boolean) => {
@@ -97,6 +99,7 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
 		// Global Cmd+K / Ctrl+K — mirrors Linear, Vercel, GitHub. We skip when
 		// the user is typing in a form field other than our own search input;
 		// cmdk already grabs focus inside the dialog so we just need to open it.
+		if (!ready) return;
 		const handler = (e: KeyboardEvent) => {
 			if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey)) {
 				e.preventDefault();
@@ -105,14 +108,14 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
 		};
 		document.addEventListener("keydown", handler, true);
 		return () => document.removeEventListener("keydown", handler, true);
-	}, []);
+	}, [ready]);
 
 	const value = useMemo(() => ({ open, setOpen }), [open, setOpen]);
 
 	return (
 		<PaletteContext.Provider value={value}>
 			{children}
-			<CommandPalette open={open} onOpenChange={setOpen} />
+			{ready ? <CommandPalette open={open} onOpenChange={setOpen} /> : null}
 		</PaletteContext.Provider>
 	);
 }

--- a/apps/web/src/components/protected-auth-boundary.tsx
+++ b/apps/web/src/components/protected-auth-boundary.tsx
@@ -1,8 +1,8 @@
 import type { ErrorComponentProps } from "@tanstack/react-router";
-import { Fragment } from "react";
+import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
 import { AuthStatus } from "@/components/auth-status";
 import RootError from "@/components/root-error";
-import { useRouteAuth } from "@/lib/auth-client";
+import { useRouteAuth, useSessionIdentity } from "@/lib/auth-client";
 import { RouteAuthUnavailable, routeAuthIdentity } from "@/lib/route-auth";
 
 export function ProtectedRouteError({ error, reset }: ErrorComponentProps) {
@@ -21,9 +21,19 @@ export function ProtectedAuthBoundary({
 	children: React.ReactNode;
 }) {
 	const auth = useRouteAuth();
+	const sessionIdentity = useSessionIdentity();
 	const identity = routeAuthIdentity(auth);
-	if (auth.status !== "signed-in") return <AuthStatus status={auth.status} />;
-	// Cached/in-flight matches cannot render under a different live session.
-	if (identity !== admittedIdentity) return <AuthStatus status="loading" />;
-	return <Fragment key={identity}>{children}</Fragment>;
+	const ready = sessionIdentity === admittedIdentity && identity === admittedIdentity;
+	// A settled disagreement is recoverable, not an endless activation skeleton.
+	const status =
+		auth.status !== "signed-in"
+			? auth.status
+			: sessionIdentity && identity !== admittedIdentity
+				? "unavailable"
+				: "loading";
+	return (
+		<AccountSuspensionBoundary identity={ready ? identity : null} status={status}>
+			{children}
+		</AccountSuspensionBoundary>
+	);
 }

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { lazy, type ReactNode, Suspense } from "react";
+import { useAccountDataIdentity } from "@/components/account-suspension-boundary";
 import { AppBreadcrumb } from "@/components/app-breadcrumb";
 import { NotificationCenter } from "@/components/notification-center";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 
@@ -22,6 +24,7 @@ const HostedNotificationCenter = IS_HOSTED_BUILD
  * with Clawdi-specific breadcrumbs and notifications.
  */
 export function SiteHeader({ actions }: { actions?: ReactNode }) {
+	const ready = Boolean(useAccountDataIdentity());
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
 			<div className="flex w-full min-w-0 items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -34,7 +37,9 @@ export function SiteHeader({ actions }: { actions?: ReactNode }) {
 					<AppBreadcrumb />
 				</div>
 				{actions}
-				{HostedNotificationCenter ? (
+				{!ready ? (
+					<Skeleton className="size-8 rounded-md" />
+				) : HostedNotificationCenter ? (
 					<Suspense fallback={<NotificationCenter />}>
 						<HostedNotificationCenter />
 					</Suspense>

--- a/apps/web/src/lib/account-suspension.test.ts
+++ b/apps/web/src/lib/account-suspension.test.ts
@@ -1,10 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import {
-	clearAccountSuspension,
-	getAccountSuspendedSnapshot,
-	isAccountSuspendedProblem,
-	observeAccountSuspensionResponse,
-} from "./account-suspension";
+import { describe, expect, test } from "bun:test";
+import { createAccountSuspensionStore, isAccountSuspendedProblem } from "./account-suspension";
 
 const problem = {
 	type: "urn:clawdi:problem:account-suspended",
@@ -14,8 +9,6 @@ const problem = {
 	code: "account_suspended",
 };
 
-afterEach(() => clearAccountSuspension());
-
 describe("account suspension contract", () => {
 	test("recognizes only the stable typed problem", () => {
 		expect(isAccountSuspendedProblem(problem)).toBe(true);
@@ -23,23 +16,29 @@ describe("account suspension contract", () => {
 		expect(isAccountSuspendedProblem({ detail: "Account is suspended" })).toBe(false);
 	});
 
-	test("a suspension response switches the global access boundary", async () => {
+	test("a late suspension response affects only its originating account scope", async () => {
+		const store = createAccountSuspensionStore();
+		const nextAccount = createAccountSuspensionStore();
 		const response = new Response(JSON.stringify(problem), {
 			status: 401,
 			headers: { "content-type": "application/problem+json" },
 		});
 
-		expect(await observeAccountSuspensionResponse(response)).toBe(true);
-		expect(getAccountSuspendedSnapshot()).toBe(true);
+		expect(await store.observeResponse(response)).toBe(true);
+		expect(store.getSnapshot()).toBe(true);
+		expect(nextAccount.getSnapshot()).toBe(false);
 	});
 
 	test("ordinary authentication failures do not look suspended", async () => {
+		const store = createAccountSuspensionStore();
+		const nextAccount = createAccountSuspensionStore();
 		const response = new Response(JSON.stringify({ detail: "Invalid credentials" }), {
 			status: 401,
 			headers: { "content-type": "application/json" },
 		});
 
-		expect(await observeAccountSuspensionResponse(response)).toBe(false);
-		expect(getAccountSuspendedSnapshot()).toBe(false);
+		expect(await store.observeResponse(response)).toBe(false);
+		expect(store.getSnapshot()).toBe(false);
+		expect(nextAccount.getSnapshot()).toBe(false);
 	});
 });

--- a/apps/web/src/lib/account-suspension.ts
+++ b/apps/web/src/lib/account-suspension.ts
@@ -1,11 +1,9 @@
 import type { AccountSuspendedProblem } from "@clawdi/shared/api";
+import { createContext, useContext } from "react";
 
 export const ACCOUNT_SUSPENDED_CODE: AccountSuspendedProblem["code"] = "account_suspended";
 const ACCOUNT_SUSPENDED_TYPE: AccountSuspendedProblem["type"] =
 	"urn:clawdi:problem:account-suspended";
-
-let accountSuspended = false;
-const listeners = new Set<() => void>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -21,39 +19,38 @@ export function isAccountSuspendedProblem(value: unknown): value is AccountSuspe
 	);
 }
 
-export function getAccountSuspendedSnapshot(): boolean {
-	return accountSuspended;
+export function createAccountSuspensionStore() {
+	let suspended = false;
+	const listeners = new Set<() => void>();
+	return {
+		getSnapshot: () => suspended,
+		subscribe: (listener: () => void) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		async observeResponse(response: Response): Promise<boolean> {
+			if (response.status !== 401) return false;
+			try {
+				const body: unknown = await response.clone().json();
+				if (!isAccountSuspendedProblem(body)) return false;
+				suspended = true;
+				for (const listener of listeners) listener();
+				return true;
+			} catch {
+				return false;
+			}
+		},
+	};
 }
 
-export function getAccountSuspendedServerSnapshot(): boolean {
-	return false;
-}
+export const AccountSuspensionContext = createContext<ReturnType<
+	typeof createAccountSuspensionStore
+> | null>(null);
 
-export function subscribeToAccountSuspension(listener: () => void): () => void {
-	listeners.add(listener);
-	return () => listeners.delete(listener);
-}
-
-export function markAccountSuspended(): void {
-	if (accountSuspended) return;
-	accountSuspended = true;
-	for (const listener of listeners) listener();
-}
-
-export function clearAccountSuspension(): void {
-	if (!accountSuspended) return;
-	accountSuspended = false;
-	for (const listener of listeners) listener();
-}
-
-export async function observeAccountSuspensionResponse(response: Response): Promise<boolean> {
-	if (response.status !== 401) return false;
-	try {
-		const body: unknown = await response.clone().json();
-		if (!isAccountSuspendedProblem(body)) return false;
-		markAccountSuspended();
-		return true;
-	} catch {
-		return false;
-	}
+export function useAccountSuspension() {
+	const store = useContext(AccountSuspensionContext);
+	if (!store) throw new Error("Missing account scope");
+	return store;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,7 +4,7 @@ import { type components, extractApiDetail, type paths } from "@clawdi/shared/ap
 import createClient from "openapi-fetch";
 import createQueryClient from "openapi-react-query";
 import { useCallback, useMemo } from "react";
-import { observeAccountSuspensionResponse } from "@/lib/account-suspension";
+import { useAccountSuspension } from "@/lib/account-suspension";
 import { ApiError, ApiNetworkError, apiErrorCode } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { env } from "@/lib/env";
@@ -67,10 +67,6 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
 		controller.abort();
 	}, REQUEST_TIMEOUT_MS);
 	return fetch(request, { ...init, signal: controller.signal })
-		.then(async (response) => {
-			await observeAccountSuspensionResponse(response);
-			return response;
-		})
 		.catch((cause: unknown) => {
 			if (timedOut) throw new ApiNetworkError("timeout", { cause });
 			if (caller?.aborted) throw cause;
@@ -82,6 +78,18 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
 		});
 }
 
+function useAccountFetch() {
+	const suspension = useAccountSuspension();
+	return useCallback(
+		async (request: Request, init?: RequestInit) => {
+			const response = await fetchWithTimeout(request, init);
+			await suspension.observeResponse(response);
+			return response;
+		},
+		[suspension],
+	);
+}
+
 /**
  * openapi-fetch client authenticated via Clerk. Response types are inferred
  * from the OpenAPI path + method, so call sites never pass a manual generic.
@@ -90,9 +98,10 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
  * in the browser tree.
  */
 function useConfiguredApi(throwOnError: boolean) {
+	const accountFetch = useAccountFetch();
 	const { getToken } = useAuthToken();
 	return useMemo(() => {
-		const client = createClient<ApiPaths>({ baseUrl: API_URL, fetch: fetchWithTimeout });
+		const client = createClient<ApiPaths>({ baseUrl: API_URL, fetch: accountFetch });
 		client.use({
 			async onRequest({ request }) {
 				const token = await getToken();
@@ -111,7 +120,17 @@ function useConfiguredApi(throwOnError: boolean) {
 			});
 		}
 		return client;
-	}, [getToken, throwOnError]);
+	}, [accountFetch, getToken, throwOnError]);
+}
+
+/** Share previews are explicitly anonymous; private clients require a session. */
+export function getPublicSharePreview(token: string) {
+	return createClient<paths>({ baseUrl: API_URL, fetch: fetchWithTimeout }).GET(
+		"/v1/share/{token}/preview",
+		{
+			params: { path: { token } },
+		},
+	);
 }
 
 /** Generated fetch client for flows that inspect the typed response envelope directly. */
@@ -174,6 +193,7 @@ async function readJson<T>(response: Response): Promise<T> {
 }
 
 export function useSkillArchiveUploader() {
+	const accountFetch = useAccountFetch();
 	const { getToken } = useAuthToken();
 	return useCallback(
 		async (
@@ -192,7 +212,7 @@ export function useSkillArchiveUploader() {
 			const token = await getToken();
 			if (token) headers.set("Authorization", `Bearer ${token}`);
 
-			const response = await fetchWithTimeout(
+			const response = await accountFetch(
 				new Request(apiUrl(`/v1/projects/${encodeURIComponent(projectId)}/skills/upload`), {
 					method: "POST",
 					headers,
@@ -204,11 +224,12 @@ export function useSkillArchiveUploader() {
 			}
 			return readJson<SkillUploadResponse>(response);
 		},
-		[getToken],
+		[accountFetch, getToken],
 	);
 }
 
 export function useAgentAvatarUploader() {
+	const accountFetch = useAccountFetch();
 	const { getToken } = useAuthToken();
 	return useCallback(
 		async (environmentId: string, file: File): Promise<EnvironmentResponse> => {
@@ -219,7 +240,7 @@ export function useAgentAvatarUploader() {
 			const token = await getToken();
 			if (token) headers.set("Authorization", `Bearer ${token}`);
 
-			const response = await fetchWithTimeout(
+			const response = await accountFetch(
 				new Request(apiUrl(`/v1/agents/${encodeURIComponent(environmentId)}/avatar`), {
 					method: "POST",
 					headers,
@@ -229,6 +250,6 @@ export function useAgentAvatarUploader() {
 			if (!response.ok) throw await apiErrorFromResponse(response);
 			return readJson<EnvironmentResponse>(response);
 		},
-		[getToken],
+		[accountFetch, getToken],
 	);
 }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,8 @@
 "use client";
 
-import { useAuth, useClerk, useUser } from "@clerk/tanstack-react-start";
+import { useAuth, useClerk, useSession, useUser } from "@clerk/tanstack-react-start";
+import { useCallback } from "react";
+import { ApiError } from "@/lib/api-errors";
 import { env } from "@/lib/env";
 import { resolveRouteAuth } from "@/lib/route-auth";
 
@@ -27,7 +29,19 @@ export function useAuthToken() {
 	if (env.VITE_DEV_AUTH_BYPASS) {
 		return DEV_AUTH_TOKEN_RESULT;
 	}
-	const { getToken } = useAuth();
+	const { session } = useSession();
+	const clerk = useClerk();
+	const getToken = useCallback(async () => {
+		// A retained request must never acquire credentials for a later session.
+		if (!session || clerk.session?.id !== session.id) {
+			throw new ApiError(401, "Session is not available");
+		}
+		const token = await session.getToken();
+		if (!token || clerk.session?.id !== session.id) {
+			throw new ApiError(401, "Session is not available");
+		}
+		return token;
+	}, [clerk, session]);
 	return { getToken };
 }
 
@@ -41,7 +55,9 @@ export function useDashboardAuth() {
 			getToken: async () => DEV_AUTH_BEARER,
 		};
 	}
-	return useAuth();
+	const auth = useAuth();
+	const { getToken } = useAuthToken();
+	return { ...auth, getToken };
 }
 
 export function useRouteAuth() {
@@ -75,4 +91,12 @@ export function useAuthActions() {
 		};
 	}
 	return useClerk();
+}
+
+// Unlike useAuth's SSR snapshot, a SessionResource is usable only after the
+// browser SDK has supplied it. Private data regions wait for that native resource.
+export function useSessionIdentity() {
+	if (env.VITE_DEV_AUTH_BYPASS) return JSON.stringify([DEV_USER.id, "dev_browser_session"]);
+	const { isLoaded, session } = useSession();
+	return isLoaded && session ? JSON.stringify([session.user.id, session.id]) : null;
 }

--- a/apps/web/src/lib/route-auth.ts
+++ b/apps/web/src/lib/route-auth.ts
@@ -5,10 +5,6 @@ export type RouteAuth =
 	| { status: "loading" | "unavailable" | "signed-out" }
 	| { status: "signed-in"; userId: string; sessionId: string };
 
-export interface AppRouterContext {
-	auth: RouteAuth | undefined;
-}
-
 export function routeAuthIdentity(auth: RouteAuth | undefined): string | null {
 	return auth?.status === "signed-in" ? JSON.stringify([auth.userId, auth.sessionId]) : null;
 }

--- a/apps/web/src/pages/cli-authorize/page.tsx
+++ b/apps/web/src/pages/cli-authorize/page.tsx
@@ -5,6 +5,7 @@ import { Link } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle2, Clock, Terminal, XCircle } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useEffect, useRef, useState } from "react";
+import { AccountDataBoundary } from "@/components/account-suspension-boundary";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -32,15 +33,13 @@ const CLI_AUTHORIZE_ERROR_NORMALIZER: ApiErrorNormalizer = {
 // Keep the URL-state body under Suspense and preserve the existing loading shell.
 export default function CliAuthorizePage() {
 	return (
-		<Suspense
-			fallback={
-				<Shell>
-					<Skeleton className="h-32 w-full" />
-				</Shell>
-			}
-		>
-			<CliAuthorizeContent />
-		</Suspense>
+		<Shell>
+			<Suspense fallback={<Skeleton className="h-32 w-full" />}>
+				<AccountDataBoundary>
+					<CliAuthorizeContent />
+				</AccountDataBoundary>
+			</Suspense>
+		</Shell>
 	);
 }
 
@@ -103,36 +102,28 @@ function CliAuthorizeContent() {
 
 	if (!code) {
 		return (
-			<Shell>
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Missing authorization code</AlertTitle>
-					<AlertDescription>
-						Open this page through the link `clawdi auth login` printed in your terminal — it
-						already includes the code.
-					</AlertDescription>
-				</Alert>
-			</Shell>
+			<Alert variant="destructive">
+				<AlertCircle />
+				<AlertTitle>Missing authorization code</AlertTitle>
+				<AlertDescription>
+					Open this page through the link `clawdi auth login` printed in your terminal — it already
+					includes the code.
+				</AlertDescription>
+			</Alert>
 		);
 	}
 
 	if (lookup.isLoading) {
-		return (
-			<Shell>
-				<Skeleton className="h-32 w-full" />
-			</Shell>
-		);
+		return <Skeleton className="h-32 w-full" />;
 	}
 
 	if (lookup.error) {
 		return (
-			<Shell>
-				<ApiErrorPanel
-					error={lookup.error}
-					normalizer={CLI_AUTHORIZE_ERROR_NORMALIZER}
-					title="Authorization request unavailable"
-				/>
-			</Shell>
+			<ApiErrorPanel
+				error={lookup.error}
+				normalizer={CLI_AUTHORIZE_ERROR_NORMALIZER}
+				title="Authorization request unavailable"
+			/>
 		);
 	}
 
@@ -145,37 +136,31 @@ function CliAuthorizeContent() {
 
 	if (visibleStatus === "approved") {
 		return (
-			<Shell>
-				<TerminalCard
-					icon={<CheckCircle2 className="size-10 text-success" />}
-					title="CLI authorized"
-					body="Return to your terminal — the CLI should pick up the credentials within a couple of seconds."
-				/>
-			</Shell>
+			<TerminalCard
+				icon={<CheckCircle2 className="size-10 text-success" />}
+				title="CLI authorized"
+				body="Return to your terminal — the CLI should pick up the credentials within a couple of seconds."
+			/>
 		);
 	}
 
 	if (visibleStatus === "denied") {
 		return (
-			<Shell>
-				<TerminalCard
-					icon={<XCircle className="size-10 text-destructive" />}
-					title="Authorization denied"
-					body="The CLI on the other side will see this and stop polling. Re-run `clawdi auth login` to start fresh."
-				/>
-			</Shell>
+			<TerminalCard
+				icon={<XCircle className="size-10 text-destructive" />}
+				title="Authorization denied"
+				body="The CLI on the other side will see this and stop polling. Re-run `clawdi auth login` to start fresh."
+			/>
 		);
 	}
 
 	if (visibleStatus === "expired" || visibleStatus === "consumed") {
 		return (
-			<Shell>
-				<TerminalCard
-					icon={<Clock className="size-10 text-muted-foreground" />}
-					title="Code expired"
-					body="Authorization codes are good for 10 minutes. Run `clawdi auth login` again to get a new one."
-				/>
-			</Shell>
+			<TerminalCard
+				icon={<Clock className="size-10 text-muted-foreground" />}
+				title="Code expired"
+				body="Authorization codes are good for 10 minutes. Run `clawdi auth login` again to get a new one."
+			/>
 		);
 	}
 
@@ -183,57 +168,55 @@ function CliAuthorizeContent() {
 	const minutesLeft = Math.max(0, Math.round((expiresAt.getTime() - Date.now()) / 60000));
 
 	return (
-		<Shell>
-			<Card>
-				<CardHeader className="space-y-1">
-					<CardTitle className="flex items-center gap-2">
-						<Terminal className="size-5" />
-						Authorize the Clawdi CLI
-					</CardTitle>
-					<p className="text-sm text-muted-foreground">
-						A CLI on this machine is asking to act on behalf of your account. Confirm the code below
-						matches what your terminal shows.
-					</p>
-				</CardHeader>
-				<CardContent className="space-y-5">
-					<div className="rounded-lg border bg-muted/30 p-4">
-						<div className="text-xs uppercase tracking-wide text-muted-foreground">Code</div>
-						<div className="mt-1 font-mono text-2xl font-semibold tracking-widest">
-							{data.user_code}
-						</div>
-						{data.client_label ? (
-							<div className="mt-3 text-sm text-muted-foreground">
-								<span className="text-xs uppercase tracking-wide">Client</span>
-								<div className="font-mono text-sm">{data.client_label}</div>
-							</div>
-						) : null}
-						<div className="mt-3 text-xs text-muted-foreground">
-							Expires in ~{minutesLeft} minute{minutesLeft === 1 ? "" : "s"}.
-						</div>
+		<Card>
+			<CardHeader className="space-y-1">
+				<CardTitle className="flex items-center gap-2">
+					<Terminal className="size-5" />
+					Authorize the Clawdi CLI
+				</CardTitle>
+				<p className="text-sm text-muted-foreground">
+					A CLI on this machine is asking to act on behalf of your account. Confirm the code below
+					matches what your terminal shows.
+				</p>
+			</CardHeader>
+			<CardContent className="space-y-5">
+				<div className="rounded-lg border bg-muted/30 p-4">
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">Code</div>
+					<div className="mt-1 font-mono text-2xl font-semibold tracking-widest">
+						{data.user_code}
 					</div>
-
-					<div className="flex items-center justify-end gap-2">
-						<Button
-							variant="ghost"
-							onClick={() => void deny.execute().catch(() => undefined)}
-							disabled={deny.isPending || approve.isPending}
-						>
-							{deny.isPending ? "Denying…" : "Deny"}
-						</Button>
-						<Button
-							onClick={() => void approve.execute().catch(() => undefined)}
-							disabled={approve.isPending || deny.isPending}
-						>
-							{approve.isPending ? "Authorizing…" : "Authorize"}
-						</Button>
-					</div>
-
-					{approve.error || deny.error ? (
-						<ApiErrorPanel error={approve.error || deny.error} title="Action failed" />
+					{data.client_label ? (
+						<div className="mt-3 text-sm text-muted-foreground">
+							<span className="text-xs uppercase tracking-wide">Client</span>
+							<div className="font-mono text-sm">{data.client_label}</div>
+						</div>
 					) : null}
-				</CardContent>
-			</Card>
-		</Shell>
+					<div className="mt-3 text-xs text-muted-foreground">
+						Expires in ~{minutesLeft} minute{minutesLeft === 1 ? "" : "s"}.
+					</div>
+				</div>
+
+				<div className="flex items-center justify-end gap-2">
+					<Button
+						variant="ghost"
+						onClick={() => void deny.execute().catch(() => undefined)}
+						disabled={deny.isPending || approve.isPending}
+					>
+						{deny.isPending ? "Denying…" : "Deny"}
+					</Button>
+					<Button
+						onClick={() => void approve.execute().catch(() => undefined)}
+						disabled={approve.isPending || deny.isPending}
+					>
+						{approve.isPending ? "Authorizing…" : "Authorize"}
+					</Button>
+				</div>
+
+				{approve.error || deny.error ? (
+					<ApiErrorPanel error={approve.error || deny.error} title="Action failed" />
+				) : null}
+			</CardContent>
+		</Card>
 	);
 }
 

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -2,6 +2,10 @@
 
 import { useMatches } from "@tanstack/react-router";
 import { lazy, type ReactNode, Suspense, useCallback, useState } from "react";
+import {
+	AccountDataBoundary,
+	useAccountDataIdentity,
+} from "@/components/account-suspension-boundary";
 import { AppSidebar } from "@/components/app-sidebar";
 import { BreadcrumbTitleProvider } from "@/components/breadcrumb-title";
 import { CommandPaletteProvider } from "@/components/command-palette";
@@ -58,6 +62,25 @@ const GlobalWalletBalance = IS_HOSTED_BUILD
 	: null;
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
+	const identity = useAccountDataIdentity();
+	return (
+		<SidebarProvider
+			defaultOpen
+			style={
+				{
+					"--sidebar-width": "calc(var(--spacing) * 64)",
+					"--clawdi-rail-width": "calc(var(--spacing) * 20)",
+					"--header-height": "calc(var(--spacing) * 12)",
+				} as React.CSSProperties
+			}
+		>
+			<DashboardAccountLayout key={identity ?? "pending"}>{children}</DashboardAccountLayout>
+		</SidebarProvider>
+	);
+}
+
+function DashboardAccountLayout({ children }: { children: ReactNode }) {
+	const ready = Boolean(useAccountDataIdentity());
 	// Layout belongs to the presented matches, not the pending destination.
 	const pathname = useMatches({ select: (matches) => matches.at(-1)?.pathname ?? "/" });
 	const hydrated = useHydrated();
@@ -68,7 +91,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 	const [productAccess, setProductAccess] = useState<ProductAccess>(() =>
 		IS_HOSTED_BUILD ? LOADING_PRODUCT_ACCESS : UNAVAILABLE_PRODUCT_ACCESS,
 	);
-	const showOwnershipSensor = hydrated && Boolean(HostedAgentOwnershipSensor);
+	const showOwnershipSensor = ready && hydrated && Boolean(HostedAgentOwnershipSensor);
 	const updateHostedOwnership = useCallback(
 		(nextOwnership: AgentOwnership | null, nextExistingCloudDeploymentCount: number | null) => {
 			setOwnership(nextOwnership);
@@ -90,98 +113,87 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 	const hideHostedLauncher = IS_HOSTED_BUILD && (pathname === "/deploy" || isAgentLiveToolRoute);
 	const reserveHostedLauncherClearance = IS_HOSTED_BUILD && !hideHostedLauncher;
 	return (
-		<SidebarProvider
-			defaultOpen
-			style={
-				{
-					"--sidebar-width": "calc(var(--spacing) * 64)",
-					"--clawdi-rail-width": "calc(var(--spacing) * 20)",
-					"--header-height": "calc(var(--spacing) * 12)",
-				} as React.CSSProperties
-			}
-		>
-			<ProductAccessProvider value={productAccess}>
-				{HostedProductAccessSensor ? (
+		<ProductAccessProvider value={productAccess}>
+			{ready && HostedProductAccessSensor ? (
+				<Suspense fallback={null}>
+					<HostedProductAccessSensor onChange={setProductAccess} />
+				</Suspense>
+			) : null}
+			<AgentOwnershipProvider value={providedOwnership}>
+				{HostedAgentOwnershipSensor && showOwnershipSensor ? (
 					<Suspense fallback={null}>
-						<HostedProductAccessSensor onChange={setProductAccess} />
+						<HostedAgentOwnershipSensor onChange={updateHostedOwnership} />
 					</Suspense>
 				) : null}
-				<AgentOwnershipProvider value={providedOwnership}>
-					{HostedAgentOwnershipSensor && showOwnershipSensor ? (
-						<Suspense fallback={null}>
-							<HostedAgentOwnershipSensor onChange={updateHostedOwnership} />
-						</Suspense>
-					) : null}
-					<CommandPaletteProvider>
-						<BreadcrumbTitleProvider>
-							<AppSidebar variant="inset" />
-							{/* 1rem = SidebarInset's md:m-2 top+bottom when the sidebar uses
+				<CommandPaletteProvider>
+					<BreadcrumbTitleProvider>
+						<AppSidebar variant="inset" />
+						{/* 1rem = SidebarInset's md:m-2 top+bottom when the sidebar uses
 							    dashboard-01's inset variant. Keep the scroll container inside
 							    the inset so the sticky SiteHeader pins correctly. */}
-							<SidebarInset
-								id="dashboard-scroll-container"
-								data-scroll-restoration-id="dashboard-scroll-container"
-								data-live-tool-route={isAgentLiveToolRoute ? "true" : undefined}
+						<SidebarInset
+							id="dashboard-scroll-container"
+							data-scroll-restoration-id="dashboard-scroll-container"
+							data-live-tool-route={isAgentLiveToolRoute ? "true" : undefined}
+							className={cn(
+								"md:h-[calc(100svh-1rem)]",
+								isAgentLiveToolRoute
+									? "h-svh overflow-hidden md:overflow-hidden"
+									: "md:overflow-y-auto",
+							)}
+						>
+							<SiteHeader
+								actions={
+									ready && IS_HOSTED_BUILD ? (
+										<DashboardHeaderActionSlot>
+											{GlobalWalletBalance ? (
+												<Suspense fallback={<Skeleton className="h-8 w-full" />}>
+													<GlobalWalletBalance
+														existingCloudDeploymentCount={existingCloudDeploymentCount}
+													/>
+												</Suspense>
+											) : null}
+										</DashboardHeaderActionSlot>
+									) : null
+								}
+							/>
+							<div
 								className={cn(
-									"md:h-[calc(100svh-1rem)]",
-									isAgentLiveToolRoute
-										? "h-svh overflow-hidden md:overflow-hidden"
-										: "md:overflow-y-auto",
+									"flex flex-1 flex-col",
+									isAgentLiveToolRoute && "min-h-0 overflow-hidden",
 								)}
 							>
-								<SiteHeader
-									actions={
-										IS_HOSTED_BUILD ? (
-											<DashboardHeaderActionSlot>
-												{GlobalWalletBalance ? (
-													<Suspense fallback={<Skeleton className="h-8 w-full" />}>
-														<GlobalWalletBalance
-															existingCloudDeploymentCount={existingCloudDeploymentCount}
-														/>
-													</Suspense>
-												) : null}
-											</DashboardHeaderActionSlot>
-										) : null
-									}
-								/>
 								<div
 									className={cn(
-										"flex flex-1 flex-col",
+										"@container/main flex flex-1 flex-col gap-2",
 										isAgentLiveToolRoute && "min-h-0 overflow-hidden",
 									)}
 								>
 									<div
+										data-testid="dashboard-page-content"
+										data-mava-launcher={hideHostedLauncher ? "hidden" : undefined}
 										className={cn(
-											"@container/main flex flex-1 flex-col gap-2",
-											isAgentLiveToolRoute && "min-h-0 overflow-hidden",
+											"mx-auto flex w-full flex-col",
+											isAgentLiveToolRoute
+												? "min-h-0 flex-1 overflow-hidden"
+												: "gap-4 pt-4 md:gap-5 md:pt-5",
+											CONTENT_MAX_WIDTH,
+											!isAgentLiveToolRoute &&
+												(reserveHostedLauncherClearance
+													? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"
+													: "pb-4 md:pb-5"),
 										)}
 									>
-										<div
-											data-testid="dashboard-page-content"
-											data-mava-launcher={hideHostedLauncher ? "hidden" : undefined}
-											className={cn(
-												"mx-auto flex w-full flex-col",
-												isAgentLiveToolRoute
-													? "min-h-0 flex-1 overflow-hidden"
-													: "gap-4 pt-4 md:gap-5 md:pt-5",
-												CONTENT_MAX_WIDTH,
-												!isAgentLiveToolRoute &&
-													(reserveHostedLauncherClearance
-														? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"
-														: "pb-4 md:pb-5"),
-											)}
-										>
-											{children}
-										</div>
+										<AccountDataBoundary>{children}</AccountDataBoundary>
 									</div>
 								</div>
-							</SidebarInset>
-							<Toaster />
-						</BreadcrumbTitleProvider>
-					</CommandPaletteProvider>
-				</AgentOwnershipProvider>
-			</ProductAccessProvider>
-		</SidebarProvider>
+							</div>
+						</SidebarInset>
+						<Toaster />
+					</BreadcrumbTitleProvider>
+				</CommandPaletteProvider>
+			</AgentOwnershipProvider>
+		</ProductAccessProvider>
 	);
 }
 

--- a/apps/web/src/pages/oauth/codex/callback/page.tsx
+++ b/apps/web/src/pages/oauth/codex/callback/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { lazy, Suspense } from "react";
+import { AccountDataBoundary } from "@/components/account-suspension-boundary";
 import { RouteLoadingSkeleton } from "@/components/route-loading-skeleton";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
@@ -15,7 +16,9 @@ const CodexOAuthCallback = IS_HOSTED_BUILD
 export default function CodexOAuthCallbackPage() {
 	return CodexOAuthCallback ? (
 		<Suspense fallback={<RouteLoadingSkeleton />}>
-			<CodexOAuthCallback />
+			<AccountDataBoundary>
+				<CodexOAuthCallback />
+			</AccountDataBoundary>
 		</Suspense>
 	) : null;
 }

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -9,9 +9,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
-import { unwrap, useApi } from "@/lib/api";
+import { getPublicSharePreview, unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
-import { useCurrentUser, useDashboardAuth } from "@/lib/auth-client";
+import { useCurrentUser, useDashboardAuth, useSessionIdentity } from "@/lib/auth-client";
 import { projectDetailHref } from "@/lib/project-resource-model";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
 
@@ -67,6 +67,7 @@ export default function SharePage({ token }: { token: string }) {
 	const router = useRouter();
 	const { isSignedIn, getToken } = useDashboardAuth();
 	const { user } = useCurrentUser();
+	const sessionIdentity = useSessionIdentity();
 	const previewRequestRef = useRef(0);
 	const [preview, setPreview] = useState<{
 		data: SharePreview | null;
@@ -81,9 +82,7 @@ export default function SharePage({ token }: { token: string }) {
 		setPreview({ data: null, error: null, isLoading: true });
 		void (async () => {
 			try {
-				const result = await api.GET("/v1/share/{token}/preview", {
-					params: { path: { token } },
-				});
+				const result = await getPublicSharePreview(token);
 				if (result.error !== undefined)
 					throw shareErrorFromApi(result.response.status, result.error);
 				if (previewRequestRef.current === requestId) {
@@ -98,7 +97,7 @@ export default function SharePage({ token }: { token: string }) {
 		return () => {
 			previewRequestRef.current += 1;
 		};
-	}, [api, token]);
+	}, [token]);
 
 	const upgrade = useSensitiveAction(async () => {
 		const bearer = await getToken();
@@ -176,7 +175,7 @@ export default function SharePage({ token }: { token: string }) {
 						<div className="space-y-3">
 							<Button
 								onClick={() => void upgrade.execute().catch(() => undefined)}
-								disabled={upgrade.isPending}
+								disabled={upgrade.isPending || !sessionIdentity}
 								className="w-full"
 								size="lg"
 							>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -5,7 +5,6 @@ import { routeTree } from "./routeTree.gen";
 export function getRouter() {
 	const router = createRouter({
 		routeTree,
-		context: { auth: undefined },
 		defaultPreload: "intent",
 		scrollRestoration: true,
 		scrollToTopSelectors: ["#dashboard-scroll-container"],

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,19 +1,18 @@
 /// <reference types="vite/client" />
 
-import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { AppNotFound } from "@/components/app-not-found";
 import { AuthProvider } from "@/components/auth-provider";
 import { Providers } from "@/components/providers";
 import RootError from "@/components/root-error";
 import { APP_TITLE } from "@/lib/document-title";
-import type { AppRouterContext } from "@/lib/route-auth";
 import "@/styles/globals.css";
 
 const DESCRIPTION =
 	"Cloud control plane for AI agents - manage sessions, skills, memories, and secrets across the machines you connect.";
 
-export const Route = createRootRouteWithContext<AppRouterContext>()({
+export const Route = createRootRoute({
 	head: () => ({
 		meta: [
 			{ charSet: "utf-8" },

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,8 +1,7 @@
 import { auth } from "@clerk/tanstack-react-start/server";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { createIsomorphicFn, createServerFn } from "@tanstack/react-start";
+import { createServerFn } from "@tanstack/react-start";
 import { setResponseHeader } from "@tanstack/react-start/server";
-import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
 import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
 import { env } from "@/lib/env";
 import { type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
@@ -16,19 +15,13 @@ const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
 	return { userId, sessionId };
 });
 
-const admitRoute = createIsomorphicFn()
-	.server(async ({ href }: { auth: RouteAuth | undefined; href: string }) => {
+export const Route = createFileRoute("/_protected")({
+	beforeLoad: async ({ location }) => {
 		const { userId, sessionId } = await getAuthState();
 		const serverAuth: RouteAuth =
 			userId && sessionId ? { status: "signed-in", userId, sessionId } : { status: "signed-out" };
-		return { authIdentity: requireRouteIdentity(serverAuth, href) };
-	})
-	.client(({ auth, href }: { auth: RouteAuth | undefined; href: string }) => ({
-		authIdentity: requireRouteIdentity(auth, href),
-	}));
-
-export const Route = createFileRoute("/_protected")({
-	beforeLoad: ({ context, location }) => admitRoute({ auth: context.auth, href: location.href }),
+		return { authIdentity: requireRouteIdentity(serverAuth, location.href) };
+	},
 	errorComponent: ProtectedRouteError,
 	component: ProtectedLayout,
 });
@@ -37,9 +30,7 @@ function ProtectedLayout() {
 	const { authIdentity } = Route.useRouteContext();
 	return (
 		<ProtectedAuthBoundary identity={authIdentity}>
-			<AccountSuspensionBoundary>
-				<Outlet />
-			</AccountSuspensionBoundary>
+			<Outlet />
 		</ProtectedAuthBoundary>
 	);
 }

--- a/apps/web/src/routes/_protected/terminal/$id.tsx
+++ b/apps/web/src/routes/_protected/terminal/$id.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
+import { AccountDataBoundary } from "@/components/account-suspension-boundary";
 import { isAgentRouteId } from "@/lib/agent-routes";
 import { routeHeadTitle } from "@/lib/document-title";
 import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
@@ -20,7 +21,9 @@ function TerminalWindowRoute() {
 			data-mava-launcher="hidden"
 			className="flex h-svh min-h-0 w-full overflow-hidden bg-background"
 		>
-			<AgentDetailClient environmentId={id} section="terminal" routeSearch={{}} standalone />
+			<AccountDataBoundary>
+				<AgentDetailClient environmentId={id} section="terminal" routeSearch={{}} standalone />
+			</AccountDataBoundary>
 		</main>
 	);
 }

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -73,6 +73,11 @@ status through typed native Router context; it does not reverify the session
 on the Start server for each navigation. API, Files grants, runtime and stream
 authorization remain independent server boundaries.
 
+Clerk-owned navigation uses native document push/replace so login and signup
+enter through fresh SSR admission. Clerk temporarily clears its session while
+awaiting navigation; routing that transition through SPA admission would replace
+the destination with a global auth loading state. Dashboard links remain SPA.
+
 `AuthRouterBridge` replaces the QueryClient on user/session identity changes,
 retires protected route preloads, and invalidates protected matches.
 `ProtectedAuthBoundary` prevents a cached match from rendering under another

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -67,30 +67,31 @@ validated env module. If you bypass that Bun config, seed
 
 ## Route admission
 
-Initial SSR still uses Clerk request middleware and server `auth()` with
-`cache-control: no-store`. SPA navigation uses live Clerk `useAuth()` and SDK
-status through typed native Router context; it does not reverify the session
-on the Start server for each navigation. API, Files grants, runtime and stream
-authorization remain independent server boundaries.
+Protected routes use Clerk request middleware and a Start server function calling
+`auth()` for both SSR and SPA admission, with `cache-control: no-store`. This adds
+a server round trip to protected navigation. Clerk's default SPA navigation is
+unchanged: its session cookie is updated before navigation, while its client
+session resource is published after navigation completes.
 
-Clerk-owned navigation uses native document push/replace so login and signup
-enter through fresh SSR admission. Clerk temporarily clears its session while
-awaiting navigation; routing that transition through SPA admission would replace
-the destination with a global auth loading state. Dashboard links remain SPA.
+`ProtectedAuthBoundary` supplies account-data readiness without replacing the
+layout. The actual dashboard frame and navigation remain visible; private page
+content, account actions, notifications, prefetches, and hosted sensors wait for
+the native SessionResource and live auth identity to match server admission.
+SSR does not invent a browser SessionResource. Non-dashboard protected pages
+keep their own layouts. Same ready identity navigation retains mounted pages,
+iframes, drafts, and caches. Identity loss/change clears private regions and
+resets account-owned layout state.
 
-`AuthRouterBridge` replaces the QueryClient on user/session identity changes,
-retires protected route preloads, and invalidates protected matches.
-`ProtectedAuthBoundary` prevents a cached match from rendering under another
-live identity. Same-identity navigation keeps its cache and mounted state.
-Clerk's native authenticated SSR snapshot remains admitted while its browser
-SDK initializes; script loading alone does not replace the cache or unmount
-content. Unknown auth, pending/signed-out sessions and explicit SDK
-degraded/error states do not admit protected UI. No application auth snapshot
-is retained: Clerk owns the handover from SSR to emitted client resources.
-Native auth is not proof of immediate remote revocation or current JWT validity;
-denied API requests remain errors. Account-admission failures block protected content;
-401 offers explicit reauthentication, while other failures remain recoverable
-without signing the user out.
+`AuthRouterBridge` scopes QueryClient and account-suspension observations to the
+live user/session, retires protected preloads, and revalidates server admission
+on settled identity changes. It does not invalidate routes while Clerk is in its
+transitive unloaded state. Token getters bind to the native SessionResource and
+reject absent tokens or a changed active session instead of sending anonymous
+requests or acquiring another session's credentials. Late suspension responses
+and query/mutation cache callbacks retain their originating account scope.
+API, Files grants, runtime, and stream authorization remain server boundaries.
+An account-admission 401 offers explicit reauthentication; other failures remain
+recoverable without signing the user out.
 
 Inside an isolated Docker browser-test environment with dependencies and
 Chromium installed, run the SDK-event contract suite:
@@ -99,8 +100,12 @@ Chromium installed, run the SDK-event contract suite:
 bun run --cwd apps/web e2e --config=playwright.auth.config.ts
 ```
 
-Done: the lifecycle suite passes without Clerk credentials. Its event mocks
-test the integration contract, not a live Clerk tenant.
+Done: the lifecycle suite passes without Clerk credentials. Its simulated SDK
+resource and cookie events exercise the production dashboard layout and Router, including the activation
+ordering, SSR resource handover, null tokens, and late old-account responses.
+They do not authenticate against a live Clerk tenant. Set
+`VITE_CLAWDI_HOSTED=true` and filter to `--grep "native SPA activation"` to also
+exercise hosted notifications and access sensors.
 
 ## OSS build boundary
 


### PR DESCRIPTION
Clerk temporarily clears its browser session while awaiting login navigation. Live-client route admission treated this normal transition as a full-page authentication loader. Protected SSR and SPA routes now use the existing server `auth()` function for admission, while Clerk keeps its default SPA navigation.

The real dashboard frame remains visible. Private content, account actions, notifications and hosted sensors wait until the native SessionResource matches the admitted identity. Same-session navigation retains mounted pages, iframes and drafts. Request credentials bind to their originating session and reject missing tokens; QueryClient and account-suspension effects are scoped to that session so late requests cannot affect the next account. Anonymous invitation previews remain public.

Validation in isolated Docker: 17 browser contracts, an additional hosted activation case, 8 real production-bundle SSR checks using synthetic JWTs, 38 focused unit tests, typecheck, Biome and OSS build passed. Restoring either the prior hard-navigation override or the prior global loading boundary made the activation regression fail. Root reviewed the full two-dot diff and removed two duplicate assertions; final head is c8ec3311a.

Tradeoffs: protected navigation adds a server authentication round trip, and private data waits for the browser SessionResource rather than treating the SSR snapshot as usable browser credentials. Browser SDK events are simulated; no real tenant login or permanent-hang reproduction is claimed. No API schema, database or CLI package changes are included.
