### PR TITLE
perf(cli): avoid projecting unrelated Pi sessions during resolution

### DIFF
--- a/packages/cli/src/adapters/pi.ts
+++ b/packages/cli/src/adapters/pi.ts
@@ -453,11 +453,15 @@ function listJsonlFiles(root: string): string[] {
 	return files.sort();
 }
 
-function parseSession(filePath: string, projectFilter?: string): RawSession | null {
+function parseSession(
+	filePath: string,
+	projectFilter?: string,
+	sourceId?: string,
+): RawSession | null {
 	const parsed = readPiFile(filePath);
 	if (!parsed) return null;
 	const sessionKey = jsonString(parsed.header.id);
-	if (!sessionKey) return null;
+	if (!sessionKey || (sourceId !== undefined && sessionKey !== sourceId)) return null;
 	const cwd = jsonString(parsed.header.cwd);
 	if (projectFilter && (!cwd || resolve(cwd) !== resolve(projectFilter))) return null;
 	const events = sequenceSessionEvents(
@@ -552,7 +556,7 @@ export class PiAdapter implements AgentAdapterCore {
 	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
 		const sourceId = localSessionId.startsWith("pi.") ? localSessionId.slice(3) : localSessionId;
 		for (const path of listJsonlFiles(getPiSessionsDir())) {
-			const session = parseSession(path);
+			const session = parseSession(path, undefined, sourceId);
 			if (session?.localSessionId === `pi.${sourceId}`) return session;
 		}
 		return null;


### PR DESCRIPTION
Resolving one Pi session for a queued upload previously constructed events and visible messages for every preceding file before comparing the session ID. Compare the same parsed header ID before projection so unrelated sessions avoid that CPU work. File reads, JSONL parsing, file order, branch selection, and the selected session's output are preserved; no cache or filename-based identity shortcut is introduced.

In an alternating local adapter benchmark with 32 synthetic histories, last-target resolution median fell from 49.0 to 13.8 ms and process CPU from 59.5 to 29.3 ms. All 240 complete outputs matched. Unfiltered collection was slightly slower (63.7 to 64.8 ms); no general scan, memory, end-to-end daemon, or production improvement is claimed.

Validation in bounded Docker: all 152 CLI test files plus the clean-runner contract were covered in segments, totaling 1,849 passed and four native lifecycle skips. Typecheck, CLI build, publish-manifest check, and full repository Biome passed. Earlier harness permission/init failures are documented; these results are not a single uninterrupted suite run or a native release qualification. Root reviewed the actual one-file diff. No version bump, Hosted V1, Web, backend, or protocol changes.
