### PR TITLE
feat(desktop): enable Dashboard updates through the live website

### DIFF
--- a/.github/workflows/desktop-preview.yml
+++ b/.github/workflows/desktop-preview.yml
@@ -45,6 +45,7 @@ jobs:
             --arm64 \
             --publish never \
             --config.mac.identity=- \
+            --config.extraMetadata.clawdiDashboardSource=bundled \
             --config.mac.hardenedRuntime=false
           cd apps/desktop/release
           dmg=(Clawdi-*.dmg)
@@ -124,9 +125,8 @@ jobs:
             --publish never \
             --config.directories.output="$smoke_output" \
             --config.mac.identity=- \
+            --config.extraMetadata.clawdiDashboardSource=bundled \
             --config.mac.hardenedRuntime=false
-          cp "$production_cli" "$native_cli"
-          trap - EXIT
           dashboard_app="$runtime_home/Applications/Clawdi.app"
           mkdir -p "$(dirname "$dashboard_app")"
           ditto "$smoke_output/mac-arm64/Clawdi.app" "$dashboard_app"
@@ -135,6 +135,18 @@ jobs:
             "$dashboard_app/Contents/MacOS/Clawdi" \
             "$runtime_home/dashboard-smoke" \
             dashboard
+          CSC_FOR_PULL_REQUEST=true node apps/desktop/node_modules/electron-builder/cli.js \
+            --projectDir apps/desktop --mac dir --arm64 --publish never \
+            --config.directories.output="$RUNNER_TEMP/clawdi-remote-smoke" \
+            --config.mac.identity=- --config.mac.hardenedRuntime=false \
+            --config.extraMetadata.clawdiDashboardSource=remote
+          cp "$production_cli" "$native_cli"
+          trap - EXIT
+          remote_app="$runtime_home/remote/Applications/Clawdi.app"
+          mkdir -p "$(dirname "$remote_app")"
+          ditto "$RUNNER_TEMP/clawdi-remote-smoke/mac-arm64/Clawdi.app" "$remote_app"
+          node apps/desktop/scripts/smoke-packaged.mjs \
+            "$remote_app/Contents/MacOS/Clawdi" "$runtime_home/remote-smoke" remote
           cd "$(dirname "$dmg_path")"
           shasum -a 256 "${dmg[0]}" > "${dmg[0]}.sha256"
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -46,7 +46,11 @@ Only the trusted main frame receives the versioned, narrow Desktop bridge.
 Web changes must preserve bridge v1 methods and feature-detect new capabilities
 before calling them. Never require a new bridge method without an app update path.
 CLI owns credentials, Agent registration, and daemon lifecycle. The production
-site's CSP and TLS rules apply; no certificate bypass is installed.
+site's CSP and TLS rules apply; no certificate bypass is installed. Production
+documents use per-response CSP nonces through TanStack SSR and Clerk's nonce prop,
+with no script unsafe-inline/unsafe-eval and no shared document caching.
+The Web bridge adapter accepts the released unversioned beta.1 and version 1;
+unknown versions or missing v1 methods display a Desktop upgrade message.
 
 `clawdiDashboardSource=bundled` is retained for packaged SPA regression tests.
 Production defaults to remote; failures show the local recovery UI rather than

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -33,10 +33,24 @@ backend. Native Windows x64/arm64 lifecycle implementation and Authenticode
 signing credentials must be supplied and tested before NSIS/MSIX distribution.
 Do not label Linux package builds or unsigned previews as full release validation.
 
