### PR TITLE
fix(web): preserve Sui profile when deploying from Cloud dashboard

### DIFF
--- a/apps/web/e2e/handoff/handoff.pw.ts
+++ b/apps/web/e2e/handoff/handoff.pw.ts
@@ -175,7 +175,7 @@ for (const scenario of [
 				.getByRole("button", { name: /Deploy on Clawdi/ })
 				.click();
 		} else {
-			const link = page.getByRole("link", { name: "Deploy on Clawdi", exact: true });
+			const link = page.getByRole("button", { name: "Deploy on Clawdi", exact: true });
 			await expect(link).toHaveAttribute(
 				"href",
 				scenario.recommended ? "/deploy?deploy_profile=sui" : "/deploy",

--- a/apps/web/e2e/handoff/handoff.pw.ts
+++ b/apps/web/e2e/handoff/handoff.pw.ts
@@ -139,3 +139,56 @@ test("unknown, duplicate and absent sources hide the recommendation", async ({ b
 	expect(settingsWrites).toBe(0);
 	await context.close();
 });
+
+for (const scenario of [
+	{ search: "?deploy_profile=sui", sidebar: false, signedIn: true, recommended: true },
+	{ search: "?deploy_profile=sui", sidebar: true, signedIn: true, recommended: true },
+	{ search: "?deploy_profile=sui", sidebar: false, signedIn: false, recommended: true },
+	{ search: "", sidebar: false, signedIn: true, recommended: false },
+	{
+		search: "?deploy_profile=unknown&utm_source=sui",
+		sidebar: true,
+		signedIn: true,
+		recommended: false,
+	},
+]) {
+	test(`Cloud home ${scenario.search || "plain"} → ${scenario.sidebar ? "sidebar" : "overview"} deploy (${scenario.signedIn ? "signed in" : "login"})`, async ({
+		browser,
+	}) => {
+		const context = await browser.newContext();
+		await isolateNetwork(context);
+		if (scenario.signedIn)
+			await context.addCookies([{ name: "test-user", value: "account-a", url: cloud }]);
+		const page = await context.newPage();
+		await stubHostedApi(page, { plans: [basicPlan] });
+		await page.goto(`${cloud}/${scenario.search}`);
+		if (!scenario.signedIn) {
+			await page.waitForURL(`${cloud}/sign-in?**`);
+			expect(new URL(page.url()).searchParams.get("redirect_url")).toBe(`/${scenario.search}`);
+			await page.getByRole("button", { name: "Complete simulated auth return" }).click();
+		}
+		await expect(page).toHaveURL(`${cloud}/${scenario.search}`);
+		if (scenario.sidebar) {
+			await page.getByRole("button", { name: "New Agent", exact: true }).first().click();
+			await page
+				.getByRole("dialog")
+				.getByRole("button", { name: /Deploy on Clawdi/ })
+				.click();
+		} else {
+			const link = page.getByRole("link", { name: "Deploy on Clawdi", exact: true });
+			await expect(link).toHaveAttribute(
+				"href",
+				scenario.recommended ? "/deploy?deploy_profile=sui" : "/deploy",
+			);
+			await link.click();
+		}
+		await expect(page).toHaveURL(
+			`${cloud}/deploy${scenario.recommended ? "?deploy_profile=sui" : ""}`,
+		);
+		await expectDeploymentEnabled(page);
+		const bundle = page.getByRole("button", { name: /Sui bundle/ });
+		if (scenario.recommended) await expect(bundle).toHaveAttribute("aria-pressed", "true");
+		else await expect(bundle).toHaveCount(0);
+		await context.close();
+	});
+}

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "@tanstack/react-router";
+import { useRouter, useRouterState } from "@tanstack/react-router";
 import { CirclePlus, Loader2, Rocket, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { deployChannelSearch } from "@/lib/deploy-channel";
 import { useDesktopBridge } from "@/lib/desktop";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useProductAccess } from "@/lib/product-access";
@@ -34,6 +35,7 @@ export function NewAgentButton({
 	className?: string;
 } = {}) {
 	const router = useRouter();
+	const search = useRouterState({ select: (state) => state.location.searchStr });
 	const desktopBridge = useDesktopBridge();
 	const hostedAccess = useProductAccess();
 	const hydrated = useHydrated();
@@ -65,7 +67,7 @@ export function NewAgentButton({
 		if (!canDeployOnClawdi) return;
 		setChooserOpen(false);
 		onNavigate?.();
-		void router.navigate({ href: "/deploy" });
+		void router.navigate({ to: "/deploy", search: deployChannelSearch(search) });
 	}
 
 	const trigger = (

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { Rocket, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { deployChannelSearch } from "@/lib/deploy-channel";
 
 type OnboardingCardProps = {
 	variant?: "first-agent" | "additional-agent";
@@ -23,6 +24,7 @@ export function OnboardingCard({
 	variant = "first-agent",
 	canDeployOnClawdi = false,
 }: OnboardingCardProps) {
+	const search = useRouterState({ select: (state) => state.location.searchStr });
 	const [connectOpen, setConnectOpen] = useState(false);
 	const isAdditionalAgent = variant === "additional-agent";
 	const title = isAdditionalAgent
@@ -56,7 +58,7 @@ export function OnboardingCard({
 					>
 						{canDeployOnClawdi ? (
 							<Button
-								render={<Link to="/deploy" />}
+								render={<Link to="/deploy" search={deployChannelSearch(search)} />}
 								nativeButton={false}
 								size="lg"
 								className="w-full"

--- a/apps/web/src/lib/deploy-channel.test.ts
+++ b/apps/web/src/lib/deploy-channel.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { deployChannelAuthSearch, resolveDeployChannel } from "./deploy-channel";
+import {
+	deployChannelAuthSearch,
+	deployChannelSearch,
+	resolveDeployChannel,
+} from "./deploy-channel";
 
 describe("deployment channel links", () => {
 	test("accepts direct and authentication return links", () => {
@@ -52,4 +56,18 @@ test("normalizes direct auth entries", () => {
 		"?redirect_url=%2Fdeploy%3Fdeploy_profile%3Dsui",
 	);
 	expect(deployChannelAuthSearch("?redirect_url=%2Fdeploy%3Fdeploy_profile%3Dsui")).toBeNull();
+});
+
+test("deployment navigation carries only a valid profile", () => {
+	expect(deployChannelSearch("?deploy_profile=sui&settings=general&other=value")).toEqual({
+		deploy_profile: "sui",
+	});
+	expect(deployChannelSearch("?utm_source=sui")).toEqual({ deploy_profile: "sui" });
+	for (const search of [
+		"",
+		"?deploy_profile=unknown&utm_source=sui",
+		"?deploy_profile=sui&deploy_profile=sui",
+	]) {
+		expect(deployChannelSearch(search)).toEqual({});
+	}
 });

--- a/apps/web/src/lib/deploy-channel.ts
+++ b/apps/web/src/lib/deploy-channel.ts
@@ -24,6 +24,10 @@ export function resolveDeployChannel(search: string): "sui" | null {
 	return values.length === 1 && values[0] === "sui" ? "sui" : null;
 }
 
+export function deployChannelSearch(search: string): { deploy_profile?: "sui" } {
+	return resolveDeployChannel(search) ? { deploy_profile: "sui" } : {};
+}
+
 // Normalize direct auth entry links to Clerk's native return URL contract.
 export function deployChannelAuthSearch(search: string): string | null {
 	const params = new URLSearchParams(search);


### PR DESCRIPTION
Cloud dashboard visitors arriving at `/?deploy_profile=sui` lost the profile when choosing either the overview's Deploy on Clawdi link or the sidebar's New Agent → Deploy action, so the Sui bundle card did not appear.

Both entry points now use the existing channel parser to forward only a valid profile to `/deploy`. Ordinary and invalid-profile entries remain plain deployments. No API or storage changes.

Validation in Docker: parameter tests (5 tests, 26 assertions), web typecheck, and Biome passed. All 5 dashboard browser scenarios passed, covering both entry points, login return, and plain/invalid profiles. The 4 existing marketing/auth/payload scenarios also passed. Identity and APIs are controlled fixtures against actual application pages.
