### PR TITLE
perf(cli): avoid unnecessary local session processing in 0.14.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.66 skips unnecessary content processing when filtering local Codex
+  sessions by project and reduces repeated comparisons in Claude Code resume histories.
+
 - CLI 0.14.65 reduces local processing during session synchronization and avoids
   repeated session-list scans when pushing large local histories.
 

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.65",
+      "version": "0.14.66",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.65",
+	"version": "0.14.66",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -529,8 +529,8 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
  * via Claude Code's file-history-snapshot replay). We drop the predecessor
  * from the upload set and keep the longest leaf.
  *
- * Multi-link chains (A ⊂ B ⊂ C) collapse in a single pass by always linking
- * each predecessor to the LARGEST proper superset in its project group.
+ * Multi-link chains (A ⊂ B ⊂ C) collapse in a single pass: each predecessor
+ * is dropped as soon as any proper superset is found in its project group.
  *
  * Sessions with fewer than 10 uuids are excluded from the predecessor side
  * of the comparison — too short to reliably tell "real subset" from
@@ -563,9 +563,6 @@ function dedupeResumeChains(
 			const a = candidates[i];
 			const aSet = uuids.get(a);
 			if (!aSet) continue;
-			// Find the LARGEST b that strictly contains a — handles A⊂B⊂C
-			// by deduping both A and B into C in a single pass.
-			let bestJ = -1;
 			for (let j = i + 1; j < candidates.length; j++) {
 				const b = candidates[j];
 				const bSet = uuids.get(b);
@@ -577,9 +574,11 @@ function dedupeResumeChains(
 						break;
 					}
 				}
-				if (isSubset) bestJ = j;
+				if (isSubset) {
+					dedupedIds.add(a.localSessionId);
+					break;
+				}
 			}
-			if (bestJ >= 0) dedupedIds.add(a.localSessionId);
 		}
 	}
 

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -388,7 +388,7 @@ function parseSessionFile(filePath: string, absFilter: string | null): RawSessio
 	}
 	if (!sessionId) return null;
 	if (absFilter) {
-		if (!projectPath) return null;
+		if (typeof projectPath !== "string") return null;
 		if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) return null;
 	}
 	const events = sequenceSessionEvents(

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -387,6 +387,10 @@ function parseSessionFile(filePath: string, absFilter: string | null): RawSessio
 		rawEntries.push({ raw, recordSeq, model: lastModel });
 	}
 	if (!sessionId) return null;
+	if (absFilter) {
+		if (!projectPath) return null;
+		if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) return null;
+	}
 	const events = sequenceSessionEvents(
 		rawEntries.flatMap(({ raw, recordSeq, model }) =>
 			codexEventDrafts(raw, sessionId as string, recordSeq).map((draft) =>
@@ -397,10 +401,6 @@ function parseSessionFile(filePath: string, absFilter: string | null): RawSessio
 	const messages = projectEventsToMessages(events);
 
 	if (messages.length === 0 || !startedAt) return null;
-	if (absFilter) {
-		if (!projectPath) return null;
-		if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) return null;
-	}
 
 	endedAt ??= startedAt;
 	const firstRealUser = messages.find(

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -315,6 +315,30 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		expect(result.sessions.map((s) => s.localSessionId)).toEqual(["cccc-cccc"]);
 	});
 
+	it("keeps equal-sized resume leaves, including identical uuid sets", async () => {
+		const cwd = "/Users/fixture/resume-branches";
+		const shared = uuidRange("shared", 10);
+		writeResumeSessionFile({ cwd, sessionId: "predecessor", uuids: shared });
+		for (const [sessionId, suffix] of [
+			["branch-a", "a"],
+			["branch-a-copy", "a"],
+			["branch-b", "b"],
+		]) {
+			writeResumeSessionFile({ cwd, sessionId, uuids: [...shared, suffix] });
+		}
+
+		const adapter = new ClaudeCodeAdapter();
+		const result = await adapter.sessions.collect({ kind: "complete", projectFilter: cwd });
+		expect(result.sessions.map((session) => session.localSessionId).sort()).toEqual([
+			"branch-a",
+			"branch-a-copy",
+			"branch-b",
+		]);
+		expect(result.dedupedCount).toBe(1);
+		expect(await adapter.sessions.resolve("predecessor")).toBeNull();
+		expect((await adapter.sessions.resolve("branch-a-copy"))?.localSessionId).toBe("branch-a-copy");
+	});
+
 	it("does not dedupe across different projects even when uuid sets are subset", async () => {
 		const aUuids = uuidRange("u", 12);
 		const bUuids = [...aUuids, ...uuidRange("v", 8)];

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -157,6 +157,32 @@ describe("CodexAdapter.collectSessions", () => {
 		expect((await a.sessions.collect({ kind: "complete" })).sessions).toEqual([]);
 	});
 
+	it("skips malformed project metadata during filtered scans", async () => {
+		const path = join(tmpHome, ".codex", "sessions", "invalid-project.jsonl");
+		writeFileSync(
+			path,
+			`${JSON.stringify({ type: "session_meta", payload: { id: "invalid", cwd: 123 } })}\n`,
+		);
+		const adapter = new CodexAdapter();
+		expect(
+			(
+				await adapter.sessions.collect({
+					kind: "complete",
+					projectFilter: "/Users/fixture/project",
+				})
+			).sessions,
+		).toHaveLength(1);
+		expect(
+			(
+				await adapter.sessions.collect({
+					kind: "paths",
+					paths: [path],
+					projectFilter: "/Users/fixture/project",
+				})
+			).sessions,
+		).toEqual([]);
+	});
+
 	it("summary skips <environment_context> prefix user messages", async () => {
 		const a = new CodexAdapter();
 		const s = (await a.sessions.collect({ kind: "complete" })).sessions[0]!;


### PR DESCRIPTION
Local Codex project scans constructed content for unrelated projects, and Claude Code resume dedupe kept searching after it had already found a strict superset. CLI 0.14.66 filters after the complete metadata scan but before Codex content projection, and stops each Claude predecessor comparison at the first strict superset.

Selection still uses final metadata, project boundaries, existing UUID thresholds and the same backing-store reads. Filtered Codex scans explicitly skip malformed non-string project paths. Two focused regressions cover that boundary and equal-size branched histories.

Validation: final integrated CLI typecheck, 60 existing/focused tests and Biome passed in Docker at 2 CPU / 3 GiB. Controlled full-adapter comparisons preserved complete results: Codex selected-project median 447→52 ms (48 synthetic files), Claude long-chain collect/resolve 2704→1481 and 2716→1552 ms (384 synthetic histories). Controls contain adverse/noisy results; these are favorable local fixtures, not production or general whole-CLI speedups. Codex timing precedes the malformed-path guard; legal fixture behavior is unchanged and final correctness checks include the guard.

The version bump triggers the standard immutable CLI publication workflow after merge. Package layout and Hosted selected versions are unchanged.
