### PR TITLE
fix(shared): accept validated OpenClaw gateway handoffs

### DIFF
--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -115,6 +115,58 @@ describe("Runtime UI access contracts", () => {
 		).toBe(true);
 	});
 
+	test.each(["", "/", "/openclaw", "/openclaw/", "/nested/openclaw/"])(
+		"accepts a public gateway URL for endpoint path %s",
+		(path) => {
+			const url = `https://runtime.example${path}`;
+			const fragment = new URLSearchParams({
+				bootstrapToken: "one-time+token/&=",
+				bootstrapProfile: "owner",
+				gatewayUrl: `wss://runtime.example${path.replace(/\/+$/, "")}`,
+			});
+			expect(
+				isRuntimeUiCredentials({
+					runtime: "openclaw",
+					auth_mode: "openclaw_token",
+					url,
+					deployment_resource_version: "rv-current",
+					token: "gateway-token",
+					handoff_url: `${url}#${fragment}`,
+				}),
+			).toBe(true);
+		},
+	);
+
+	test.each([
+		...[
+			"",
+			"ws://runtime.example/openclaw",
+			"wss://other.example/openclaw",
+			"wss://runtime.example:18789/openclaw",
+			"wss://runtime.example/other",
+			"wss://runtime.example/openclaw/",
+			"wss://runtime.example/openclaw?redirect=evil",
+			"wss://runtime.example/openclaw#evil",
+			"wss://user@runtime.example/openclaw",
+			"wss://runtime.example/openclaw\n",
+		].map((value) => `gatewayUrl=${encodeURIComponent(value)}`),
+		"unknown=value",
+		"bootstrapToken=other",
+		"bootstrapProfile=owner",
+		"gatewayUrl=wss%3A%2F%2Fruntime.example%2Fopenclaw&gatewayUrl=wss%3A%2F%2Fruntime.example%2Fopenclaw",
+	])("rejects untrusted or duplicate handoff fields: %s", (extra) => {
+		expect(
+			isRuntimeUiCredentials({
+				runtime: "openclaw",
+				auth_mode: "openclaw_token",
+				url: "https://runtime.example/openclaw/",
+				deployment_resource_version: "rv-current",
+				token: "gateway-token",
+				handoff_url: `https://runtime.example/openclaw/#bootstrapToken=token&bootstrapProfile=owner&${extra}`,
+			}),
+		).toBe(false);
+	});
+
 	test("accepts the exact legacy token fallback and rejects mismatched handoffs", () => {
 		const credential = {
 			runtime: "openclaw",

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -95,14 +95,17 @@ function isOpenClawLaunchHandoff(handoff: string, endpoint: string, token: strin
 		const cleanEndpoint = new URL(endpoint);
 		const fragment = new URLSearchParams(target.hash.slice(1));
 		const entries = [...fragment.entries()];
+		// OpenClaw WebSocket links use the base path without a trailing slash.
+		const gatewayUrl = `wss://${cleanEndpoint.host}${cleanEndpoint.pathname.replace(/\/+$/, "")}`;
 		target.hash = "";
 		return (
 			target.href === cleanEndpoint.href &&
-			entries.length === 2 &&
-			new Set(entries.map(([key]) => key)).size === 2 &&
+			entries.length === (fragment.has("gatewayUrl") ? 3 : 2) &&
+			new Set(entries.map(([key]) => key)).size === entries.length &&
 			typeof fragment.get("bootstrapToken") === "string" &&
 			Boolean(fragment.get("bootstrapToken")) &&
-			fragment.get("bootstrapProfile") === "owner"
+			fragment.get("bootstrapProfile") === "owner" &&
+			(!fragment.has("gatewayUrl") || fragment.get("gatewayUrl") === gatewayUrl)
 		);
 	} catch {
 		return false;


### PR DESCRIPTION
OpenClaw 2026.9.3 adds `gatewayUrl` to its native browser handoff. The shared credential guard rejects this valid response because it permits exactly two fragment fields, preventing Control UI from opening.

Accept the optional third field only when it exactly matches the current endpoint's public WebSocket target. Keep legacy two-field and shared-token handoffs compatible, while rejecting duplicate fields, unknown fields, and untrusted targets. Preserve the upstream rule that the WebSocket base path has no trailing slash.

Validation: Docker-isolated shared suite passed (100 tests), with type and Biome checks passing. Regression coverage includes root/prefixed paths, encoded bootstrap tokens, and invalid or duplicate fields. The subsequent main sync changed unrelated files; GitHub CI validates the final branch.

Deploy this client change before https://github.com/Clawdi-AI/clawdi-hosted/pull/2175, which begins returning the validated and rebound field. Production verification is pending release.

Official contract: https://github.com/openclaw/openclaw/blob/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7/src/commands/control-ui-handoff.ts and https://github.com/openclaw/openclaw/blob/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7/src/gateway/control-ui-links.ts.
