### PR TITLE
refactor(web): remove redundant auth admission and token branches

### DIFF
--- a/apps/web/e2e/auth/hydration.browser.tsx
+++ b/apps/web/e2e/auth/hydration.browser.tsx
@@ -11,12 +11,14 @@ import { useLayoutEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { AccountDataBoundary } from "@/components/account-suspension-boundary";
 import { AuthRouterBridge } from "@/components/auth-router-bridge";
-import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
-import { type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
+import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
+import RootError from "@/components/root-error";
+import { requireRouteIdentity } from "@/lib/route-auth";
 import { useHydrated } from "@/lib/use-hydrated";
 import { emitSdk, serverAuth as readServerAuth } from "./clerk-fixture";
 
-const serverAuth: RouteAuth = { status: "signed-in", userId: "user-a", sessionId: "session-a" };
+const serverAuth = { userId: "user-a", sessionId: "session-a" };
+let admissions = 0;
 const errors: string[] = [];
 let hydrated = false;
 
@@ -49,19 +51,12 @@ function createProbeRouter(isServer: boolean) {
 		getParentRoute: () => root,
 		id: "_protected",
 		beforeLoad: ({ location }) => {
-			const { userId, sessionId } = readServerAuth();
+			admissions += 1;
 			return {
-				authIdentity: requireRouteIdentity(
-					isServer
-						? serverAuth
-						: userId && sessionId
-							? { status: "signed-in", userId, sessionId }
-							: { status: "signed-out" },
-					location.href,
-				),
+				authIdentity: requireRouteIdentity(isServer ? serverAuth : readServerAuth(), location.href),
 			};
 		},
-		errorComponent: ProtectedRouteError,
+		errorComponent: RootError,
 		component: () => (
 			<ProtectedAuthBoundary identity={protectedRoute.useRouteContext().authIdentity}>
 				<header>
@@ -113,6 +108,9 @@ if (typeof document !== "undefined") {
 	const element = document.getElementById("app");
 	if (!element) throw new Error("Missing hydration root");
 	window.hydrationTest = {
+		get admissions() {
+			return admissions;
+		},
 		errors,
 		emitSdk,
 		get hydrated() {
@@ -134,6 +132,7 @@ if (typeof document !== "undefined") {
 declare global {
 	interface Window {
 		hydrationTest: {
+			admissions: number;
 			hydrated: boolean;
 			errors: string[];
 			emitSdk: typeof emitSdk;

--- a/apps/web/e2e/auth/hydration.pw.ts
+++ b/apps/web/e2e/auth/hydration.pw.ts
@@ -26,6 +26,7 @@ for (const signedOut of [false, true]) {
 			expect(await page.evaluate(() => window.hydrationTest.errors)).toEqual([]);
 			expect(await header.evaluate((node) => node === document.querySelector("header"))).toBe(true);
 			expect(requests).toEqual([]);
+			expect(await page.evaluate(() => window.hydrationTest.admissions)).toBe(0);
 			await page.evaluate(
 				(signedOut) =>
 					window.hydrationTest.emitSdk({
@@ -46,6 +47,7 @@ for (const signedOut of [false, true]) {
 				await expect.poll(() => requests.length).toBeGreaterThan(0);
 				expect(requests.every((token) => token === "Bearer user-a:session-a")).toBe(true);
 			}
+			expect(await page.evaluate(() => window.hydrationTest.admissions)).toBe(signedOut ? 1 : 0);
 		} finally {
 			entry.resolve();
 		}

--- a/apps/web/e2e/auth/lifecycle.browser.tsx
+++ b/apps/web/e2e/auth/lifecycle.browser.tsx
@@ -10,14 +10,13 @@ import {
 import { useLayoutEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { AuthProvider } from "@/components/auth-provider";
-import { AuthStatus } from "@/components/auth-status";
 import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
 import { Providers } from "@/components/providers";
 import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import { useApi } from "@/lib/api";
 import { ApiError, normalizeApiError } from "@/lib/api-errors";
 import { useAuthToken, useRouteAuth } from "@/lib/auth-client";
-import { RouteAuthUnavailable, requireRouteIdentity } from "@/lib/route-auth";
+import { requireRouteIdentity } from "@/lib/route-auth";
 import DashboardLayout from "@/pages/dashboard/layout";
 import SharePage from "@/pages/share/project-share-page";
 import {
@@ -30,6 +29,7 @@ import {
 import "@/styles/globals.css";
 
 const commits: { identity: string | null; data: string | undefined }[] = [];
+let admissions = 0;
 let currentClient: ReturnType<typeof useQueryClient> | undefined;
 let held: ReturnType<typeof Promise.withResolvers<string>> | undefined;
 let abortedPreload = false;
@@ -50,20 +50,10 @@ const protectedRoute = createRoute({
 	getParentRoute: () => root,
 	id: "_protected",
 	beforeLoad: async ({ location }) => {
-		const { userId, sessionId } = serverAuth();
-		return {
-			authIdentity: requireRouteIdentity(
-				userId && sessionId ? { status: "signed-in", userId, sessionId } : { status: "signed-out" },
-				location.href,
-			),
-		};
+		admissions += 1;
+		return { authIdentity: requireRouteIdentity(serverAuth(), location.href) };
 	},
-	errorComponent: ({ error }) =>
-		error instanceof RouteAuthUnavailable ? (
-			<AuthStatus status={error.status} />
-		) : (
-			<p role="alert">Route failed</p>
-		),
+	errorComponent: () => <p role="alert">Route failed</p>,
 	component: () => {
 		const { authIdentity } = protectedRoute.useRouteContext();
 		return (
@@ -190,6 +180,9 @@ function PrivatePane() {
 }
 
 window.authTest = {
+	get admissions() {
+		return admissions;
+	},
 	emitSdk,
 	activateSession,
 	releaseActivation,
@@ -229,6 +222,7 @@ window.authTest = {
 declare global {
 	interface Window {
 		authTest: {
+			admissions: number;
 			emitSdk: typeof emitSdk;
 			activateSession: typeof activateSession;
 			releaseActivation: typeof releaseActivation;
@@ -248,4 +242,19 @@ declare global {
 }
 const element = document.getElementById("app");
 if (!element) throw new Error("Missing test root");
-createRoot(element).render(<RouterProvider router={router} />);
+const bootstrap = new URLSearchParams(location.search).get("bootstrap");
+if (bootstrap) {
+	// Complete server admission before mounting, then publish the first live SDK snapshot.
+	void router
+		.navigate({ href: "/private/a" })
+		.then(() => {
+			if (bootstrap === "signed-out") emitSdk({ userId: null, sessionId: null });
+			if (bootstrap === "other-account") emitSdk({ userId: "user-b", sessionId: "session-b" });
+			createRoot(element).render(<RouterProvider router={router} />);
+		})
+		.catch(() => {
+			element.textContent = "Initial route failed";
+		});
+} else {
+	createRoot(element).render(<RouterProvider router={router} />);
+}

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -1,7 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 import type {} from "./lifecycle.browser";
 
-async function start(page: Page) {
+async function start(page: Page, bootstrap?: string) {
 	await page.route("http://127.0.0.1:8000/**", (route) =>
 		route.fulfill({
 			contentType: "application/json",
@@ -12,9 +12,34 @@ async function start(page: Page) {
 					: "[]",
 		}),
 	);
-	await page.goto("/e2e/auth/");
+	await page.goto(bootstrap ? `/e2e/auth/?bootstrap=${bootstrap}` : "/e2e/auth/");
+	if (bootstrap) return;
 	await page.evaluate(() => window.authTest.navigate("/private/a"));
 	await expect(page.locator("[data-private]")).toHaveText("user-a:session-a");
+}
+
+for (const bootstrap of ["same-account", "other-account", "signed-out"]) {
+	test(`first settled mount revalidates only an admission mismatch: ${bootstrap}`, async ({
+		page,
+	}) => {
+		await start(page, bootstrap);
+		if (bootstrap === "signed-out") {
+			await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sign in");
+			await expect(page.locator("[data-private]")).toHaveCount(0);
+		} else {
+			await expect(page.locator("[data-private]")).toHaveText(
+				bootstrap === "same-account" ? "user-a:session-a" : "user-b:session-b",
+			);
+		}
+		expect(await page.evaluate(() => window.authTest.admissions)).toBe(
+			bootstrap === "same-account" ? 1 : 2,
+		);
+		expect(
+			await page.evaluate(() =>
+				window.authTest.commits.filter((commit) => commit.data && commit.data !== commit.identity),
+			),
+		).toEqual([]);
+	});
 }
 
 test("same identity keeps cache, draft and iframe document across navigation and history", async ({

--- a/apps/web/src/components/auth-router-bridge.tsx
+++ b/apps/web/src/components/auth-router-bridge.tsx
@@ -13,7 +13,12 @@ export function AuthRouterBridge({ children }: { children: React.ReactNode }) {
 	const auth = useRouteAuth();
 	const identity = routeAuthIdentity(auth);
 	const authKey = identity ?? auth.status;
-	const previousAuthKey = useRef<string | undefined>(undefined);
+	// Hydration restores beforeLoad context. Use that admission as the baseline,
+	// so the first live snapshot still revalidates a different user or sign-out.
+	const admittedMatch = router.state.matches.find((match) => match.routeId === "/_protected");
+	const previousAuthKey = useRef(
+		admittedMatch?.status === "success" ? admittedMatch.context.authIdentity : undefined,
+	);
 	const [scope, setScope] = useState(() => ({
 		identity,
 		queryClient: createAppQueryClient(),

--- a/apps/web/src/components/protected-auth-boundary.tsx
+++ b/apps/web/src/components/protected-auth-boundary.tsx
@@ -1,17 +1,6 @@
-import type { ErrorComponentProps } from "@tanstack/react-router";
 import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
-import { AuthStatus } from "@/components/auth-status";
-import RootError from "@/components/root-error";
 import { useRouteAuth, useSessionIdentity } from "@/lib/auth-client";
-import { RouteAuthUnavailable, routeAuthIdentity } from "@/lib/route-auth";
-
-export function ProtectedRouteError({ error, reset }: ErrorComponentProps) {
-	return error instanceof RouteAuthUnavailable ? (
-		<AuthStatus status={error.status} />
-	) : (
-		<RootError error={error} reset={reset} />
-	);
-}
+import { routeAuthIdentity } from "@/lib/route-auth";
 
 export function ProtectedAuthBoundary({
 	identity: admittedIdentity,

--- a/apps/web/src/hosted/access/product-access.ts
+++ b/apps/web/src/hosted/access/product-access.ts
@@ -23,7 +23,7 @@ export const hostedProductAccessKeys = {
 };
 
 async function fetchHostedProductAccessProfile(
-	getToken: () => Promise<string | null>,
+	getToken: () => Promise<string>,
 ): Promise<HostedProductAccessProfile> {
 	const token = await getToken();
 	const api = createClient<DeployPaths>({
@@ -31,7 +31,7 @@ async function fetchHostedProductAccessProfile(
 		fetch: fetchHostedProductAccessWithTimeout,
 	});
 	const result = await api.GET("/v1/me", {
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+		headers: { Authorization: `Bearer ${token}` },
 	});
 	if (!result.response.ok) {
 		throw new ApiError(

--- a/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
+++ b/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
@@ -35,7 +35,6 @@ export function useFilesGrantBootstrap(url: string): FilesGrantBootstrapState {
 		void (async () => {
 			try {
 				const token = await getToken();
-				if (!token) throw new Error("No Clerk session token");
 				await primeFilesGrant(url, token);
 				if (!cancelled) setState("ready");
 			} catch {
@@ -69,7 +68,6 @@ export function useOpenFilesInNewWindow(url: string, deploymentId: string): () =
 		trackRuntimeWindow(deploymentId, popup);
 		try {
 			const token = await getToken();
-			if (!token) throw new Error("No Clerk session token");
 			await primeFilesGrant(url, token);
 			popup.location.replace(url);
 		} catch {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -76,7 +76,7 @@ export { isDeployApiConfigured };
 
 type DeployResult<T> = { data?: T; error?: unknown; response: Response };
 type BillingFetch = (request: Request) => Promise<Response>;
-type BillingAuthTokenGetter = () => Promise<string | null | undefined>;
+type BillingAuthTokenGetter = () => Promise<string>;
 
 export type AcceptedOperation = { deploymentId: string; operation: DeploymentOperation };
 export type DeploymentDeleteResult = AcceptedOperation | { deploymentId: string; operation: null };
@@ -524,7 +524,7 @@ export function createBillingClient(
 	api.use({
 		async onRequest({ request }) {
 			const token = await getToken();
-			if (token) request.headers.set("Authorization", `Bearer ${token}`);
+			request.headers.set("Authorization", `Bearer ${token}`);
 			return request;
 		},
 	});
@@ -566,7 +566,7 @@ export function createBillingClient(
 			Accept: "text/event-stream",
 			"Last-Event-ID": cursor,
 		});
-		if (token) headers.set("Authorization", `Bearer ${token}`);
+		headers.set("Authorization", `Bearer ${token}`);
 		const path = deploymentId
 			? `/v2/deployments/${encodeURIComponent(deploymentId)}/events`
 			: "/v2/events";

--- a/apps/web/src/hosted/notification-center.tsx
+++ b/apps/web/src/hosted/notification-center.tsx
@@ -26,13 +26,6 @@ const accountNotificationKeys = {
 	all: (userId: string) => ["hosted-account-notifications", userId] as const,
 };
 
-async function authorizationHeaders(
-	getToken: () => Promise<string | null>,
-): Promise<{ Authorization: string } | undefined> {
-	const token = await getToken();
-	return token ? { Authorization: `Bearer ${token}` } : undefined;
-}
-
 function responseError(response: Response): ApiError {
 	return new ApiError(response.status, response.statusText || "Hosted notification request failed");
 }
@@ -67,7 +60,7 @@ export function HostedNotificationCenter() {
 						cursor: pageParam,
 					},
 				},
-				headers: await authorizationHeaders(getToken),
+				headers: { Authorization: `Bearer ${await getToken()}` },
 				signal,
 			});
 			if (!result.response.ok || !result.data) throw responseError(result.response);
@@ -98,7 +91,7 @@ export function HostedNotificationCenter() {
 			const result = await notificationApi.PATCH("/v1/me/notifications/{notification_id}", {
 				params: { path: { notification_id: id } },
 				body: { read },
-				headers: await authorizationHeaders(getToken),
+				headers: { Authorization: `Bearer ${await getToken()}` },
 			});
 			if (!result.response.ok || !result.data) throw responseError(result.response);
 			return result.data;
@@ -113,7 +106,7 @@ export function HostedNotificationCenter() {
 		mutationFn: async (id: string) => {
 			const result = await notificationApi.DELETE("/v1/me/notifications/{notification_id}", {
 				params: { path: { notification_id: id } },
-				headers: await authorizationHeaders(getToken),
+				headers: { Authorization: `Bearer ${await getToken()}` },
 			});
 			if (!result.response.ok) throw responseError(result.response);
 		},
@@ -126,7 +119,7 @@ export function HostedNotificationCenter() {
 	const markAllRead = useMutation({
 		mutationFn: async () => {
 			const result = await notificationApi.POST("/v1/me/notifications/read-all", {
-				headers: await authorizationHeaders(getToken),
+				headers: { Authorization: `Bearer ${await getToken()}` },
 			});
 			if (!result.response.ok || !result.data) throw responseError(result.response);
 			return result.data;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -105,7 +105,7 @@ function useConfiguredApi(throwOnError: boolean) {
 		client.use({
 			async onRequest({ request }) {
 				const token = await getToken();
-				if (token) request.headers.set("Authorization", `Bearer ${token}`);
+				request.headers.set("Authorization", `Bearer ${token}`);
 				return request;
 			},
 		});
@@ -210,7 +210,7 @@ export function useSkillArchiveUploader() {
 
 			const headers = new Headers();
 			const token = await getToken();
-			if (token) headers.set("Authorization", `Bearer ${token}`);
+			headers.set("Authorization", `Bearer ${token}`);
 
 			const response = await accountFetch(
 				new Request(apiUrl(`/v1/projects/${encodeURIComponent(projectId)}/skills/upload`), {
@@ -238,7 +238,7 @@ export function useAgentAvatarUploader() {
 
 			const headers = new Headers();
 			const token = await getToken();
-			if (token) headers.set("Authorization", `Bearer ${token}`);
+			headers.set("Authorization", `Bearer ${token}`);
 
 			const response = await accountFetch(
 				new Request(apiUrl(`/v1/agents/${encodeURIComponent(environmentId)}/avatar`), {

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -61,8 +61,10 @@ export function useDashboardAuth() {
 }
 
 export function useRouteAuth() {
-	const auth = useDashboardAuth();
-	if (env.VITE_DEV_AUTH_BYPASS) return resolveRouteAuth(auth, "ready");
+	if (env.VITE_DEV_AUTH_BYPASS) {
+		return { status: "signed-in", userId: DEV_USER.id, sessionId: "dev_browser_session" } as const;
+	}
+	const auth = useAuth();
 	const clerk = useClerk();
 	// ClerkProvider propagates status changes. useAuth owns the native SSR
 	// snapshot during SDK bootstrap; script loading is not identity loss.

--- a/apps/web/src/lib/route-auth.test.ts
+++ b/apps/web/src/lib/route-auth.test.ts
@@ -1,17 +1,12 @@
 import { expect, test } from "bun:test";
 import { isRedirect } from "@tanstack/react-router";
-import {
-	RouteAuthUnavailable,
-	requireRouteIdentity,
-	resolveRouteAuth,
-	routeAuthIdentity,
-} from "./route-auth";
+import { requireRouteIdentity, resolveRouteAuth, routeAuthIdentity } from "./route-auth";
 
 const signedIn = { isLoaded: true, isSignedIn: true, userId: "user-a", sessionId: "session-a" };
 
-test("admission uses a loaded live session, including same-user session changes", () => {
+test("server admission and live identity agree, including same-user session changes", () => {
 	const auth = resolveRouteAuth(signedIn, "ready");
-	expect(requireRouteIdentity(auth, "/agents")).toBe(JSON.stringify(["user-a", "session-a"]));
+	expect(requireRouteIdentity(signedIn, "/agents")).toBe(JSON.stringify(["user-a", "session-a"]));
 	expect(
 		routeAuthIdentity(resolveRouteAuth({ ...signedIn, sessionId: "session-b" }, "ready")),
 	).not.toBe(routeAuthIdentity(auth));
@@ -24,27 +19,18 @@ test("native authenticated SSR state admits during SDK bootstrap", () => {
 	expect(resolveRouteAuth(signedIn, "loading")).toEqual(resolveRouteAuth(signedIn, "ready"));
 });
 
-test("unknown auth and explicit SDK failures never admit, even with a signed-in SSR snapshot", () => {
+test("unloaded auth and explicit SDK failures block private data despite an SSR snapshot", () => {
 	for (const status of ["degraded", "error"] as const) {
-		expect(() => requireRouteIdentity(resolveRouteAuth(signedIn, status), "/agents")).toThrow(
-			RouteAuthUnavailable,
-		);
+		expect(resolveRouteAuth(signedIn, status)).toEqual({ status: "unavailable" });
 	}
-	expect(() => requireRouteIdentity(undefined, "/agents")).toThrow(RouteAuthUnavailable);
-	for (const status of ["loading", "ready"] as const) {
-		expect(() =>
-			requireRouteIdentity(resolveRouteAuth({ ...signedIn, isLoaded: false }, status), "/agents"),
-		).toThrow(RouteAuthUnavailable);
-	}
+	expect(resolveRouteAuth({ ...signedIn, isLoaded: false }, "ready")).toEqual({
+		status: "loading",
+	});
 });
 
-test("signed-out and Clerk's default pending-as-signed-out result redirect with the destination", () => {
-	const auth = resolveRouteAuth(
-		{ isLoaded: true, isSignedIn: false, userId: null, sessionId: null },
-		"ready",
-	);
+test("signed-out server admission redirects with the destination", () => {
 	try {
-		requireRouteIdentity(auth, "/agents?view=all");
+		requireRouteIdentity({ userId: null, sessionId: null }, "/agents?view=all");
 		throw new Error("Expected a redirect");
 	} catch (error) {
 		expect(isRedirect(error)).toBe(true);

--- a/apps/web/src/lib/route-auth.ts
+++ b/apps/web/src/lib/route-auth.ts
@@ -1,12 +1,13 @@
 import type { useAuth, useClerk } from "@clerk/tanstack-react-start";
+import type { auth } from "@clerk/tanstack-react-start/server";
 import { redirect } from "@tanstack/react-router";
 
 export type RouteAuth =
 	| { status: "loading" | "unavailable" | "signed-out" }
 	| { status: "signed-in"; userId: string; sessionId: string };
 
-export function routeAuthIdentity(auth: RouteAuth | undefined): string | null {
-	return auth?.status === "signed-in" ? JSON.stringify([auth.userId, auth.sessionId]) : null;
+export function routeAuthIdentity(auth: RouteAuth): string | null {
+	return auth.status === "signed-in" ? JSON.stringify([auth.userId, auth.sessionId]) : null;
 }
 
 export function resolveRouteAuth(
@@ -19,19 +20,12 @@ export function resolveRouteAuth(
 	return { status: "signed-in", userId: auth.userId, sessionId: auth.sessionId };
 }
 
-export class RouteAuthUnavailable extends Error {
-	constructor(readonly status: "loading" | "unavailable") {
-		super("Authentication is not ready");
-	}
-}
-
-export function requireRouteIdentity(auth: RouteAuth | undefined, href: string): string {
-	if (!auth || auth.status === "loading" || auth.status === "unavailable") {
-		throw new RouteAuthUnavailable(auth?.status === "unavailable" ? "unavailable" : "loading");
-	}
-	const identity = routeAuthIdentity(auth);
-	if (identity === null) {
+export function requireRouteIdentity(
+	{ userId, sessionId }: Pick<Awaited<ReturnType<typeof auth>>, "userId" | "sessionId">,
+	href: string,
+): string {
+	if (!userId || !sessionId) {
 		throw redirect({ to: "/sign-in", search: { redirect_url: href } });
 	}
-	return identity;
+	return JSON.stringify([userId, sessionId]);
 }

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -2,9 +2,10 @@ import { auth } from "@clerk/tanstack-react-start/server";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { setResponseHeader } from "@tanstack/react-start/server";
-import { ProtectedAuthBoundary, ProtectedRouteError } from "@/components/protected-auth-boundary";
+import { ProtectedAuthBoundary } from "@/components/protected-auth-boundary";
+import RootError from "@/components/root-error";
 import { env } from "@/lib/env";
-import { type RouteAuth, requireRouteIdentity } from "@/lib/route-auth";
+import { requireRouteIdentity } from "@/lib/route-auth";
 
 const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
 	setResponseHeader("cache-control", "no-store");
@@ -17,12 +18,9 @@ const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
 
 export const Route = createFileRoute("/_protected")({
 	beforeLoad: async ({ location }) => {
-		const { userId, sessionId } = await getAuthState();
-		const serverAuth: RouteAuth =
-			userId && sessionId ? { status: "signed-in", userId, sessionId } : { status: "signed-out" };
-		return { authIdentity: requireRouteIdentity(serverAuth, location.href) };
+		return { authIdentity: requireRouteIdentity(await getAuthState(), location.href) };
 	},
-	errorComponent: ProtectedRouteError,
+	errorComponent: RootError,
 	component: ProtectedLayout,
 });
 

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -84,7 +84,10 @@ resets account-owned layout state.
 
 `AuthRouterBridge` scopes QueryClient and account-suspension observations to the
 live user/session, retires protected preloads, and revalidates server admission
-on settled identity changes. It does not invalidate routes while Clerk is in its
+on settled identity changes. The initial baseline is the Router's restored
+`beforeLoad` identity: matching server admission needs no extra invalidation,
+while a different first browser identity or sign-out still revalidates. It does
+not invalidate routes while Clerk is in its
 transitive unloaded state. Token getters bind to the native SessionResource and
 reject absent tokens or a changed active session instead of sending anonymous
 requests or acquiring another session's credentials. Late suspension responses
@@ -92,6 +95,18 @@ and query/mutation cache callbacks retain their originating account scope.
 API, Files grants, runtime, and stream authorization remain server boundaries.
 An account-admission 401 offers explicit reauthentication; other failures remain
 recoverable without signing the user out.
+
+These boundaries follow Clerk's [server/client auth guidance](https://clerk.com/docs/tanstack-react-start/guides/users/reading),
+[native session readiness](https://clerk.com/docs/tanstack-react-start/reference/hooks/use-session.md),
+and [nullable session tokens](https://clerk.com/docs/tanstack-react-start/reference/objects/session.md).
+TanStack's [route guards](https://raw.githubusercontent.com/TanStack/router/main/docs/router/guide/authenticated-routes.md)
+control navigation, not API authorization. Account-scoped caches and private-region
+[React keys](https://react.dev/learn/preserving-and-resetting-state) isolate business
+data and drafts; they do not manage Clerk activation. The scope's conditional
+[render-time state update](https://react.dev/reference/react/useState#storing-information-from-previous-renders)
+prevents children from committing against the previous account's cache.
+The admission query keeps [Query's `Infinity` stale time](https://raw.githubusercontent.com/TanStack/query/main/docs/framework/react/guides/important-defaults.md)
+and disables focus retries after failures; API authorization remains per request.
 
 Inside an isolated Docker browser-test environment with dependencies and
 Chromium installed, run the SDK-event contract suite:


### PR DESCRIPTION
A server-admitted dashboard mount unnecessarily invalidated protected routes a second time, while obsolete client-admission errors and nullable-token branches remained after the native login fix. Initialize the auth-change baseline from TanStack Router's restored admission so the same identity avoids duplicate work and an initial different account or sign-out still revalidates.

Remove the unreachable auth-error wrapper, narrow server admission directly to Clerk's auth result, avoid constructing unused token hooks, and remove downstream anonymous-token branches now that the shared session-bound getter returns a token or rejects. Native Clerk navigation, private data readiness and account-scoped caches remain intact. Production code is reduced by 21 lines, with no new settings or dependencies. The existing frontend guide links the Clerk, TanStack and React documentation behind the retained boundaries.

Validation in isolated Docker: 76 unit tests, 20 browser tests, one additional hosted activation case, eight production SSR checks, typecheck, Biome and OSS build passed. Negative controls caught both redundant first-mount invalidation and suppression of real initial identity mismatches. Root reviewed the complete two-dot diff against origin/main. Browser SDK events are simulated; no real Clerk tenant login was performed.
