### PR TITLE
refactor(web): remove redundant deployment navigation identity

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -634,8 +634,7 @@ describe("declarative deployment mutations", () => {
 		);
 		expect(checkout.flow_type).toBe("checkout_session");
 		expect(checkout.checkout_url).toBe("https://checkout.example.com/session");
-		expect(await client.waitForDeploymentRequest(intentKey)).toMatchObject({
-			agentId: "44444444-4444-4444-8444-444444444444",
+		expect(await client.waitForDeploymentRequest(intentKey)).toEqual({
 			deploymentId: "hdep_test",
 			operation: null,
 		});

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -648,13 +648,10 @@ export function createBillingClient(
 				throw terminalDeployRequestError(status);
 			}
 			if (projection.kind === "operation") {
-				return {
-					...acceptDeclarativeOperation({
-						operation: projection.operation,
-						deploymentId: projection.deploymentId,
-					}),
-					agentId: projection.agentId,
-				};
+				return acceptDeclarativeOperation({
+					operation: projection.operation,
+					deploymentId: projection.deploymentId,
+				});
 			}
 			if (projection.kind === "operation_name") {
 				const remainingMs = deadline - Date.now();
@@ -676,22 +673,16 @@ export function createBillingClient(
 				} finally {
 					globalThis.clearTimeout(operationTimeoutId);
 				}
-				return {
-					...acceptDeclarativeOperation({
-						operation,
-						deploymentId: projection.deploymentId,
-					}),
-					agentId: projection.agentId,
-				};
+				return acceptDeclarativeOperation({
+					operation,
+					deploymentId: projection.deploymentId,
+				});
 			}
 			if (projection.kind === "deployment") {
-				return {
-					...acceptDeclarativeOperation({
-						deploymentId: projection.deploymentId,
-						operation: null,
-					}),
-					agentId: projection.agentId,
-				};
+				return acceptDeclarativeOperation({
+					deploymentId: projection.deploymentId,
+					operation: null,
+				});
 			}
 			if (projection.kind === "invalid_success") {
 				return acceptDeclarativeOperation({ deploymentId: null, operation: null });

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -16,7 +16,7 @@ const MARKER_PARAMS = [
 
 export type CheckoutReturnNavigationTarget =
 	| { kind: "deploy_request"; deployRequestId: string }
-	| { kind: "deployment"; agentId?: string | null; deploymentId: string };
+	| { kind: "deployment"; deploymentId: string };
 export type CheckoutReturnNavigationResult = boolean | "handled";
 
 export function checkoutReturnWasCanceled(searchStr: string): boolean {

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -170,7 +170,7 @@ describe("subscription creation adapter", () => {
 		});
 	});
 
-	test("projects activation identity and entitlement fields consumed by the UI", () => {
+	test("projects activation navigation target and entitlement fields consumed by the UI", () => {
 		const activation: Extract<CheckoutOperationResult, { flow_type: "subscription_activation" }> = {
 			flow_type: "subscription_activation",
 			funding_source: "wallet",
@@ -192,7 +192,6 @@ describe("subscription creation adapter", () => {
 			flowType: "subscription_activation",
 			target: {
 				kind: "deployment",
-				agentId: "33333333-3333-4333-8333-333333333333",
 				deploymentId: "hdep_created",
 			},
 			currentPeriodEnd: "2027-07-15T00:00:00Z",

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -4,6 +4,7 @@ import {
 	type HostedDeployCheckoutUiMode,
 } from "@clawdi/shared/api";
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
+import type { CheckoutReturnNavigationTarget } from "@/hosted/billing/checkout-return";
 import type {
 	CheckoutRequest,
 	ComputePlanSlug,
@@ -92,9 +93,7 @@ export type SubscriptionCreateOutcomeView =
 	  }
 	| {
 			flowType: "subscription_activation";
-			target:
-				| { kind: "deployment"; agentId: string | null; deploymentId: string }
-				| { kind: "deploy_request"; deployRequestId: string };
+			target: CheckoutReturnNavigationTarget;
 			currentPeriodEnd: string | null;
 			entitledUntil: string | null;
 	  };
@@ -173,11 +172,9 @@ export function subscriptionCreateOutcome(
 	}
 	const deploymentId = result.deployment_id?.trim();
 	const deployRequestId = result.deploy_request_id?.trim();
-	let target:
-		| { kind: "deployment"; agentId: string | null; deploymentId: string }
-		| { kind: "deploy_request"; deployRequestId: string };
+	let target: CheckoutReturnNavigationTarget;
 	if (deploymentId) {
-		target = { kind: "deployment", agentId: result.agent_id?.trim() || null, deploymentId };
+		target = { kind: "deployment", deploymentId };
 	} else if (deployRequestId) {
 		target = { kind: "deploy_request", deployRequestId };
 	} else {


### PR DESCRIPTION
Deployment navigation already uses authenticated deployment detail, but checkout adapters and request resolution still propagated unused Agent UUID hints. Remove that second identity from navigation targets, reuse CheckoutReturnNavigationTarget, and return accepted operation results directly. Wire contracts and shared projections remain intact.

Validation in isolated Docker: web typecheck, Biome, 52 focused checkout/client/navigation tests, OSS build, and 9 production SSR checks passed. Existing assertions were updated; no new test suite or fallback was added. Follows #1494.
