### PR TITLE
fix: honor upload cancellation and reveal Session search matches

### DIFF
--- a/apps/web/src/components/sessions/virtualized-message-list.tsx
+++ b/apps/web/src/components/sessions/virtualized-message-list.tsx
@@ -84,10 +84,11 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 		}
 		if (handledScrollRequestRef.current === requestKey) return;
 		handledScrollRequestRef.current = requestKey;
+		// Let Virtuoso correct the target as variable-height rows are measured.
 		virtuoso.scrollToIndex({
 			index: highlightedRowIndex,
 			align: "center",
-			behavior: "smooth",
+			behavior: "auto",
 		});
 	}, [
 		highlightedRowIndex,

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -52,3 +52,36 @@ describe("ApiClient machine fence", () => {
 		).toBe(true);
 	});
 });
+
+describe("ApiClient upload cancellation", () => {
+	it.each(["before request", "during credentials"])(
+		"does not send an upload canceled %s",
+		async (timing) => {
+			const abort = new AbortController();
+			const api = new ApiClient({ requireAuth: false, abortSignal: abort.signal });
+			let requests = 0;
+			globalThis.fetch = (async (_request: Request) => {
+				requests += 1;
+				return Response.json({ status: "ok" });
+			}) as typeof fetch;
+			if (timing === "before request") abort.abort();
+			else {
+				api.getAccessToken = async () => {
+					abort.abort();
+					return "";
+				};
+			}
+			await expect(
+				api.uploadSessionEventGenerationChunk({
+					localSessionId: "session",
+					generation: "generation",
+					startSeq: 0,
+					baseHeadHash: "a".repeat(64),
+					contentHash: "b".repeat(64),
+					file: Buffer.from("{}\n"),
+				}),
+			).rejects.toMatchObject({ name: "ApiError", body: "aborted", isTimeout: false });
+			expect(requests).toBe(0);
+		},
+	);
+});

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -624,6 +624,7 @@ export class ApiClient {
 		// frustrating systemd / launchd's restart cadence.
 		const onEngineAbort = () => controller.abort();
 		this.abortSignal?.addEventListener("abort", onEngineAbort, { once: true });
+		if (this.abortSignal?.aborted) controller.abort();
 		try {
 			const headers: Record<string, string> = {
 				Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
Multipart uploads canceled before dispatch could still send a request when cancellation occurred before listener registration, including while credentials were resolving. Recheck the signal immediately after registration so these calls use the existing aborted-error path without sending bytes.

Session search navigation could render the matching message below the viewport while variable-height rows were being measured. Use Virtuoso's automatic scroll correction instead of smooth scrolling for search-target positioning. Readiness, request deduplication, and centering remain intact.

Validation: isolated Docker CLI typecheck, 36 tests / 131 assertions, and Biome passed; the two cancellation cases fail against baseline and pass with zero fetch calls after the fix. Web typecheck, Biome, 13 OSS tests, five existing browser regressions, and OSS build passed. Real local Web/API/PostgreSQL search navigation failed to bring the target into view in five baseline trials and succeeded in all five candidate trials. Independent read-only review found no blockers in either patch.

Large-upload memory experiments were not retained: lower peak RSS came with higher CPU and no rewrite wall-time improvement. The separate observation that an already-open Session does not automatically refresh after upload remains unresolved. Measurements use isolated synthetic data, not production latency. No Hosted V1, protocol, schema, or version changes.
