### PR TITLE
perf: reduce project detail queries and CLI scan state reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.67 reduces repeated local state reads when scanning large session histories.
+- Project details fetch related owner and membership information together.
+
 - CLI 0.14.66 skips unnecessary content processing when filtering local Codex
   sessions by project and reduces repeated comparisons in Claude Code resume histories.
 

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -432,7 +432,16 @@ async def get_project(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
     row = (
         await db.execute(
-            select(Project, *_project_count_columns(auth.user_id)).where(
+            select(Project, User, ProjectMembership, *_project_count_columns(auth.user_id))
+            .outerjoin(User, User.id == Project.user_id)
+            .outerjoin(
+                ProjectMembership,
+                and_(
+                    ProjectMembership.project_id == Project.id,
+                    ProjectMembership.member_user_id == auth.user_id,
+                ),
+            )
+            .where(
                 Project.id == project_uuid,
                 active_project_filter(),
             )
@@ -440,16 +449,7 @@ async def get_project(
     ).one_or_none()
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
-    project, skill_count, vault_count, agent_count, member_count = row
-    owner = (await db.execute(select(User).where(User.id == project.user_id))).scalar_one_or_none()
-    membership = (
-        await db.execute(
-            select(ProjectMembership).where(
-                ProjectMembership.project_id == project.id,
-                ProjectMembership.member_user_id == auth.user_id,
-            )
-        )
-    ).scalar_one_or_none()
+    project, owner, membership, skill_count, vault_count, agent_count, member_count = row
     return _project_response(
         project,
         auth.user_id,

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.project_membership import ProjectMembership
 from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
 from app.models.vault import Vault, VaultProjectAttachment
@@ -13,6 +14,44 @@ from app.services import sync_events
 from tests.conftest import create_env_with_project, create_test_hosted_runtime_state
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("prefix", ["/v1", "/api"])
+async def test_project_detail_uses_callers_membership(client, db_session, seed_user, prefix):
+    owner = User(clerk_id=f"project-owner-{uuid.uuid4()}", name="Current Owner")
+    other = User(clerk_id=f"project-viewer-{uuid.uuid4()}")
+    db_session.add_all([owner, other])
+    await db_session.flush()
+    project = Project(
+        user_id=owner.id, name="Shared Project", slug="shared", kind=PROJECT_KIND_WORKSPACE
+    )
+    db_session.add(project)
+    await db_session.flush()
+    memberships = [
+        ProjectMembership(
+            project_id=project.id,
+            member_user_id=user.id,
+            role="viewer",
+            joined_via="link",
+            joined_at=datetime.now(UTC),
+            resolved_owner_handle=handle,
+        )
+        for user, handle in [(seed_user, "original-owner"), (other, "other-owner-handle")]
+    ]
+    db_session.add_all(memberships)
+    await db_session.commit()
+
+    response = await client.get(f"{prefix}/projects/{project.id}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["is_owner"] is False
+    assert body["owner_display"] == "Current Owner"
+    assert body["owner_handle"] == "original-owner"
+    assert body["member_count"] == 2
+
+    await db_session.delete(memberships[0])
+    await db_session.commit()
+    assert (await client.get(f"{prefix}/projects/{project.id}")).status_code == 404
 
 
 async def test_create_project_generates_workspace_slug(client, db_session, seed_user):

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.66",
+      "version": "0.14.67",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.66",
+	"version": "0.14.67",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -25,7 +25,7 @@ import {
 	sessionPlanIsDurablyBlocked,
 	syncSessionContent,
 } from "../lib/session-upload";
-import { readFencedSessionEntry, readSessionsLock, type SessionsLock } from "../lib/sessions-lock";
+import { readFencedSessionEntry, readSessionsLock } from "../lib/sessions-lock";
 import { isValidSkillKey } from "../lib/skill-key";
 import {
 	computeSkillFolderHash,
@@ -143,7 +143,6 @@ export async function push(opts: PushOpts) {
 	const strictModuleSelection = explicitlySelectedModules && targetTypes.length === 1;
 
 	const moduleState = readModuleState();
-	const sessionsLock = readSessionsLock();
 
 	// Project selection is agent-independent (derived only from flags), so
 	// resolve it once and report it once — not per agent.
@@ -177,7 +176,7 @@ export async function push(opts: PushOpts) {
 				moduleSkips.push({ agentType, modules: missing });
 			}
 			if (availableModules.length === 0) continue;
-			const scan = await scanOneAgent(adapter, availableModules, opts, projectFilter, sessionsLock);
+			const scan = await scanOneAgent(adapter, availableModules, opts, projectFilter);
 			if ("error" in scan) {
 				scanError = scan.error;
 				break;
@@ -323,7 +322,6 @@ async function scanOneAgent(
 	modules: string[],
 	opts: PushOpts,
 	projectFilter: string | undefined,
-	sessionsLock: SessionsLock,
 ): Promise<AgentScanResult | { error: string }> {
 	const agentType = adapter.agentType;
 	const envId = getEnvIdByAgent(agentType);
@@ -466,7 +464,9 @@ async function scanOneAgent(
 	// filters can't pollute it because each session has its own entry.
 	let sessionsCacheSkipped = 0;
 	let sessionsBlocked = 0;
-	if (sessionsModule && sessionProtocol) {
+	// This snapshot belongs only to the synchronous eligibility pass after collection.
+	const sessionsLock = modules.includes("sessions") ? readSessionsLock() : null;
+	if (sessionsModule && sessionProtocol && sessionsLock) {
 		const before = sessions.length;
 		sessions = sessions.filter((s) => {
 			const plan = planSessionUpload(s, sessionProtocol);
@@ -477,7 +477,7 @@ async function scanOneAgent(
 				adapter: agentType,
 				sourceSessionKey: s.localSessionId,
 			});
-			const blocked = sessionPlanIsDurablyBlocked(fence, plan);
+			const blocked = sessionPlanIsDurablyBlocked(fence, plan, sessionsLock);
 			if (blocked) {
 				sessionsBlocked += 1;
 				notes.push(blocked);
@@ -498,7 +498,7 @@ async function scanOneAgent(
 	}
 
 	// Guidance when nothing matched at all.
-	if (modules.includes("sessions") && sessions.length === 0 && sessionsCacheSkipped === 0) {
+	if (sessionsLock && sessions.length === 0 && sessionsCacheSkipped === 0) {
 		const isFirstRun = !Object.keys(sessionsLock.sessions).some((k) =>
 			k.startsWith(`${agentType}:`),
 		);

--- a/packages/cli/src/lib/session-upload.test.ts
+++ b/packages/cli/src/lib/session-upload.test.ts
@@ -15,9 +15,14 @@ import {
 	negotiateSessionProtocol,
 	planSessionUpload,
 	sessionFence,
+	sessionPlanIsDurablyBlocked,
 	syncSessionContent,
 } from "./session-upload";
-import { readFencedSessionEntry, readSessionsLock } from "./sessions-lock";
+import {
+	persistFencedSessionEntry,
+	readFencedSessionEntry,
+	readSessionsLock,
+} from "./sessions-lock";
 
 const originalHome = process.env.HOME;
 const originalClawdiHome = process.env.CLAWDI_HOME;
@@ -100,6 +105,35 @@ function eventApi(): ApiClient {
 }
 
 describe("session upload negotiation and integrity", () => {
+	it("uses a supplied scan snapshot while default blocked reads stay fresh", () => {
+		const session = rawSession([event("snapshot", "content")]);
+		const plan = planSessionUpload(session, "events-v1");
+		const fence = sessionFence(new ApiClient({ requireAuth: false }), {
+			environmentId: "agent-pi",
+			adapter: "pi",
+			sourceSessionKey: session.localSessionId,
+		});
+		const entry = { protocol: plan.protocol, local_hash: plan.localHash };
+		persistFencedSessionEntry(fence, entry);
+		const snapshot = readSessionsLock();
+		persistFencedSessionEntry(fence, {
+			...entry,
+			blocked: {
+				code: "event_too_large",
+				content_hash: plan.localHash,
+				size_bytes: 100,
+				message: "blocked after snapshot",
+				blocked_at: new Date().toISOString(),
+			},
+		});
+		expect(sessionPlanIsDurablyBlocked(fence, plan, snapshot)).toBeNull();
+		expect(sessionPlanIsDurablyBlocked(fence, plan)).toBe("blocked after snapshot");
+		expect(sessionPlanIsDurablyBlocked({ ...fence, environmentId: "other" }, plan)).toBeNull();
+		expect(sessionPlanIsDurablyBlocked(fence, { ...plan, localHash: "different" })).toBeNull();
+		persistFencedSessionEntry(fence, entry);
+		expect(sessionPlanIsDurablyBlocked(fence, plan)).toBeNull();
+	});
+
 	it("falls back on an old server and refuses a mismatched stored hash", async () => {
 		const originalFetch = globalThis.fetch;
 		try {

--- a/packages/cli/src/lib/session-upload.ts
+++ b/packages/cli/src/lib/session-upload.ts
@@ -9,6 +9,7 @@ import {
 	readFencedSessionEntry,
 	readSessionsLock,
 	type SessionFence,
+	type SessionsLock,
 } from "./sessions-lock";
 
 export type SelectedSessionProtocol = "snapshot-v1" | "events-v1";
@@ -115,8 +116,9 @@ export function sessionPlanMatchesLock(fence: SessionFence, plan: SessionUploadP
 export function sessionPlanIsDurablyBlocked(
 	fence: SessionFence,
 	plan: SessionUploadPlan,
+	lock: SessionsLock = readSessionsLock(),
 ): string | null {
-	const entry = readFencedSessionEntry(readSessionsLock(), fence);
+	const entry = readFencedSessionEntry(lock, fence);
 	return entry?.local_hash === plan.localHash ? (entry.blocked?.message ?? null) : null;
 }
 

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -2,8 +2,17 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentType } from "../../src/adapters/agent-types";
+import { CodexAdapter } from "../../src/adapters/codex";
+import { adapterRegistry } from "../../src/adapters/registry";
 import { push } from "../../src/commands/push";
-import { readFencedSessionEntry, readSessionsLock } from "../../src/lib/sessions-lock";
+import { ApiClient } from "../../src/lib/api-client";
+import { EMPTY_EVENT_HEAD } from "../../src/lib/session-events";
+import { planSessionUpload, sessionFence } from "../../src/lib/session-upload";
+import {
+	persistFencedSessionEntry,
+	readFencedSessionEntry,
+	readSessionsLock,
+} from "../../src/lib/sessions-lock";
 import { recordProjectSkillMaterialization } from "../../src/lib/skills-lock";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
 import {
@@ -57,6 +66,120 @@ afterEach(() => {
 	// `bun test` (1.3.13+) inherits the file's final exitCode.
 	process.exitCode = 0;
 	if (tmpHome) cleanupTmp(tmpHome);
+});
+
+describe("push — scan snapshot", () => {
+	it("reads pending and blocked state after collection on every push", async () => {
+		setup("codex");
+		const session = (await new CodexAdapter().sessions.collect({ kind: "complete" })).sessions[0];
+		if (!session?.events) throw new Error("expected Codex event fixture");
+		const eventCount = session.events.length;
+		const plan = planSessionUpload(session, "events-v1");
+		const fence = sessionFence(new ApiClient(), {
+			environmentId: "env-test",
+			adapter: "codex",
+			sourceSessionKey: session.localSessionId,
+		});
+		const entry = { protocol: plan.protocol, local_hash: plan.localHash };
+		const generation = "11111111-1111-4111-8111-111111111111";
+		const entries = {
+			success: entry,
+			pending: {
+				...entry,
+				pending: {
+					kind: "append" as const,
+					append_id: generation,
+					generation,
+					base_generation: generation,
+					base_revision: 1,
+					base_count: 0,
+					base_head_hash: EMPTY_EVENT_HEAD,
+					final_count: eventCount,
+					final_head_hash: plan.localHash,
+				},
+			},
+			blocked: {
+				...entry,
+				blocked: {
+					code: "event_too_large" as const,
+					content_hash: plan.localHash,
+					size_bytes: 100,
+					message: "scan block",
+					blocked_at: new Date().toISOString(),
+				},
+			},
+		};
+		persistFencedSessionEntry(fence, entry);
+		let mode: "pending" | "blocked" | "success" = "pending";
+		const originalCreate = adapterRegistry.codex.create;
+		adapterRegistry.codex.create = () => {
+			const adapter = new CodexAdapter();
+			const collect = adapter.sessions.collect;
+			adapter.sessions.collect = async (request) => {
+				const result = await collect(request);
+				persistFencedSessionEntry(fence, entries[mode]);
+				return result;
+			};
+			return adapter;
+		};
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				path: "/v1/sessions/upload-capabilities",
+				response: () =>
+					jsonResponse({
+						protocols: ["snapshot-v1", "events-v1"],
+						event_chunk_target_bytes: 1024 * 1024,
+						event_chunk_max_bytes: 8 * 1024 * 1024,
+					}),
+			},
+			{
+				method: "POST",
+				path: "/v1/sessions/batch",
+				response: () =>
+					jsonResponse({
+						created: 0,
+						updated: 0,
+						unchanged: 1,
+						needs_content: [],
+					}),
+			},
+			{
+				path: `/v1/sessions/${session.localSessionId}/events/head`,
+				response: () =>
+					jsonResponse({
+						protocol: "events-v1",
+						generation,
+						revision: 2,
+						count: eventCount,
+						head_hash: plan.localHash,
+					}),
+			},
+		]);
+		try {
+			for (const [nextMode, expectedBatches] of [
+				["pending", 1],
+				["pending", 2],
+				["blocked", 2],
+				["success", 2],
+			] as const) {
+				mode = nextMode;
+				await push({ agent: "codex", modules: "sessions", all: true });
+				expect(captured.filter((request) => request.path === "/v1/sessions/batch")).toHaveLength(
+					expectedBatches,
+				);
+			}
+		} finally {
+			adapterRegistry.codex.create = originalCreate;
+			restore();
+		}
+		const batches = captured.filter((request) => request.path === "/v1/sessions/batch");
+		expect(
+			batches.map((request) => batchSessions(request).map((item) => item.local_session_id)),
+		).toEqual([[session.localSessionId], [session.localSessionId]]);
+		expect(readFencedSessionEntry(readSessionsLock(), fence)?.pending).toBeUndefined();
+		expect(readFencedSessionEntry(readSessionsLock(), fence)?.blocked).toBeUndefined();
+	});
 });
 
 describe("push — Hermes fixture", () => {


### PR DESCRIPTION
Project detail requests fetched owner and membership separately, and CLI session scans reparsed the complete lock file for each session. Join project metadata into the existing authorized detail query, and let CLI 0.14.67 use one fresh lock snapshot for each synchronous eligibility pass after collection.

CLI snapshots do not cross agents, scans, queue waits or uploads. Default blocked reads and pending/write paths remain fresh, and fence/hash/protocol/pending checks are preserved. Project visibility and response construction retain their existing contracts; no API schema or runtime concurrency changes.

Validation: 47 backend route/visibility/isolation tests and targeted static gates passed; final CLI typecheck, Biome and 120 tests passed in Docker (2 CPU / 3 GiB). Tests cover caller membership/revocation, explicit versus default lock reads, and pending/blocked updates made during collection across successive pushes.

Controlled measurements: project owner/viewer requests drop from 5 to 3 SQL statements (1,600 matching synthetic-auth ASGI responses, medians 10.2→8.2 / 11.7→9.4 ms). Real CLI push-handler dry-run over 1,000 cached synthetic sessions drops from 1,001 to 1 lock read, with median 2120→115 ms across three alternating pairs and identical output. These exclude production network/auth and CLI process startup respectively; no whole-product latency claim.

The CLI version change triggers standard immutable npm/native publication. Backend deployment follows the existing release workflow; Hosted has separate PRs.
