### PR TITLE
fix(web): open accepted Agents from authenticated deployment details

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4157,6 +4157,93 @@ for (const entry of ["inline", "return"] as const) {
 	});
 }
 
+for (const runtime of ["openclaw", "hermes"] as const) {
+	for (const fundingSource of ["stripe", "wallet"] as const) {
+		test(`replayed ${runtime} ${fundingSource} checkout opens the authoritative Agent`, async ({
+			page,
+		}) => {
+			const retryDetail = runtime === "openclaw" && fundingSource === "wallet";
+			const created: DeploymentMutationFixture = {
+				...paidBasicDeployment,
+				id: "hdep_replayed_checkout",
+				name: "Replayed Agent",
+				status: "creating",
+				config_info: { ...paidBasicDeployment.config_info, runtime },
+			};
+			const checkoutRequests: string[] = [];
+			const detailRequests: string[] = [];
+			await stubHostedApi(page, {
+				deployments: [
+					includedBasicDeployment,
+					{ ...paidBasicDeployment, status: "stopped" },
+					created,
+				],
+				plans: [basicPlan],
+				walletState: { ...walletState, balance_usd: "500.00" },
+				checkoutRequests,
+				checkoutResponses: [
+					{
+						status: 202,
+						body: {
+							flow_type: "subscription_activation",
+							funding_source: fundingSource,
+							subscription_id: 42,
+							deployment_id: created.id,
+							agent_id: "00000000-0000-4000-8000-000000000000",
+							deployment_name: created.name,
+							metadata_generation: 1,
+							checkout_url: "",
+						},
+					},
+				],
+				deploymentDetailRequests: detailRequests,
+				deploymentDetailResponses: retryDetail
+					? [
+							{ status: 503, body: { detail: "Temporarily unavailable" } },
+							{ status: 200, body: created },
+						]
+					: [{ status: 200, body: created }],
+				cloudAgentNotFoundIds: [fixtureAgentId(created)],
+			});
+			await page.goto("/deploy");
+			await expect(
+				page
+					.getByTestId("app-sidebar-agent-rail")
+					.getByRole("button", { name: created.name, exact: true }),
+			).toBeVisible();
+			if (runtime === "openclaw") await page.getByRole("button", { name: /OpenClaw/i }).click();
+			if (fundingSource === "wallet")
+				await page
+					.locator("form")
+					.getByRole("button", { name: /Wallet balance/ })
+					.click();
+			await page
+				.getByTestId("deploy-action-bar")
+				.getByRole("button", {
+					name: fundingSource === "wallet" ? "Pay & deploy" : "Continue",
+					exact: true,
+				})
+				.click();
+			if (retryDetail) {
+				await expect(
+					page.getByText("Retrying loads the deployed Agent without creating another one."),
+				).toBeVisible();
+				await page.getByTestId("deploy-action-bar").getByRole("button", { name: /Retry/ }).click();
+			}
+			await expect(page).toHaveURL(`/agents/${fixtureAgentId(created)}`);
+			await expect(page.getByRole("heading", { name: "Deploy an Agent" })).toHaveCount(0);
+			await expect(page.getByTestId("hosted-initial-deployment-panel")).toBeVisible();
+			await expect(page.getByText("Agent couldn’t be opened", { exact: true })).toHaveCount(0);
+			expect(checkoutRequests).toHaveLength(1);
+			expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
+				funding_source: fundingSource,
+				deploy_config: { runtime },
+			});
+			expect(detailRequests).toEqual(Array(retryDetail ? 2 : 1).fill(created.id));
+		});
+	}
+}
+
 test("paid checkout waits for deployment membership before navigation without LRO convergence", async ({
 	page,
 }) => {

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
+import { createBillingClient } from "@/hosted/billing/billing-client";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	type AcceptedDeploymentNavigate,
@@ -31,7 +32,6 @@ describe("accepted deployment navigation", () => {
 		const events: string[] = [];
 
 		const handoff = navigateToAcceptedDeployment({
-			agentId: authoritative.agent_id,
 			deploymentId: authoritative.resource.id,
 			getDeployment: async () => {
 				events.push("hydrate");
@@ -95,7 +95,6 @@ describe("accepted deployment navigation", () => {
 
 		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
 		await navigateToAcceptedDeployment({
-			agentId: authoritative.agent_id,
 			deploymentId: authoritative.resource.id,
 			getDeployment: async () => authoritative,
 			navigate: async (options) => {
@@ -144,7 +143,6 @@ describe("accepted deployment navigation", () => {
 		let navigated = false;
 		await expect(
 			navigateToAcceptedDeployment({
-				agentId: "11111111-1111-4111-8111-111111111111",
 				deploymentId: "hdep_accepted",
 				getDeployment: async () => {
 					throw failure;
@@ -160,24 +158,72 @@ describe("accepted deployment navigation", () => {
 		queryClient.clear();
 	});
 
-	test("rejects a deployment response without a canonical Agent UUID", async () => {
+	test.each([
+		{
+			id: "hdep_other",
+			agentId: "11111111-1111-4111-8111-111111111111",
+			error: "different deployment",
+		},
+		{ id: "hdep_expected", agentId: "hdep_invalid_identity", error: "invalid Agent identity" },
+	])("rejects an authoritative response with $error", async ({ id, agentId, error }) => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-		const authoritative = hostedDeploymentFixture({
-			id: "hdep_invalid_identity",
-			agentId: "hdep_invalid_identity",
-		});
+		const authoritative = hostedDeploymentFixture({ id, agentId });
 
 		await expect(
 			navigateToAcceptedDeployment({
-				deploymentId: authoritative.resource.id,
+				deploymentId: "hdep_expected",
 				getDeployment: async () => authoritative,
 				navigate: () => {
 					throw new Error("navigation must not run");
 				},
 				queryClient,
 			}),
-		).rejects.toThrow("invalid Agent identity");
+		).rejects.toThrow(error);
 		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toBeUndefined();
+		queryClient.clear();
+	});
+
+	test("opens the authenticated detail identity despite a replayed request's old Agent hint", async () => {
+		const queryClient = new QueryClient();
+		const authoritative = hostedDeploymentFixture({ id: "hdep_replayed", status: "creating" });
+		const requests: string[] = [];
+		const client = createBillingClient(async () => "current-token", {
+			fetch: async (request) => {
+				expect(request.method).toBe("GET");
+				expect(request.headers.get("Authorization")).toBe("Bearer current-token");
+				const path = new URL(request.url).pathname;
+				requests.push(path);
+				return Response.json(
+					path.endsWith("/by-request/replayed")
+						? {
+								request_status: "processing",
+								deploy_request_id: "replayed",
+								lineage_tail: {
+									deployment_id: authoritative.resource.id,
+									agent_id: "00000000-0000-4000-8000-000000000000",
+									lineage_version: 1,
+									lineage_state: "processing",
+								},
+							}
+						: authoritative,
+				);
+			},
+		});
+		const navigations: Parameters<AcceptedDeploymentNavigate>[0][] = [];
+		await navigateToAcceptedDeploymentRequest({
+			deployRequestId: "replayed",
+			resolveDeploymentRequest: client.waitForDeploymentRequest,
+			getDeployment: client.getDeployment,
+			queryClient,
+			navigate: (options) => {
+				navigations.push(options);
+			},
+		});
+		expect(requests).toEqual([
+			"/v2/deployments/by-request/replayed",
+			"/v2/deployments/hdep_replayed",
+		]);
+		expect(navigations).toEqual([{ href: `/agents/${authoritative.agent_id}`, replace: false }]);
 		queryClient.clear();
 	});
 

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
-import { agentRouteIdsEqual, agentSectionHref, isAgentRouteId } from "@/lib/agent-routes";
+import { agentSectionHref, isAgentRouteId } from "@/lib/agent-routes";
 
 export type AcceptedDeploymentNavigate = (options: {
 	href: string;
@@ -10,7 +10,7 @@ export type AcceptedDeploymentNavigate = (options: {
 
 type AcceptedDeploymentRequestResolver = (
 	deployRequestId: string,
-) => Promise<{ agentId?: string | null; deploymentId: string }>;
+) => Promise<{ deploymentId: string }>;
 
 function upsertAuthoritativeDeployment(
 	deployments: readonly HostedDeployment[] | undefined,
@@ -28,12 +28,10 @@ function upsertAuthoritativeDeployment(
 }
 
 async function hydrateAcceptedDeployment({
-	agentId,
 	deploymentId,
 	getDeployment,
 	queryClient,
 }: {
-	agentId?: string;
 	deploymentId: string;
 	getDeployment: (deploymentId: string) => Promise<HostedDeployment>;
 	queryClient: QueryClient;
@@ -44,9 +42,6 @@ async function hydrateAcceptedDeployment({
 	}
 	if (!isAgentRouteId(authoritative.agent_id)) {
 		throw new Error("The deployment service returned an invalid Agent identity.");
-	}
-	if (agentId && !agentRouteIdsEqual(authoritative.agent_id, agentId)) {
-		throw new Error("The deployment service returned a different Agent identity.");
 	}
 
 	// A list read that started before acceptance can be older than the committed
@@ -61,27 +56,19 @@ async function hydrateAcceptedDeployment({
 
 /** Hydrate deployment membership before opening its canonical Agent route. */
 export async function navigateToAcceptedDeployment({
-	agentId,
 	deploymentId,
 	getDeployment,
 	navigate,
 	queryClient,
 	replace = false,
 }: {
-	agentId?: string | null;
 	deploymentId: string;
 	getDeployment: (deploymentId: string) => Promise<HostedDeployment>;
 	navigate: AcceptedDeploymentNavigate;
 	queryClient: QueryClient;
 	replace?: boolean;
 }): Promise<void> {
-	const acceptedAgentId = agentId?.trim() || null;
-	if (acceptedAgentId && !isAgentRouteId(acceptedAgentId)) {
-		throw new Error("The deployment service returned an invalid Agent identity.");
-	}
-
 	const authoritative = await hydrateAcceptedDeployment({
-		agentId: acceptedAgentId ?? undefined,
 		deploymentId,
 		getDeployment,
 		queryClient,
@@ -104,7 +91,7 @@ export async function navigateToAcceptedDeploymentRequest({
 	onAccepted?: () => void;
 	resolveDeploymentRequest: AcceptedDeploymentRequestResolver;
 }): Promise<void> {
-	const { agentId, deploymentId } = await resolveDeploymentRequest(deployRequestId);
+	const { deploymentId } = await resolveDeploymentRequest(deployRequestId);
 	onAccepted?.();
-	await navigateToAcceptedDeployment({ ...navigation, agentId, deploymentId });
+	await navigateToAcceptedDeployment({ ...navigation, deploymentId });
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -344,7 +344,6 @@ export function DeployWizard() {
 				} else {
 					await navigateToAcceptedDeployment({
 						...navigation,
-						agentId: target.agentId,
 						deploymentId: target.deploymentId,
 					});
 				}


### PR DESCRIPTION
An accepted deployment could already appear in the sidebar while the wizard displayed Agent couldn’t be opened: checkout carried a different Agent UUID than the authenticated deployment detail. The navigation helper already waits for that detail, so using the checkout hint as a second identity authority also trapped retries and replayed responses.

Use the authenticated detail as the sole Agent route identity across direct creation, checkout activation, request-lineage return and recovery. Keep expected deployment-ID and valid UUID checks, cancel stale inventory reads, and hydrate membership before navigating. No synthetic cache entries, retry loops or ignored detail mismatches are added.

Validation in isolated Docker: 41 focused frontend tests, six production-build Chromium scenarios including actual Agent UI and retry without duplicate checkout, plus type/lint/build and SSR checks. Root performed production-browser negative/positive checkout response replay with live detail/list reads; the wrong hint reproduced the exact error and the canonical response opened the real overview. No production checkout or charge was sent by replay.

The paired Hosted fix corrects checkout UUID generation from the public typed deployment ID; this frontend correction also supports old/replayed responses. No CLI release or runtime rollout is needed.


Paired fix: https://github.com/Clawdi-AI/clawdi-hosted/pull/2193
