### PR TITLE
fix(providers): recover authenticated prior provider ownership

### DIFF
--- a/backend/app/services/ai_provider_connection_ownership.py
+++ b/backend/app/services/ai_provider_connection_ownership.py
@@ -22,6 +22,8 @@ from app.services.app_setting_registry import (
 )
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
 from app.services.runtime_drift_summary import read_runtime_drift_summaries
+from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import persisted_runtime_source_error
 
 
 async def require_connection_ownership_migration(
@@ -186,6 +188,64 @@ async def require_custom_provider_cli(
                     or previous_state.generation
                 },
             )
+            # Applied provider ownership survives a failed desired-state change.
+            # This is not a readiness claim: only the exact previous incarnation's
+            # already-applied providers may use historical evidence. An unscoped
+            # read deliberately refuses multiple boots, including expired ones.
+            historical = await read_runtime_drift_summaries(
+                db,
+                RuntimeDriftSummaryReadRequest(
+                    bindings=[
+                        RuntimeDriftBindingRequest(
+                            environmentId=previous_state.environment_id,
+                            deploymentId=previous_state.deployment_id,
+                        )
+                    ]
+                ),
+            )
+            owned_environment = await db.scalar(
+                select(AgentEnvironment.id).where(
+                    AgentEnvironment.id == previous_state.environment_id,
+                    AgentEnvironment.user_id == owner_user_id,
+                    AgentEnvironment.archived_at.is_(None),
+                )
+            )
+            if owned_environment is None:
+                raise HTTPException(409, "Custom provider recovery binding is invalid")
+            if len(historical.items) == 1:
+                history = historical.items[0]
+                prior_head = history.observation.head
+                prior_applied = prior_head.diagnostics.applied if prior_head else None
+                if (
+                    history.binding == "active"
+                    and history.source_authority.instance_id == previous_state.instance_id
+                    and prior_head is not None
+                    and prior_applied is not None
+                    and prior_head.captured_at <= historical.observed_at
+                    and prior_head.diagnostics.active_cli_version in versions
+                    and previous_state.cli_package_spec
+                    == f"clawdi@{prior_head.diagnostics.active_cli_version}"
+                    and prior_applied.instance_id == previous_state.instance_id
+                    and (
+                        history.source_authority.status == "unavailable"
+                        and persisted_runtime_source_error(previous_state)
+                        or (
+                            history.source_authority.status == "present"
+                            and history.source_authority.source_revision
+                            == prior_applied.source_revision
+                            and history.source_authority.etag == prior_applied.etag
+                        )
+                    )
+                    and prior_applied.generation
+                    == (previous_state.apply_generation or previous_state.generation)
+                    and prior_head.runtime_identity.generation == prior_applied.generation
+                    and prior_head.runtime_identity.apply_receipt_id
+                    and prior_head.runtime_identity.boot_nonce
+                    and prior_applied.etag
+                    == expected_runtime_bundle_v2_etag(prior_applied.source_revision)
+                    and custom - previous_ids <= set(prior_applied.applied_provider_ids)
+                ):
+                    return
             if len(evidence.items) != 1:
                 raise HTTPException(
                     409, "Custom provider binding requires current runtime evidence"

--- a/backend/tests/test_ai_provider_connection_ownership.py
+++ b/backend/tests/test_ai_provider_connection_ownership.py
@@ -56,13 +56,15 @@ async def consumer(
     source_revision=REVISION,
     boot="boot-connection-test",
     health="ok",
+    applied_provider_ids=None,
+    runtime_name="openclaw",
 ):
     env = await create_env_with_project(
         db,
         user_id=owner_id,
         machine_id=str(uuid4()),
         machine_name="Connection migration",
-        agent_type="openclaw",
+        agent_type=runtime_name,
     )
     deployment = f"dep-{env.id}"
     state = HostedRuntimeState(
@@ -79,7 +81,7 @@ async def consumer(
         live_sync={},
         recovery={},
         runtimes={
-            "openclaw": {
+            runtime_name: {
                 "enabled": True,
                 "providerMode": "configured",
                 "provider_ids": [PROVIDER],
@@ -106,7 +108,9 @@ async def consumer(
                 "sourceRevision": source_revision,
                 "generation": 1,
                 "instanceId": state.instance_id,
-                "appliedProviderIds": [PROVIDER],
+                "appliedProviderIds": [PROVIDER]
+                if applied_provider_ids is None
+                else applied_provider_ids,
             },
             "boot": None,
             "cli": None,
@@ -454,7 +458,12 @@ async def test_custom_handoff_and_binding_require_exact_qualified_cli(
     )
     # Adding this Custom provider to an existing runtime requires fresh consumed evidence,
     # not merely a requested upgrade in the incoming state.
-    state = await consumer(db_session, seed_user.id, boot="custom-binding-target")
+    state = await consumer(
+        db_session,
+        seed_user.id,
+        boot="custom-binding-target",
+        applied_provider_ids=["different-provider"],
+    )
     state.runtimes = {
         "openclaw": {
             "enabled": True,
@@ -471,7 +480,13 @@ async def test_custom_handoff_and_binding_require_exact_qualified_cli(
         cli_package_spec=f"clawdi@{VERSION}",
         previous_state=state,
     )
-    failed = await consumer(db_session, seed_user.id, boot="custom-binding-failed", health="error")
+    failed = await consumer(
+        db_session,
+        seed_user.id,
+        boot="custom-binding-failed",
+        health="error",
+        applied_provider_ids=["different-provider"],
+    )
     failed.runtimes = state.runtimes
     await db_session.flush()
     with pytest.raises(HTTPException):
@@ -482,3 +497,126 @@ async def test_custom_handoff_and_binding_require_exact_qualified_cli(
             cli_package_spec=f"clawdi@{VERSION}",
             previous_state=failed,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    [
+        "recover",
+        "expired",
+        "wrong-owner",
+        "wrong-instance",
+        "wrong-generation",
+        "wrong-source",
+        "new-provider",
+        "retired",
+        "ambiguous",
+    ],
+)
+async def test_failed_custom_selection_recovers_only_authenticated_applied_ownership(
+    client, db_session, seed_user, case
+):
+    from fastapi import HTTPException
+
+    from app.models.ai_provider import AiProvider
+    from app.services.ai_provider_connection_ownership import require_custom_provider_cli
+
+    await create_provider(client)
+    provider = await db_session.scalar(
+        select(AiProvider).where(
+            AiProvider.owner_user_id == seed_user.id,
+            AiProvider.provider_id == PROVIDER,
+        )
+    )
+    provider.configuration_mode = "custom"
+    db_session.add(AppSetting(key="supported_custom_provider_cli_versions", value_json=[VERSION]))
+    state = await consumer(
+        db_session,
+        seed_user.id,
+        health="error",
+        runtime_name="hermes",
+        captured_at=datetime.now(UTC) - timedelta(hours=2) if case == "expired" else None,
+        applied_provider_ids=["unrelated-provider"] if case == "new-provider" else [PROVIDER],
+    )
+    # A failed desired selection must not erase the last completed ownership
+    # transfer. Source rendering now fails because that desired provider vanished.
+    state.runtimes = {
+        "hermes": {
+            "enabled": True,
+            "providerMode": "configured",
+            "provider_ids": ["missing-provider"],
+            "primary_model": None,
+            "install": {"source": "official"},
+        }
+    }
+    state.source_revision = None
+    if case == "wrong-instance":
+        state.instance_id = "replacement-instance"
+    if case == "wrong-generation":
+        state.apply_generation = 2
+    if case == "wrong-source":
+        state.source_revision = "b" * 64
+    if case == "retired":
+        from app.models.session import AgentEnvironment
+
+        env = await db_session.get(AgentEnvironment, state.environment_id)
+        env.archived_at = datetime.now(UTC)
+    if case == "ambiguous":
+        now = datetime.now(UTC)
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=state.environment_id,
+            credential_deployment_id=state.deployment_id,
+            value=RuntimeObservationEventV2.model_validate(
+                {
+                    "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+                    "reportedAt": now,
+                    "capturedAt": now,
+                    "runtimeMode": "hosted",
+                    "status": "error",
+                    "activeCliVersion": VERSION,
+                    "applied": {
+                        "etag": f'"sha256:{REVISION}"',
+                        "sourceRevision": REVISION,
+                        "generation": 1,
+                        "instanceId": state.instance_id,
+                        "appliedProviderIds": [PROVIDER],
+                    },
+                    "boot": None,
+                    "cli": None,
+                    "applyReceiptId": "other-receipt-0001",
+                    "bootNonce": "other-nonce-000001",
+                    "bootSessionId": "other-boot",
+                    "sequence": 1,
+                    "eventId": str(uuid4()),
+                }
+            ),
+            received_at=now,
+        )
+    await db_session.flush()
+    if case == "wrong-owner":
+        # Keep the requested provider owned by the caller, but not the environment.
+        from app.models.session import AgentEnvironment
+
+        env = await db_session.get(AgentEnvironment, state.environment_id)
+        from app.models.user import User
+
+        other = User(clerk_id=f"other-{uuid4()}", email="other@example.test", name="Other")
+        db_session.add(other)
+        await db_session.flush()
+        env.user_id = other.id
+        await db_session.flush()
+    call = require_custom_provider_cli(
+        db_session,
+        owner_user_id=seed_user.id,
+        provider_ids=[PROVIDER],
+        cli_package_spec=f"clawdi@{VERSION}",
+        previous_state=state,
+    )
+    if case in {"recover", "expired"}:
+        await call
+    else:
+        with pytest.raises(HTTPException):
+            await call
+    assert state.runtimes["hermes"]["provider_ids"] == ["missing-provider"]

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -503,3 +503,30 @@ Do not commit decrypted or imported env files.
   providers.
 - Changing the public REST provider-array contract as part of Core Hosted
   binding admission.
+
+
+## Recovering an already-applied custom provider
+
+A failed desired provider change must not prevent restoring a custom provider
+whose ownership was already transferred by a qualified CLI. Same-instance
+runtime-state writes may recover only newly requested custom IDs found in the
+unique authenticated applied observation for the persisted apply generation.
+The active environment owner, deployment binding, instance, CLI selection,
+receipt/boot identity and source/ETag pair must match. Multiple boots (even
+expired ones), missing observations, retired bindings and changed incarnations
+fail closed. The ordinary runtime-state generation and owner locks still apply.
+
+Historical error/expired observations establish previous ownership, never health
+or current convergence. When the current source exists it must match the applied
+source. When rendering fails, the persisted failure must belong to the current
+renderer contract. A historical claim cannot admit an unrelated custom provider;
+new handoffs retain the fresh, healthy, exact-source CLI requirement.
+
+The CLI still creates a missing provider only on initialization when it has no
+previous ownership record or a pending creation. A completed ownership record
+never authorizes recreating a missing provider. Recovery preserves native models
+and user configuration; it does not explain who removed a provider.
+
+Done: `bash scripts/test.sh backend tests/test_ai_provider_connection_ownership.py`
+passes against the runner's isolated PostgreSQL. No CLI or wire-schema change is
+required.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -665,3 +665,10 @@ Core tables verified under `backend/app/models/`:
 
 Add an ADR or focused design note before turning a known absence into a new
 module.
+
+
+Custom provider recovery uses authenticated prior applied ownership for the same
+runtime incarnation, with separate admission for new handoffs. See
+[AI Provider recovery](ai-providers.md#recovering-an-already-applied-custom-provider).
+This changes Cloud admission only; Hosted owns lifecycle repair and the CLI
+retains native configuration ownership.


### PR DESCRIPTION
A failed desired custom-provider selection can leave an already-applied provider unable to recover: the healthy-runtime requirement rejects the write needed to restore health. Allow only authenticated historical ownership for the same owner, active deployment binding, instance, apply generation and qualified CLI. Wrong source/instance/generation, ambiguous boots and unrelated new providers remain rejected; historical ownership is not readiness evidence.

Validation: 27 real-PostgreSQL provider ownership tests pass, including the failed Hermes selection and expired evidence recovery plus negative ownership/fence cases. Ruff and doc-link checks passed; root reviewed the diff and whitespace check. No CLI, schema, tenant-image or credential changes.

Deploy this Cloud receiver before the paired Hosted compensated-provisioning repair. Production recovery still uses Hosted's existing CAS operator-repair API; this PR neither replays a live write nor repairs tenant files directly.