-Clawdi Desktop packages the production TanStack dashboard as a local SPA. The
-renderer keeps the `https://cloud.clawdi.ai` origin for Clerk and API behavior,
-but executable UI is served only from the signed application bundle. CLI owns
-OAuth credentials, Agent registration, and daemon lifecycle.
+Clawdi Desktop loads the production Dashboard from `https://cloud.clawdi.ai`.
+Web deployments take effect on the next Dashboard load or View > Reload Dashboard
+without installing a new application. An active page is never forcibly reloaded.
+Server-side rollback uses the existing Web deployment workflow. This is remote
+HTTPS content in a sandbox, not downloaded JavaScript executed by the main process.
+The native wizard and failure screen remain bundled and work when the site is
+unavailable. Native shell, IPC additions, and CLI changes still require a signed
+application update; beta.1 must upgrade once to acquire remote Dashboard support.
+
+Only the trusted main frame receives the versioned, narrow Desktop bridge.
+Web changes must preserve bridge v1 methods and feature-detect new capabilities
+before calling them. Never require a new bridge method without an app update path.
+CLI owns credentials, Agent registration, and daemon lifecycle. The production
+site's CSP and TLS rules apply; no certificate bypass is installed.
+
+`clawdiDashboardSource=bundled` is retained for packaged SPA regression tests.
+Production defaults to remote; failures show the local recovery UI rather than
+silently mixing cached bundled code with current remote assets.
 
 Dashboard uses a persistent Chromium partition for Clerk's browser session.
 Startup first restores that session; only an expired or missing session requests

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,7 @@
 			"package.json"
 		],
 		"extraMetadata": {
+			"clawdiDashboardSource": "remote",
 			"clawdiUpdateChannel": "disabled"
 		},
 		"linux": {

--- a/apps/desktop/scripts/fake-native-smoke.sh
+++ b/apps/desktop/scripts/fake-native-smoke.sh
@@ -10,7 +10,7 @@ case "$1 ${2:-}" in
 		printf '0.0.0-smoke\tdarwin-arm64\n'
 		;;
 	"auth status")
-		if [ "${CLAWDI_DESKTOP_SMOKE_SURFACE:-install}" = "dashboard" ]; then
+		if [ "${CLAWDI_DESKTOP_SMOKE_SURFACE:-install}" = "dashboard" ] || [ "${CLAWDI_DESKTOP_SMOKE_SURFACE:-install}" = "remote" ]; then
 			printf '%s\n' '{"authenticated":true,"credentialType":"clerk-oauth","user":{"id":"smoke-user","email":"smoke@clawdi.ai"}}'
 		else
 			printf '%s\n' '{"authenticated":false,"source":"none"}'

--- a/apps/desktop/scripts/smoke-packaged.mjs
+++ b/apps/desktop/scripts/smoke-packaged.mjs
@@ -7,7 +7,11 @@ import { chromium } from "@playwright/test";
 
 const [executablePath, runtimeRoot, surface = "install"] = process.argv.slice(2);
 const smokeAgentId = "00000000-0000-4000-8000-000000000001";
