### PR TITLE
fix(web): prevent awkward wrapping beneath Deploy

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1648,21 +1648,21 @@ export function DeployWizard() {
 											? "Retry"
 											: deployLabel}
 								</Button>
-								{visibleSubmitBlockingReason ? (
-									<p
-										id="deploy-blocking-reason"
-										className={cn(
-											"max-w-sm text-xs @2xl/main:text-right",
-											nameError ? "text-destructive" : "text-muted-foreground",
-										)}
-										role="status"
-									>
-										{visibleSubmitBlockingReason}
-									</p>
-								) : null}
 							</div>
 						</div>
 					</div>
+					{visibleSubmitBlockingReason ? (
+						<p
+							id="deploy-blocking-reason"
+							className={cn(
+								"mt-1 max-w-sm text-xs @2xl/main:ml-auto @2xl/main:text-right",
+								nameError ? "text-destructive" : "text-muted-foreground",
+							)}
+							role="status"
+						>
+							{visibleSubmitBlockingReason}
+						</p>
+					) : null}
 				</div>
 			</form>
 


### PR DESCRIPTION
The Deploy footer constrained its blocking hint to the 160px button column, causing short messages such as "Choose a subscription source." to wrap awkwardly. Place the hint below the full action row so it has its own wrapping space, stays right-aligned on desktop, and wraps naturally on mobile.

Validation: 44 existing tests, web typecheck, Biome, and OSS build passed in isolated containers. Playwright verified the actual product at 1056/1100px desktop and 320/390px mobile widths, including amount and validation states. The short hint stays on one line at 1056px; extended text was checked with a temporary DOM stress case rather than a live payment flow. No permanent tests or business logic changes.
