### PR TITLE
fix(web): allow Google Fonts styles under production CSP

### DIFF
--- a/apps/web/src/security-headers.server.ts
+++ b/apps/web/src/security-headers.server.ts
@@ -10,7 +10,7 @@ export const securityHeaders = createMiddleware().server(async ({ next }) => {
 			"default-src 'self'",
 			`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
 			"script-src-attr 'none'",
-			"style-src 'self' 'unsafe-inline'",
+			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 			"img-src 'self' data: blob: https:",
 			"font-src 'self' data: https:",
 			"connect-src 'self' https: wss:",


### PR DESCRIPTION
Production browser verification found the support widget loads a Google Fonts stylesheet. Allow only that stylesheet origin, preserving nonce-based scripts and the prohibition on inline event handlers. Clerk initializes and the sign-in form renders; Zaraz-injected inline onload handlers remain deliberately blocked. This does not grant script execution to Google Fonts.