-if (!executablePath || !runtimeRoot || !["install", "dashboard", "welcome"].includes(surface)) {
+if (
+	!executablePath ||
+	!runtimeRoot ||
+	!["install", "dashboard", "welcome", "remote"].includes(surface)
+) {
 	throw new Error("usage: smoke-packaged.mjs <executable> <runtime-root> [install|dashboard]");
 }
 
@@ -48,7 +52,22 @@ try {
 	browser = await chromium.connectOverCDP(endpoint);
 	const context = browser.contexts()[0];
 	if (!context) throw new Error("Packaged app did not create a browser context.");
-	if (surface === "welcome") {
+	if (surface === "remote") {
+		const window = await waitForWindow(context, "dashboard", 30_000);
+		await window
+			.getByRole("heading", { name: "Desktop sign-in expired" })
+			.waitFor({ timeout: 30_000 });
+		const remote = await window.evaluate(async () => {
+			const response = await fetch("/assets/not-packaged.js", { cache: "no-store" });
+			return {
+				version: window.clawdiDesktop?.apiVersion,
+				contentType: response.headers.get("content-type"),
+			};
+		});
+		assert.equal(remote.version, 1);
+		// The production server's response differs from the bundled protocol's empty 404.
+		assert.ok(remote.contentType, "Dashboard did not reach the remote web server.");
+	} else if (surface === "welcome") {
 		const window = await waitForWindow(context, null, 30_000);
 		await window.getByRole("heading", { name: "Welcome to Clawdi" }).waitFor({ timeout: 30_000 });
 	} else if (surface === "dashboard") await verifyPackagedDashboard(context);
@@ -144,6 +163,7 @@ async function verifyPackagedDashboard(context) {
 	);
 	const bridgeMethods = await window.evaluate(() => Object.keys(window.clawdiDesktop ?? {}).sort());
 	assert.deepEqual(bridgeMethods, [
+		"apiVersion",
 		"createDashboardSession",
 		"openConnectWizard",
 		"openFilesWindow",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -146,7 +146,9 @@ async function startApplication(): Promise<void> {
 	dashboardSession = session.fromPartition(DASHBOARD_PARTITION);
 	registerAppProtocol(session.defaultSession);
 	registerAppProtocol(dashboardSession);
-	registerDashboardProtocol(dashboardSession);
+	if (readPackageMetadataField("clawdiDashboardSource") === "bundled") {
+		registerDashboardProtocol(dashboardSession);
+	}
 	registerIpc();
 	configurePermissions(dashboardSession);
 	createApplicationMenu();
@@ -788,6 +790,12 @@ function createApplicationMenu(): void {
 	const viewMenu: MenuItemConstructorOptions = {
 		label: "View",
 		submenu: [
+			{
+				label: "Reload Dashboard",
+				accelerator: "CmdOrCtrl+R",
+				click: () => runAsync("reload Dashboard", loadDashboardWithRecovery(true)),
+			},
+			{ type: "separator" },
 			{ role: "resetZoom" },
 			{ role: "zoomIn" },
 			{ role: "zoomOut" },

--- a/apps/desktop/src/shell-preload.ts
+++ b/apps/desktop/src/shell-preload.ts
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import { DESKTOP_IPC } from "./ipc";
 
 const bridge: ClawdiDesktopShellBridge = {
+	apiVersion: 1,
 	signIn: () => ipcRenderer.invoke(DESKTOP_IPC.signIn),
 	signOut: () => ipcRenderer.invoke(DESKTOP_IPC.signOut),
 	openFilesWindow: (url) => ipcRenderer.invoke(DESKTOP_IPC.openFilesWindow, url),
@@ -13,4 +14,10 @@ const bridge: ClawdiDesktopShellBridge = {
 	createDashboardSession: () => ipcRenderer.invoke(DESKTOP_IPC.createDashboardSession),
 };
 
-contextBridge.exposeInMainWorld("clawdiDesktop", bridge);
+if (
+	process.isMainFrame &&
+	(location.origin === "https://cloud.clawdi.ai" ||
+		location.href === "clawdi-app://connect/renderer.html?surface=dashboard-failure")
+) {
+	contextBridge.exposeInMainWorld("clawdiDesktop", bridge);
+}

--- a/apps/web/scripts/production-ssr.mjs
+++ b/apps/web/scripts/production-ssr.mjs
@@ -45,6 +45,28 @@ function request(path) {
 	});
 }
 
+test("production documents use fresh CSP nonces on every executable script", async () => {
+	const nonces = new Set();
+	for (let i = 0; i < 2; i++) {
+		const response = await server.fetch(request("/sign-in"));
+		assert.equal(response.status, 200);
+		const csp = response.headers.get("content-security-policy") ?? "";
+		const nonce = csp.match(/'nonce-([^']+)'/)?.[1];
+		assert.ok(nonce);
+		assert.match(csp, /'strict-dynamic'/);
+		assert.doesNotMatch(csp, /script-src[^;]*(?:'unsafe-inline'|'unsafe-eval')/);
+		assert.match(response.headers.get("cache-control") ?? "", /no-store/);
+		nonces.add(nonce);
+		const html = await response.text();
+		for (const [tag] of html.matchAll(/<script\b[^>]*>/g)) {
+			if (/type="(?:application\/json|application\/ld\+json)"/.test(tag)) continue;
+			assert.ok(tag.includes(`nonce="${nonce}"`), `Script without matching nonce: ${tag}`);
+		}
+		assert.ok(html.includes(`<meta name="csp-nonce" content="${nonce}"`));
+	}
+	assert.equal(nonces.size, 2);
+});
+
 for (const [path, title] of [
 	["/sign-in", "Sign in"],
 	["/sign-in/factor-one", "Sign in"],

--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -1,5 +1,6 @@
 import { ClerkProvider } from "@clerk/tanstack-react-start";
 import { shadcn } from "@clerk/themes";
+import { useRouter } from "@tanstack/react-router";
 import { lazy, Suspense } from "react";
 import { env } from "@/lib/env";
 
@@ -14,6 +15,7 @@ const DesktopAuthProvider =
 		: null;
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+	const nonce = useRouter().options.ssr?.nonce;
 	if (isDevAuthBypass) return <>{children}</>;
 	if (DesktopAuthProvider) {
 		return (
@@ -25,6 +27,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
 	return (
 		<ClerkProvider
+			nonce={nonce}
 			appearance={shadcn}
 			publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}
 			signInFallbackRedirectUrl="/"

--- a/apps/web/src/components/root-error.tsx
+++ b/apps/web/src/components/root-error.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "@tanstack/react-router";
 import { AlertTriangle, RotateCcw } from "lucide-react";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { DesktopBridgeCompatibilityError } from "@/lib/desktop-bridge";
 
 const isDevelopment =
 	(import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env?.MODE !==
@@ -25,6 +26,7 @@ export default function RootError({
 	reset: () => void;
 }) {
 	const router = useRouter();
+	const needsDesktopUpdate = error instanceof DesktopBridgeCompatibilityError;
 
 	useEffect(() => {
 		if (import.meta.env.VITE_SENTRY_DSN) {
@@ -45,9 +47,13 @@ export default function RootError({
 			<div className="max-w-md w-full text-center space-y-4">
 				<AlertTriangle className="size-10 text-destructive mx-auto" />
 				<div>
-					<h1 className="text-lg font-semibold">Page unavailable</h1>
+					<h1 className="text-lg font-semibold">
+						{needsDesktopUpdate ? "Update Clawdi Desktop" : "Page unavailable"}
+					</h1>
 					<p className="text-sm text-muted-foreground mt-1">
-						This page couldn&apos;t load. Try again. If it keeps happening, contact support.
+						{needsDesktopUpdate
+							? "Install the latest Clawdi Desktop version to continue."
+							: "This page couldn't load. Try again. If it keeps happening, contact support."}
 					</p>
 				</div>
 				{isDevelopment && (

--- a/apps/web/src/lib/csp-nonce.ts
+++ b/apps/web/src/lib/csp-nonce.ts
@@ -1,0 +1,9 @@
+import { createIsomorphicFn } from "@tanstack/react-start";
+import { getResponseHeader } from "@tanstack/react-start/server";
+
+export const readCspNonce = createIsomorphicFn()
+	.server(() => {
+		const policy = getResponseHeader("Content-Security-Policy");
+		return typeof policy === "string" ? policy.match(/'nonce-([^']+)'/)?.[1] : undefined;
+	})
+	.client(() => document.querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')?.content);

--- a/apps/web/src/lib/desktop-bridge.test.ts
+++ b/apps/web/src/lib/desktop-bridge.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import type { ClawdiDesktopShellBridge } from "@clawdi/shared/desktop";
+import { compatibleDesktopBridge } from "./desktop-bridge";
+
+const betaOne: ClawdiDesktopShellBridge = {
+	async signIn() {
+		return { status: "authenticated" };
+	},
+	async signOut() {},
+	async openConnectWizard() {},
+	async retryDashboard() {},
+	async createDashboardSession() {
+		return "ticket";
+	},
+	async openFilesWindow() {
+		return true;
+	},
+	async openRuntimeWindow() {
+		return true;
+	},
+	async openTerminalWindow() {
+		return true;
+	},
+};
+
+test("preserves the released unversioned beta and version 1 bridge", () => {
+	expect(compatibleDesktopBridge(betaOne) === betaOne).toBe(true);
+	const current: ClawdiDesktopShellBridge = { ...betaOne, apiVersion: 1 };
+	expect(compatibleDesktopBridge(current) === current).toBe(true);
+});
+
+test("rejects missing methods and unsupported versions", () => {
+	for (const value of [null, {}, { ...betaOne, apiVersion: 2 }, { ...betaOne, signOut: null }]) {
+		expect(compatibleDesktopBridge(value)).toBeNull();
+	}
+});

--- a/apps/web/src/lib/desktop-bridge.ts
+++ b/apps/web/src/lib/desktop-bridge.ts
@@ -1,0 +1,26 @@
+import type { ClawdiDesktopShellBridge } from "@clawdi/shared/desktop";
+
+const methods = [
+	"signIn",
+	"signOut",
+	"openConnectWizard",
+	"retryDashboard",
+	"createDashboardSession",
+	"openFilesWindow",
+	"openRuntimeWindow",
+	"openTerminalWindow",
+] as const satisfies readonly (keyof ClawdiDesktopShellBridge)[];
+
+export class DesktopBridgeCompatibilityError extends Error {
+	constructor() {
+		super("Unsupported Desktop bridge.");
+	}
+}
+
+export function compatibleDesktopBridge(value: unknown): ClawdiDesktopShellBridge | null {
+	if (!value || typeof value !== "object") return null;
+	const bridge = value as Record<string, unknown>;
+	if (bridge.apiVersion !== undefined && bridge.apiVersion !== 1) return null;
+	if (!methods.every((method) => typeof bridge[method] === "function")) return null;
+	return value as ClawdiDesktopShellBridge;
+}

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -2,6 +2,7 @@
 
 import type { ClawdiDesktopShellBridge } from "@clawdi/shared/desktop";
 import { useEffect, useState } from "react";
+import { compatibleDesktopBridge, DesktopBridgeCompatibilityError } from "./desktop-bridge";
 
 declare global {
 	interface Window {
@@ -12,7 +13,10 @@ declare global {
 export function useDesktopBridge(): ClawdiDesktopShellBridge | null | undefined {
 	const [bridge, setBridge] = useState<ClawdiDesktopShellBridge | null>();
 	useEffect(() => {
-		setBridge(window.clawdiDesktop ?? null);
+		setBridge(compatibleDesktopBridge(window.clawdiDesktop));
 	}, []);
+	if (bridge === null && typeof window !== "undefined" && window.clawdiDesktop) {
+		throw new DesktopBridgeCompatibilityError();
+	}
 	return bridge;
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,10 +1,12 @@
 import * as Sentry from "@sentry/tanstackstart-react";
 import { createRouter } from "@tanstack/react-router";
+import { readCspNonce } from "./lib/csp-nonce";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
 	const router = createRouter({
 		routeTree,
+		ssr: { nonce: readCspNonce() },
 		defaultPreload: "intent",
 		scrollRestoration: true,
 		scrollToTopSelectors: ["#dashboard-scroll-container"],

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -70,7 +70,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 				<script
 					dangerouslySetInnerHTML={{
 						__html:
-							'try{var t=localStorage.getItem("clawdi-theme")||"system";var d=t==="dark"||(t==="system"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",d)}catch(e){}',
+							'if(window.clawdiDesktop){document.documentElement.dataset.clawdiDesktop="true"}try{var t=localStorage.getItem("clawdi-theme")||"system";var d=t==="dark"||(t==="system"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",d)}catch(e){}',
 					}}
 				/>
 				<HeadContent />

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet, Scripts, useRouter } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { AppNotFound } from "@/components/app-not-found";
 import { AuthProvider } from "@/components/auth-provider";
@@ -59,6 +59,7 @@ function RootComponent() {
 }
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+	const nonce = useRouter().options.ssr?.nonce;
 	return (
 		<html
 			lang="en"
@@ -67,7 +68,9 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 			suppressHydrationWarning
 		>
 			<head>
+				{nonce ? <meta name="csp-nonce" content={nonce} /> : null}
 				<script
+					nonce={nonce}
 					dangerouslySetInnerHTML={{
 						__html:
 							'if(window.clawdiDesktop){document.documentElement.dataset.clawdiDesktop="true"}try{var t=localStorage.getItem("clawdi-theme")||"system";var d=t==="dark"||(t==="system"&&matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",d)}catch(e){}',

--- a/apps/web/src/security-headers.server.ts
+++ b/apps/web/src/security-headers.server.ts
@@ -1,0 +1,30 @@
+import { randomBytes } from "node:crypto";
+import { createMiddleware } from "@tanstack/react-start";
+import { setResponseHeader } from "@tanstack/react-start/server";
+
+export const securityHeaders = createMiddleware().server(async ({ next }) => {
+	const nonce = randomBytes(18).toString("base64");
+	setResponseHeader(
+		"Content-Security-Policy",
+		[
+			"default-src 'self'",
+			`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+			"script-src-attr 'none'",
+			"style-src 'self' 'unsafe-inline'",
+			"img-src 'self' data: blob: https:",
+			"font-src 'self' data: https:",
+			"connect-src 'self' https: wss:",
+			"frame-src https:",
+			"worker-src 'self' blob:",
+			"object-src 'none'",
+			"base-uri 'self'",
+			"frame-ancestors 'none'",
+			"form-action 'self' https:",
+		].join("; "),
+	);
+	setResponseHeader("X-Content-Type-Options", "nosniff");
+	setResponseHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+	// A nonce-bearing document must not be shared across requests by a CDN.
+	setResponseHeader("Cache-Control", "private, no-store");
+	return next();
+});

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -10,16 +10,26 @@ import {
 } from "@tanstack/react-start";
 import { createClerkRequestMiddleware } from "@/clerk-middleware.server";
 import { env } from "@/lib/env";
+import { securityHeaders } from "@/security-headers.server";
 
 const getClerkRequestMiddleware = createIsomorphicFn()
 	.client(() => undefined)
 	.server(() => createClerkRequestMiddleware());
+
+const getSecurityHeaders = createIsomorphicFn()
+	.client(() => undefined)
+	.server(() => securityHeaders);
 
 const csrfMiddleware = createCsrfMiddleware({
 	filter: (ctx) => ctx.handlerType === "serverFn",
 });
 
 const requestMiddleware: AnyRequestMiddleware[] = [];
+
+if (import.meta.env.PROD && !env.VITE_CLAWDI_DESKTOP_BUILD) {
+	const middleware = getSecurityHeaders();
+	if (middleware) requestMiddleware.push(middleware);
+}
 
 if (env.VITE_SENTRY_DSN) {
 	requestMiddleware.push(sentryGlobalRequestMiddleware);

--- a/packages/shared/src/desktop.ts
+++ b/packages/shared/src/desktop.ts
@@ -92,6 +92,8 @@ export interface ClawdiDesktopConnectBridge {
 }
 
 export interface ClawdiDesktopShellBridge {
+	/** Absent on the first beta; existing methods form protocol version 1. */
+	readonly apiVersion?: 1;
 	signIn(): Promise<DesktopShellAuthenticationResult>;
 	signOut(): Promise<void>;
 	openFilesWindow(url: string): Promise<boolean>;


### PR DESCRIPTION
Desktop loads the official HTTPS Dashboard so Web deployments take effect on reopen or View > Reload Dashboard. Native shell and CLI updates remain signed app updates. Active pages are not forcibly reloaded; failures use the bundled recovery page.

- Retain sandbox, context isolation, navigation restrictions and sender-checked IPC. Expose only the v1 bridge to the trusted main frame or bundled recovery page.
- Enforce production Web CSP with per-response nonces through TanStack SSR and Clerk's nonce prop. Disable shared document caching; disallow inline script attributes, script unsafe-inline and unsafe-eval. No remote HTML rewriting or certificate bypass.
- Validate all v1 bridge methods, including the already released unversioned beta.1. Unknown/incomplete bridges display a fixed Desktop upgrade message instead of silently falling back to browser behavior.
- Keep bundled SPA regression coverage and packaged remote Dashboard smoke. Preserve main's SSR readiness/warmup fix for the auth E2E fixture; no test timeout increase or skipped assertions.

Validation: isolated Web typecheck, bridge compatibility tests and 9 production SSR checks passed, including fresh nonce uniqueness and matching nonce on every executable script. macOS packaged bundled/remote smoke passed on d13e0b894. All applicable PR checks passed on d13e0b894, including macOS remote/bundled smoke, platform packages, production SSR, auth lifecycle, OSS and Hosted browser E2E.

Deploy this Web change and verify production CSP before releasing the new remote-capable Desktop. Beta.1 needs one signed app upgrade; it cannot acquire remote loading from a Web deployment. Real-account cold restart and cross-version upgrade acceptance remain distinct from fake-ticket smoke. No merge or release has been performed by this PR.

