### PR TITLE
refactor(web): retain deployment profile once at the dashboard route

### DIFF
--- a/apps/web/e2e/handoff/handoff.pw.ts
+++ b/apps/web/e2e/handoff/handoff.pw.ts
@@ -145,6 +145,7 @@ for (const scenario of [
 	{ search: "?deploy_profile=sui", sidebar: true, signedIn: true, recommended: true },
 	{ search: "?deploy_profile=sui", sidebar: false, signedIn: false, recommended: true },
 	{ search: "", sidebar: false, signedIn: true, recommended: false },
+	{ search: "?utm_source=sui", sidebar: true, signedIn: true, recommended: true },
 	{
 		search: "?deploy_profile=unknown&utm_source=sui",
 		sidebar: true,
@@ -168,6 +169,12 @@ for (const scenario of [
 			await page.getByRole("button", { name: "Complete simulated auth return" }).click();
 		}
 		await expect(page).toHaveURL(`${cloud}/${scenario.search}`);
+		// Intermediate navigation and reload must retain the URL intent without per-link wiring.
+		await page.getByRole("link", { name: "Agents", exact: true }).click();
+		await expect(page).toHaveURL(`${cloud}/agents${scenario.search}`);
+		await page.reload();
+		await page.getByRole("link", { name: "Overview", exact: true }).click();
+		await expect(page).toHaveURL(`${cloud}/${scenario.search}`);
 		if (scenario.sidebar) {
 			await page.getByRole("button", { name: "New Agent", exact: true }).first().click();
 			await page
@@ -176,19 +183,18 @@ for (const scenario of [
 				.click();
 		} else {
 			const link = page.getByRole("button", { name: "Deploy on Clawdi", exact: true });
-			await expect(link).toHaveAttribute(
-				"href",
-				scenario.recommended ? "/deploy?deploy_profile=sui" : "/deploy",
-			);
+			await expect(link).toHaveAttribute("href", `/deploy${scenario.search}`);
 			await link.click();
 		}
-		await expect(page).toHaveURL(
-			`${cloud}/deploy${scenario.recommended ? "?deploy_profile=sui" : ""}`,
-		);
+		await expect(page).toHaveURL(`${cloud}/deploy${scenario.search}`);
 		await expectDeploymentEnabled(page);
 		const bundle = page.getByRole("button", { name: /Sui bundle/ });
 		if (scenario.recommended) await expect(bundle).toHaveAttribute("aria-pressed", "true");
 		else await expect(bundle).toHaveCount(0);
+		// A fresh URL without the parameters clears the intent; there is no hidden persistence.
+		await page.goto(`${cloud}/deploy`);
+		await expectDeploymentEnabled(page);
+		await expect(page.getByRole("button", { name: /Sui bundle/ })).toHaveCount(0);
 		await context.close();
 	});
 }

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useRouterState } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { CirclePlus, Loader2, Rocket, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { deployChannelSearch } from "@/lib/deploy-channel";
 import { useDesktopBridge } from "@/lib/desktop";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useProductAccess } from "@/lib/product-access";
@@ -35,7 +34,6 @@ export function NewAgentButton({
 	className?: string;
 } = {}) {
 	const router = useRouter();
-	const search = useRouterState({ select: (state) => state.location.searchStr });
 	const desktopBridge = useDesktopBridge();
 	const hostedAccess = useProductAccess();
 	const hydrated = useHydrated();
@@ -67,7 +65,7 @@ export function NewAgentButton({
 		if (!canDeployOnClawdi) return;
 		setChooserOpen(false);
 		onNavigate?.();
-		void router.navigate({ to: "/deploy", search: deployChannelSearch(search) });
+		void router.navigate({ href: "/deploy" });
 	}
 
 	const trigger = (

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { Link, useRouterState } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { Rocket, TerminalSquare } from "lucide-react";
 import { useState } from "react";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { deployChannelSearch } from "@/lib/deploy-channel";
 
 type OnboardingCardProps = {
 	variant?: "first-agent" | "additional-agent";
@@ -24,7 +23,6 @@ export function OnboardingCard({
 	variant = "first-agent",
 	canDeployOnClawdi = false,
 }: OnboardingCardProps) {
-	const search = useRouterState({ select: (state) => state.location.searchStr });
 	const [connectOpen, setConnectOpen] = useState(false);
 	const isAdditionalAgent = variant === "additional-agent";
 	const title = isAdditionalAgent
@@ -58,7 +56,7 @@ export function OnboardingCard({
 					>
 						{canDeployOnClawdi ? (
 							<Button
-								render={<Link to="/deploy" search={deployChannelSearch(search)} />}
+								render={<Link to="/deploy" />}
 								nativeButton={false}
 								size="lg"
 								className="w-full"

--- a/apps/web/src/lib/deploy-channel.test.ts
+++ b/apps/web/src/lib/deploy-channel.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-	deployChannelAuthSearch,
-	deployChannelSearch,
-	resolveDeployChannel,
-} from "./deploy-channel";
+import { deployChannelAuthSearch, resolveDeployChannel } from "./deploy-channel";
 
 describe("deployment channel links", () => {
 	test("accepts direct and authentication return links", () => {
@@ -56,18 +52,4 @@ test("normalizes direct auth entries", () => {
 		"?redirect_url=%2Fdeploy%3Fdeploy_profile%3Dsui",
 	);
 	expect(deployChannelAuthSearch("?redirect_url=%2Fdeploy%3Fdeploy_profile%3Dsui")).toBeNull();
-});
-
-test("deployment navigation carries only a valid profile", () => {
-	expect(deployChannelSearch("?deploy_profile=sui&settings=general&other=value")).toEqual({
-		deploy_profile: "sui",
-	});
-	expect(deployChannelSearch("?utm_source=sui")).toEqual({ deploy_profile: "sui" });
-	for (const search of [
-		"",
-		"?deploy_profile=unknown&utm_source=sui",
-		"?deploy_profile=sui&deploy_profile=sui",
-	]) {
-		expect(deployChannelSearch(search)).toEqual({});
-	}
 });

--- a/apps/web/src/lib/deploy-channel.ts
+++ b/apps/web/src/lib/deploy-channel.ts
@@ -24,10 +24,6 @@ export function resolveDeployChannel(search: string): "sui" | null {
 	return values.length === 1 && values[0] === "sui" ? "sui" : null;
 }
 
-export function deployChannelSearch(search: string): { deploy_profile?: "sui" } {
-	return resolveDeployChannel(search) ? { deploy_profile: "sui" } : {};
-}
-
 // Normalize direct auth entry links to Clerk's native return URL contract.
 export function deployChannelAuthSearch(search: string): string | null {
 	const params = new URLSearchParams(search);

--- a/apps/web/src/routes/_protected/_dashboard.tsx
+++ b/apps/web/src/routes/_protected/_dashboard.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, retainSearchParams } from "@tanstack/react-router";
 import { validateDashboardSettingsSearch } from "@/lib/settings-routes";
 import DashboardLayout from "@/pages/dashboard/layout";
 
 export const Route = createFileRoute("/_protected/_dashboard")({
 	validateSearch: validateDashboardSettingsSearch,
+	search: { middlewares: [retainSearchParams(["deploy_profile", "utm_source"])] },
 	component: DashboardRouteLayout,
 });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,11 @@ boundary and hands them to a fixed Cloud destination. Marketing attribution
 expires after seven days; navigation and handoff do not renew it.
 
 Cloud keeps the recommendation in the current URL through Clerk's `redirect_url`
-across sign-in/sign-up. The deployment form resolves only the known URL value and
+across sign-in/sign-up. The shared dashboard route uses TanStack Router's
+`retainSearchParams` for `deploy_profile` and its `utm_source` alias, so internal
+links and programmatic navigation preserve them without per-button handling.
+A fresh page load without those parameters clears the recommendation; internal
+navigation retains them. The deployment form resolves only the known URL value and
 shows a selected, optional Sui bundle card. Its choice participates in the
 existing dirty state and request fingerprint. Only this deployment submits
 `plugin_bundle: "sui"`; unchecking omits the field. Cloud does not save channel


### PR DESCRIPTION
Deployment intent was copied separately by the overview and sidebar buttons, so new entry points and intermediate dashboard navigation could lose it.

Use TanStack Router's native `retainSearchParams` once on the shared dashboard route for `deploy_profile` and the existing `utm_source` alias. Remove the per-button hooks and propagation helper. Links and imperative navigation now inherit the URL intent; a fresh URL without these parameters clears it. No API or persistence changes.

Browser regression coverage now navigates through Agents, reloads, returns to Overview, and deploys from both entry points, including login, the UTM alias, invalid/absent values, and clearing via a fresh URL. Docker verification passed: 10 actual-app browser scenarios, 4 parser tests (21 assertions), web typecheck, and Biome. Browser identity/API are controlled fixtures. The native middleware and href navigation behavior were checked against the pinned router-core 1.171.27 source.
