### PR TITLE
fix(channels): keep Discord forwarding responsive during metadata reads

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import secrets
 import threading
 import zlib
@@ -117,6 +118,7 @@ log = logging.getLogger(__name__)
 
 _DISCORD_GATEWAY_RESUME_BUFFER_SIZE = 100
 _DISCORD_GATEWAY_MAX_CHANNELS = 256
+_DISCORD_GATEWAY_STARTUP_TIMEOUT_SECONDS = 30.0
 _DISCORD_GATEWAY_MAX_SESSIONS = 256
 _DISCORD_GATEWAY_SESSION_TTL_SECONDS = 5 * 60.0
 _DISCORD_GATEWAY_CAPABILITY_SUBJECT = "clawdi_discord_gateway"
@@ -871,6 +873,7 @@ async def discord_agent_gateway(
     notified: asyncio.Event | None = None
     receive_task: asyncio.Task[JsonValue] | None = None
     wakeup_task: asyncio.Task[bool] | None = None
+    startup_task: asyncio.Task[dict[str, JsonObject]] | None = None
 
     async def send_gateway_frame(
         payload: JsonObject,
@@ -1222,7 +1225,7 @@ async def discord_agent_gateway(
                     "account_id": account.id,
                     "bot_agent_link_id": bot_agent_link_id,
                     "frames": [],
-                    "identified": True,
+                    "identified": False,
                     "projected_guilds": projected_guilds,
                     "projected_channels": projected_channels,
                     "message_checkpoints": OrderedDict(),
@@ -1235,22 +1238,29 @@ async def discord_agent_gateway(
                         account=account,
                         bot_agent_link_id=bot_agent_link_id,
                     )
-                for channel_id, guild_id in channels.items():
-                    try:
-                        result = await request_discord_provider(
-                            account=account,
-                            method="GET",
-                            path=f"channels/{channel_id}",
+                receive_task = asyncio.create_task(
+                    websocket.receive_json(), name="discord-gateway-receive"
+                )
+                startup_task = asyncio.create_task(
+                    _discord_gateway_startup_channels(account, channels),
+                    name="discord-gateway-startup",
+                )
+                try:
+                    while not startup_task.done():
+                        await asyncio.wait(
+                            {startup_task, receive_task}, return_when=asyncio.FIRST_COMPLETED
                         )
-                    except HTTPException:
-                        continue
-                    channel = _discord_gateway_channel(
-                        result,
-                        channel_id=channel_id,
-                        guild_id=guild_id,
-                    )
-                    if channel is not None:
-                        projected_channels[channel_id] = channel
+                        if receive_task.done():
+                            frame = _JSON_VALUE_ADAPTER.validate_python(receive_task.result())
+                            if isinstance(frame, dict) and frame.get("op") == 1:
+                                await send_gateway_frame({"op": 11, "d": None}, record=False)
+                            receive_task = asyncio.create_task(
+                                websocket.receive_json(), name="discord-gateway-receive"
+                            )
+                    projected_channels.update(startup_task.result())
+                except TimeoutError:
+                    await websocket.close(code=1013, reason="Gateway startup timed out")
+                    return
                 await send_dispatch(
                     "READY",
                     {
@@ -1280,6 +1290,7 @@ async def discord_agent_gateway(
                 for channel_id, channel in projected_channels.items():
                     if channels.get(channel_id) is not None:
                         await send_channel(channel)
+                session_state["identified"] = True
 
         if bot_agent_link_id is None:
             await websocket.close(code=4004)
@@ -1288,7 +1299,10 @@ async def discord_agent_gateway(
         notified = channel_inbound_messages_enqueued.subscribe(
             str(account.id), scope=str(active_link_id)
         )
-        receive_task = asyncio.create_task(websocket.receive_json(), name="discord-gateway-receive")
+        if receive_task is None:
+            receive_task = asyncio.create_task(
+                websocket.receive_json(), name="discord-gateway-receive"
+            )
 
         while True:
             # Retain the reader across notifications/timeouts, including when
@@ -1473,16 +1487,9 @@ async def discord_agent_gateway(
         return
     finally:
         try:
-            if consumer_lease is not None and consumer_lease_entered:
-                await consumer_lease.__aexit__(None, None, None)
-        finally:
-            if owns_session_entry:
-                _DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
-            if notified is not None and account is not None:
-                channel_inbound_messages_enqueued.unsubscribe(
-                    str(account.id), notified, scope=str(bot_agent_link_id)
-                )
-            tasks = [task for task in (receive_task, wakeup_task) if task is not None]
+            tasks: list[asyncio.Task[object]] = [
+                task for task in (receive_task, wakeup_task, startup_task) if task is not None
+            ]
             for task in tasks:
                 if not task.done():
                     task.cancel()
@@ -1492,6 +1499,20 @@ async def discord_agent_gateway(
 
             if tasks:
                 await finish_cleanup(collect_tasks)
+        finally:
+            try:
+                if consumer_lease is not None and consumer_lease_entered:
+                    await consumer_lease.__aexit__(None, None, None)
+            finally:
+                if owns_session_entry:
+                    if session_state is not None and not session_state["identified"]:
+                        _DISCORD_GATEWAY_SESSIONS.discard(session_id)
+                    else:
+                        _DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
+                if notified is not None and account is not None:
+                    channel_inbound_messages_enqueued.unsubscribe(
+                        str(account.id), notified, scope=str(bot_agent_link_id)
+                    )
 
 
 @router.post(
@@ -1995,6 +2016,52 @@ async def _discord_gateway_authority(
         }:
             channels[binding.external_chat_id] = None
     return guilds, channels
+
+
+async def _discord_gateway_startup_channels(
+    account: ChannelAccount, channels: dict[str, str | None]
+) -> dict[str, JsonObject]:
+    """Read the ordered startup snapshot without dropping rate-limited channels."""
+
+    async def read_channel(channel_id: str, guild_id: str | None) -> JsonObject | None:
+        while True:
+            try:
+                result = await request_discord_provider(
+                    account=account, method="GET", path=f"channels/{channel_id}"
+                )
+            except HTTPException as exc:
+                if exc.status_code != status.HTTP_429_TOO_MANY_REQUESTS:
+                    return None
+                result = DiscordProviderResult(
+                    content=b"",
+                    status_code=exc.status_code,
+                    media_type="application/json",
+                    headers=dict(exc.headers or {}),
+                )
+            if result.status_code != status.HTTP_429_TOO_MANY_REQUESTS:
+                return _discord_gateway_channel(result, channel_id=channel_id, guild_id=guild_id)
+            delay = discord_retry_after_seconds(result)
+            if delay is None or not math.isfinite(delay) or delay <= 0:
+                delay = 1.0
+            # The enclosing deadline cancels the batch before a long Retry-After
+            # can expire. A small floor prevents a provider's zero/near-zero loop.
+            await asyncio.sleep(min(max(0.1, delay), _DISCORD_GATEWAY_STARTUP_TIMEOUT_SECONDS))
+
+    projected: dict[str, JsonObject] = {}
+    snapshot = list(channels.items())
+    async with asyncio.timeout(_DISCORD_GATEWAY_STARTUP_TIMEOUT_SECONDS):
+        for offset in range(0, len(snapshot), 4):
+            batch = snapshot[offset : offset + 4]
+            async with asyncio.TaskGroup() as group:
+                reads = [
+                    group.create_task(read_channel(channel_id, guild_id))
+                    for channel_id, guild_id in batch
+                ]
+            for (channel_id, _), read in zip(batch, reads, strict=True):
+                channel = read.result()
+                if channel is not None:
+                    projected[channel_id] = channel
+    return projected
 
 
 def _discord_gateway_channel(

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -874,6 +874,7 @@ async def discord_agent_gateway(
     receive_task: asyncio.Task[JsonValue] | None = None
     wakeup_task: asyncio.Task[bool] | None = None
     startup_task: asyncio.Task[dict[str, JsonObject]] | None = None
+    channel_task: asyncio.Task[DiscordProviderResult] | None = None
 
     async def send_gateway_frame(
         payload: JsonObject,
@@ -958,6 +959,28 @@ async def discord_agent_gateway(
                 await db.commit()
         for gateway_sequence in acknowledged_sequences:
             checkpoints.pop(gateway_sequence, None)
+
+    async def handle_received_frame() -> None:
+        nonlocal receive_task
+        if receive_task is None or not receive_task.done():
+            return
+        frame = _JSON_VALUE_ADAPTER.validate_python(receive_task.result())
+        if isinstance(frame, dict) and frame.get("op") == 1:
+            if session_state is not None and session_state["identified"]:
+                await acknowledge_gateway_sequence(optional_int_param(frame.get("d")))
+            await send_gateway_frame({"op": 11, "d": None}, record=False)
+        receive_task = asyncio.create_task(websocket.receive_json(), name="discord-gateway-receive")
+
+    async def supervise_provider_read(task: asyncio.Task[object]) -> None:
+        # Only provider reads run concurrently. Receipts and socket writes stay
+        # on this owner, outside the binding/message locks held during send.
+        while True:
+            await handle_received_frame()
+            if task.done():
+                return
+            if receive_task is None:
+                raise RuntimeError("discord gateway provider read has no socket reader")
+            await asyncio.wait({task, receive_task}, return_when=asyncio.FIRST_COMPLETED)
 
     async def send_guild(guild_id: str, guild_name: str) -> None:
         payload = _discord_guild_create_payload(
@@ -1246,17 +1269,7 @@ async def discord_agent_gateway(
                     name="discord-gateway-startup",
                 )
                 try:
-                    while not startup_task.done():
-                        await asyncio.wait(
-                            {startup_task, receive_task}, return_when=asyncio.FIRST_COMPLETED
-                        )
-                        if receive_task.done():
-                            frame = _JSON_VALUE_ADAPTER.validate_python(receive_task.result())
-                            if isinstance(frame, dict) and frame.get("op") == 1:
-                                await send_gateway_frame({"op": 11, "d": None}, record=False)
-                            receive_task = asyncio.create_task(
-                                websocket.receive_json(), name="discord-gateway-receive"
-                            )
+                    await supervise_provider_read(startup_task)
                     projected_channels.update(startup_task.result())
                 except TimeoutError:
                     await websocket.close(code=1013, reason="Gateway startup timed out")
@@ -1307,14 +1320,7 @@ async def discord_agent_gateway(
         while True:
             # Retain the reader across notifications/timeouts, including when
             # both inputs complete together or dispatch batches keep arriving.
-            if receive_task.done():
-                frame = _JSON_VALUE_ADAPTER.validate_python(receive_task.result())
-                if isinstance(frame, dict) and frame.get("op") == 1:
-                    await acknowledge_gateway_sequence(optional_int_param(frame.get("d")))
-                    await send_gateway_frame({"op": 11, "d": None}, record=False)
-                receive_task = asyncio.create_task(
-                    websocket.receive_json(), name="discord-gateway-receive"
-                )
+            await handle_received_frame()
             # Clear before querying so a concurrent commit forces a recheck.
             notified.clear()
             if wakeup_task is None or wakeup_task.done():
@@ -1381,11 +1387,16 @@ async def discord_agent_gateway(
                                 break
                             result: DiscordProviderResult | None = None
                             try:
-                                result = await request_discord_provider(
-                                    account=account,
-                                    method="GET",
-                                    path=f"channels/{channel_id}",
+                                channel_task = asyncio.create_task(
+                                    request_discord_provider(
+                                        account=account,
+                                        method="GET",
+                                        path=f"channels/{channel_id}",
+                                    ),
+                                    name="discord-gateway-channel-read",
                                 )
+                                await supervise_provider_read(channel_task)
+                                result = channel_task.result()
                             except HTTPException as exc:
                                 if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
                                     retry_after = discord_retry_after_seconds(
@@ -1415,6 +1426,14 @@ async def discord_agent_gateway(
                             if result is not None and result.status_code >= 500:
                                 deferred_channels[channel_id] = monotonic() + 1.0
                                 break
+                            async with async_session_factory() as db:
+                                guilds, channels = await _discord_gateway_authority(
+                                    db,
+                                    account=account,
+                                    bot_agent_link_id=active_link_id,
+                                    priority_channel_id=channel_id,
+                                )
+                            authorized = channel_id in channels and channels[channel_id] == guild_id
                             projected = (
                                 _discord_gateway_channel(
                                     result,
@@ -1488,7 +1507,9 @@ async def discord_agent_gateway(
     finally:
         try:
             tasks: list[asyncio.Task[object]] = [
-                task for task in (receive_task, wakeup_task, startup_task) if task is not None
+                task
+                for task in (receive_task, wakeup_task, startup_task, channel_task)
+                if task is not None
             ]
             for task in tasks:
                 if not task.done():

--- a/backend/tests/test_discord_startup_qualification.py
+++ b/backend/tests/test_discord_startup_qualification.py
@@ -1,0 +1,336 @@
+"""Discord Gateway startup ordering, retries and durable receipts over real TCP/PG."""
+
+import asyncio
+import json
+import socket
+import time
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from websockets.asyncio.client import connect
+from websockets.exceptions import ConnectionClosedError
+
+from app.main import app
+from app.models.channel import ChannelAccount, ChannelBinding, ChannelBindingAlias, ChannelMessage
+from app.routes.channel_routers import discord, shared
+from app.services.discord_advisory_session import DiscordAdvisorySession
+from app.services.discord_rate_limiter import DiscordRateLimiter
+from tests.test_channels import _create_paired_discord_channel, _reset_discord_gateway_sessions
+from tests.test_channels import (
+    _verified_discord_guild_membership as _verified_discord_guild_membership,
+)
+
+pytestmark = [pytest.mark.committed_db, pytest.mark.usefixtures("channel_agent")]
+
+
+@pytest.mark.parametrize(
+    "status_code,raised",
+    [(401, False), (403, False), (404, False), (401, True), (404, True), (429, True)],
+)
+async def test_startup_retries_only_rate_limits(monkeypatch, status_code, raised):
+    calls = 0
+
+    async def request(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if raised and calls == 1:
+            raise HTTPException(status_code=status_code, headers={"Retry-After": "0.1"})
+        return shared.DiscordProviderResult(
+            content=b'{"id":"channel","guild_id":"guild","type":0}',
+            status_code=200 if status_code == 429 else status_code,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(discord, "request_discord_provider", request)
+    result = await discord._discord_gateway_startup_channels(ChannelAccount(), {"channel": "guild"})
+    assert calls == (2 if status_code == 429 else 1)
+    assert list(result) == (["channel"] if status_code == 429 else [])
+
+
+@pytest.mark.parametrize(
+    "count,delay,slow,contention,fault",
+    [
+        (1, 0.03, False, False, None),
+        (10, 0.03, False, False, None),
+        (100, 0.03, False, False, None),
+        (10, 0.03, True, False, None),
+        (100, 0.001, False, True, None),
+        (10, 0.001, False, False, "provider_once"),
+        (10, 0.001, False, False, "persistent"),
+        (10, 0.001, False, False, "long_retry"),
+        (10, 0.001, False, False, "disconnect"),
+        (10, 0.001, False, False, "partial_ready"),
+        (1, 0.001, False, False, "nan"),
+        (1, 0.001, False, False, "inf"),
+    ],
+)
+async def test_startup_snapshot(
+    client, db_session, engine, monkeypatch, count, delay, slow, contention, fault
+):
+    store = _reset_discord_gateway_sessions(monkeypatch)
+    if fault in {"persistent", "long_retry", "disconnect", "nan", "inf"}:
+        monkeypatch.setattr(discord, "_DISCORD_GATEWAY_STARTUP_TIMEOUT_SECONDS", 0.35)
+    target = "100000000000000001"
+    guild = "200000000000000001"
+    created = await _create_paired_discord_channel(
+        client, name=f"startup-{uuid4().hex}", channel_id=target, guild_id=guild
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.scalars(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).one()
+    for index in range(1, count):
+        db_session.add(
+            ChannelBindingAlias(
+                account_id=account_id,
+                bot_agent_link_id=binding.bot_agent_link_id,
+                binding_id=binding.id,
+                user_id=binding.user_id,
+                alias_external_chat_id=str(int(target) + index),
+                alias_kind="discord_channel",
+            )
+        )
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=binding.bot_agent_link_id,
+        binding_id=binding.id,
+        user_id=binding.user_id,
+        direction="inbound",
+        external_chat_id=binding.external_chat_id,
+        provider_message_id="synthetic-target",
+        payload={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "synthetic-target",
+                "channel_id": target,
+                "guild_id": guild,
+                "content": "synthetic",
+                "author": {"id": "300000000000000001"},
+            },
+        },
+    )
+    db_session.add(message)
+    await db_session.commit()
+    monkeypatch.setattr(
+        discord, "async_session_factory", async_sessionmaker(engine, expire_on_commit=False)
+    )
+    locks = DiscordAdvisorySession(engine)
+    monkeypatch.setattr(app.state, "discord_gateway_locks", locks, raising=False)
+    clock_offset = 0.0
+    limiter = DiscordRateLimiter(now=lambda: time.monotonic() + clock_offset)
+    monkeypatch.setattr(shared, "discord_rate_limiter", limiter)
+    paths = []
+    statuses = []
+    active = peak = 0
+    first = True
+    original_send = WebSocket.send_json
+
+    async def send_json(websocket, data, mode="text"):
+        if fault == "partial_ready" and not recovering and data.get("t") == "GUILD_CREATE":
+            raise WebSocketDisconnect()
+        await original_send(websocket, data, mode=mode)
+
+    monkeypatch.setattr(WebSocket, "send_json", send_json)
+    entered = asyncio.Event()
+    attempts = []
+    recovering = False
+    snapshot = []
+    original_authority = discord._discord_gateway_authority
+
+    async def authority(*args, **kwargs):
+        result = await original_authority(*args, **kwargs)
+        if not snapshot:
+            snapshot.extend(result[1])
+        return result
+
+    monkeypatch.setattr(discord, "_discord_gateway_authority", authority)
+
+    async def transport(request):
+        nonlocal active, peak, first
+        active += 1
+        peak = max(peak, active)
+        paths.append(request.url.path)
+        attempts.append(time.perf_counter())
+        attempt = len(attempts)
+        entered.set()
+        pause = (
+            10.0 if fault == "disconnect" and not recovering else (0.5 if slow and first else delay)
+        )
+        first = False
+        try:
+            await asyncio.sleep(pause)
+            if (
+                not recovering
+                and fault not in {None, "partial_ready"}
+                and (
+                    fault in {"persistent", "long_retry", "disconnect", "nan", "inf"}
+                    or attempt == 1
+                )
+            ):
+                retry = {"long_retry": "30", "nan": "nan", "inf": "inf"}.get(fault, "0.2")
+                return httpx.Response(
+                    429,
+                    headers={"Retry-After": retry, "X-RateLimit-Global": "true"},
+                    json={"global": True},
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "id": request.url.path.rsplit("/", 1)[-1],
+                    "guild_id": guild,
+                    "type": 0,
+                    "name": "synthetic",
+                },
+            )
+        finally:
+            active -= 1
+
+    async def provider(**kwargs):
+        result = await shared.request_discord_provider(**kwargs)
+        statuses.append(result.status_code)
+        return result
+
+    monkeypatch.setattr(discord, "request_discord_provider", provider)
+    server = uvicorn.Server(
+        uvicorn.Config(app, lifespan="off", log_level="critical", access_log=False)
+    )
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    try:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as http:
+            monkeypatch.setattr(shared, "get_channel_provider_http_client", lambda: http)
+            async with asyncio.timeout(15):
+                while not server.started:
+                    await asyncio.sleep(0.01)
+                if contention:
+                    account = await db_session.get(ChannelAccount, account_id)
+                    for _ in range(10):
+                        await shared.request_discord_provider(
+                            account=account, method="GET", path="users/@me"
+                        )
+                    paths.clear()
+                async with connect(f"ws://127.0.0.1:{port}/v1/channels/discord/gateway") as ws:
+                    assert json.loads(await ws.recv())["op"] == 10
+                    started = time.perf_counter()
+                    await ws.send(
+                        json.dumps({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+                    )
+                    if fault in {
+                        "persistent",
+                        "long_retry",
+                        "disconnect",
+                        "nan",
+                        "inf",
+                        "partial_ready",
+                    }:
+                        if fault == "partial_ready":
+                            partial = json.loads(await ws.recv())
+                            assert partial["t"] == "READY"
+                            failed_session = partial["d"]["session_id"]
+                        else:
+                            await entered.wait()
+                            # Heartbeats must be consumed during GET/retry waits.
+                            await ws.send(json.dumps({"op": 1, "d": None}))
+                            assert json.loads(await asyncio.wait_for(ws.recv(), 0.2)) == {
+                                "op": 11,
+                                "d": None,
+                            }
+                            failed_session = next(iter(store._entries))
+                        if fault in {"disconnect", "partial_ready"}:
+                            await ws.close()
+                        else:
+                            with pytest.raises(ConnectionClosedError) as closed:
+                                await ws.recv()
+                            assert closed.value.rcvd.code == 1013
+                            assert time.perf_counter() - started < 1.0
+                        async with asyncio.timeout(1):
+                            while store._entries:
+                                await asyncio.sleep(0.01)
+                        assert active == 0
+                        assert len(paths) <= (
+                            count
+                            if fault == "partial_ready"
+                            else (8 if fault == "persistent" else 4)
+                        )
+                        await db_session.refresh(message)
+                        assert message.delivered_at is None
+                        # Failed startup is not resumable, but a fresh IDENTIFY
+                        # still receives the original unacknowledged durable row.
+                        if fault in {"nan", "inf"}:
+                            return
+                        recovering = True
+                        clock_offset += 31.0
+                        async with connect(
+                            f"ws://127.0.0.1:{port}/v1/channels/discord/gateway"
+                        ) as retry_ws:
+                            assert json.loads(await retry_ws.recv())["op"] == 10
+                            await retry_ws.send(
+                                json.dumps(
+                                    {
+                                        "op": 6,
+                                        "d": {
+                                            "token": created["agent_token"],
+                                            "session_id": failed_session,
+                                            "seq": 0,
+                                        },
+                                    }
+                                )
+                            )
+                            assert json.loads(await retry_ws.recv()) == {"op": 9, "d": False}
+                            await retry_ws.send(
+                                json.dumps(
+                                    {"op": 2, "d": {"token": created["agent_token"], "intents": 0}}
+                                )
+                            )
+                            retry_frames = []
+                            while not retry_frames or retry_frames[-1].get("t") != "MESSAGE_CREATE":
+                                retry_frames.append(json.loads(await retry_ws.recv()))
+                            assert [
+                                f["d"]["id"] for f in retry_frames if f.get("t") == "CHANNEL_CREATE"
+                            ] == snapshot
+                            await db_session.refresh(message)
+                            assert message.delivered_at is None
+                        return
+                    ready = json.loads(await ws.recv())
+                    frames = [ready]
+                    while frames[-1].get("t") != "MESSAGE_CREATE":
+                        frames.append(json.loads(await ws.recv()))
+                    message_ms = (time.perf_counter() - started) * 1000
+                    await db_session.refresh(message)
+                    assert message.delivered_at is None
+                    await ws.send(json.dumps({"op": 1, "d": frames[-1]["s"]}))
+                    assert json.loads(await ws.recv())["op"] == 11
+                    await db_session.refresh(message)
+                    assert message.delivered_at is not None
+                projected = [f["d"]["id"] for f in frames if f.get("t") == "CHANNEL_CREATE"]
+                assert active == 0
+                assert ready["t"] == "READY" and ready["d"]["private_channels"] == []
+                assert frames[1]["t"] == "GUILD_CREATE"
+                assert projected == snapshot
+                assert frames[-1]["d"] == message.payload["d"]
+                assert [frame["d"] for frame in frames if frame.get("t") == "CHANNEL_CREATE"] == [
+                    {"id": channel_id, "guild_id": guild, "type": 0, "name": "synthetic"}
+                    for channel_id in snapshot
+                ]
+                assert statuses.count(200) == count
+                assert peak == min(4, count)
+                if fault in {"nan", "inf", "provider_once"}:
+                    assert attempts[-1] - attempts[0] >= (0.9 if fault in {"nan", "inf"} else 0.19)
+                if count == 100 and delay == 0.03:
+                    assert message_ms < 2500
+    finally:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(server_task, 10)
+        finally:
+            listener.close()
+            await locks.close()

--- a/backend/tests/test_discord_startup_qualification.py
+++ b/backend/tests/test_discord_startup_qualification.py
@@ -334,3 +334,232 @@ async def test_startup_snapshot(
         finally:
             listener.close()
             await locks.close()
+
+
+@pytest.mark.parametrize("fault", [None, "disconnect", "cancel", "failure", "timeout", "revoke"])
+async def test_ready_channel_read_supervision(client, db_session, engine, monkeypatch, fault):
+    """A held post-READY GET must not hold ACKs, receipts or socket ownership."""
+    store = _reset_discord_gateway_sessions(monkeypatch)
+    target, fresh, guild = "100000000000000001", "100000000000000002", "200000000000000001"
+    created = await _create_paired_discord_channel(
+        client, name=f"ready-{uuid4().hex}", channel_id=target, guild_id=guild
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.scalars(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).one()
+
+    def message(channel_id, label):
+        return ChannelMessage(
+            account_id=account_id,
+            bot_agent_link_id=binding.bot_agent_link_id,
+            binding_id=binding.id,
+            user_id=binding.user_id,
+            direction="inbound",
+            external_chat_id=binding.external_chat_id,
+            provider_message_id=label,
+            payload={
+                "t": "MESSAGE_CREATE",
+                "d": {
+                    "id": label,
+                    "channel_id": channel_id,
+                    "guild_id": guild,
+                    "content": label,
+                    "author": {"id": "300000000000000001"},
+                },
+            },
+        )
+
+    initial = message(target, "initial")
+    db_session.add(initial)
+    await db_session.commit()
+    monkeypatch.setattr(
+        discord, "async_session_factory", async_sessionmaker(engine, expire_on_commit=False)
+    )
+    locks = DiscordAdvisorySession(engine)
+    monkeypatch.setattr(app.state, "discord_gateway_locks", locks, raising=False)
+    monkeypatch.setattr(shared, "discord_rate_limiter", DiscordRateLimiter())
+    entered, release, exited = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    active = 0
+    attempts = 0
+    owner = None
+    original_release = locks.release
+
+    async def release_lease(lease):
+        assert active == 0
+        assert not [
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name()
+            in {"discord-gateway-receive", "discord-gateway-wakeup", "discord-gateway-channel-read"}
+        ]
+        await original_release(lease)
+
+    monkeypatch.setattr(locks, "release", release_lease)
+    original_authority = discord._discord_gateway_authority
+
+    async def authority(*args, **kwargs):
+        nonlocal owner
+        owner = asyncio.current_task()
+        return await original_authority(*args, **kwargs)
+
+    monkeypatch.setattr(discord, "_discord_gateway_authority", authority)
+
+    async def transport(request):
+        nonlocal active, attempts
+        channel_id = request.url.path.rsplit("/", 1)[-1]
+        if channel_id == fresh:
+            active += 1
+            attempts += 1
+            entered.set()
+            try:
+                await release.wait()
+                if attempts == 1:
+                    if fault == "failure":
+                        return httpx.Response(503)
+                    if fault == "timeout":
+                        raise httpx.ReadTimeout("synthetic timeout", request=request)
+            finally:
+                active -= 1
+                exited.set()
+        return httpx.Response(
+            200, json={"id": channel_id, "guild_id": guild, "type": 0, "name": "synthetic"}
+        )
+
+    server = uvicorn.Server(
+        uvicorn.Config(app, lifespan="off", log_level="critical", access_log=False)
+    )
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    url = f"ws://127.0.0.1:{listener.getsockname()[1]}/v1/channels/discord/gateway"
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    try:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(transport)) as http:
+            monkeypatch.setattr(shared, "get_channel_provider_http_client", lambda: http)
+            async with asyncio.timeout(15):
+                while not server.started:
+                    await asyncio.sleep(0.01)
+                async with connect(url) as ws:
+                    assert json.loads(await ws.recv())["op"] == 10
+                    await ws.send(
+                        json.dumps({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+                    )
+                    ready = json.loads(await ws.recv())
+                    assert ready["t"] == "READY"
+                    session_id = ready["d"]["session_id"]
+                    frame = ready
+                    while frame.get("t") != "MESSAGE_CREATE":
+                        frame = json.loads(await ws.recv())
+                    sent_sequence = frame["s"]
+                    alias = ChannelBindingAlias(
+                        account_id=account_id,
+                        bot_agent_link_id=binding.bot_agent_link_id,
+                        binding_id=binding.id,
+                        user_id=binding.user_id,
+                        alias_external_chat_id=fresh,
+                        alias_kind="discord_channel",
+                    )
+                    pending = message(fresh, "fresh")
+                    trailing = message(target, "trailing")
+                    db_session.add(alias)
+                    db_session.add(pending)
+                    await db_session.flush()
+                    db_session.add(trailing)
+                    await db_session.commit()
+                    discord.channel_inbound_messages_enqueued.signal(str(account_id))
+                    await entered.wait()
+                    # Forward and stale sequences cannot receipt the sent message;
+                    # acknowledging it must not receipt either unsent message.
+                    for sequence in (sent_sequence + 100, sent_sequence - 1, sent_sequence):
+                        await ws.send(json.dumps({"op": 1, "d": sequence}))
+                        assert json.loads(await asyncio.wait_for(ws.recv(), 0.3)) == {
+                            "op": 11,
+                            "d": None,
+                        }
+                        await db_session.refresh(initial)
+                        assert (initial.delivered_at is not None) == (sequence == sent_sequence)
+                        for row in (pending, trailing):
+                            await db_session.refresh(row)
+                            assert row.delivered_at is None
+                    assert active == 1
+                    if fault in {"disconnect", "cancel"}:
+                        if fault == "cancel":
+                            assert owner is not None
+                            owner.cancel()
+                        else:
+                            await ws.close()
+                        await asyncio.wait_for(exited.wait(), 0.3)
+                        async with asyncio.timeout(1):
+                            while store._entries[session_id].connection_count:
+                                await asyncio.sleep(0.01)
+                        assert active == 0
+                        release.set()
+                    else:
+                        if fault == "revoke":
+                            await db_session.delete(alias)
+                            await db_session.commit()
+                        release.set()
+                        frames = []
+                        while not frames or frames[-1].get("d", {}).get("id") != "trailing":
+                            frames.append(json.loads(await ws.recv()))
+                        assert [f["t"] for f in frames] == (
+                            ["MESSAGE_CREATE"]
+                            if fault == "revoke"
+                            else ["CHANNEL_CREATE", "MESSAGE_CREATE", "MESSAGE_CREATE"]
+                        )
+                        if fault != "revoke":
+                            assert [f["d"]["id"] for f in frames[1:]] == ["fresh", "trailing"]
+                            await db_session.refresh(pending)
+                            assert pending.delivered_at is None
+                            await ws.send(json.dumps({"op": 1, "d": frames[1]["s"]}))
+                            assert json.loads(await ws.recv())["op"] == 11
+                            await db_session.refresh(pending)
+                            assert pending.delivered_at is not None
+                            sent_sequence = frames[1]["s"]
+                        assert attempts == (2 if fault in {"failure", "timeout"} else 1)
+                async with asyncio.timeout(1):
+                    while store._entries[session_id].connection_count:
+                        await asyncio.sleep(0.01)
+                # Resume replays/continues in original order; only its supplied
+                # checkpoint (and subsequent heartbeat) can acknowledge rows.
+                async with connect(url) as ws:
+                    assert json.loads(await ws.recv())["op"] == 10
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "op": 6,
+                                "d": {
+                                    "token": created["agent_token"],
+                                    "session_id": session_id,
+                                    "seq": sent_sequence,
+                                },
+                            }
+                        )
+                    )
+                    frames = []
+                    while not (
+                        any(f.get("t") == "RESUMED" for f in frames)
+                        and any(f.get("d", {}).get("id") == "trailing" for f in frames)
+                    ):
+                        frames.append(json.loads(await ws.recv()))
+                    assert any(f.get("t") == "RESUMED" for f in frames)
+                    assert [f["d"]["id"] for f in frames if f.get("t") == "MESSAGE_CREATE"] == (
+                        ["fresh", "trailing"] if fault in {"disconnect", "cancel"} else ["trailing"]
+                    )
+                    await db_session.refresh(trailing)
+                    assert trailing.delivered_at is None
+                    await ws.send(json.dumps({"op": 1, "d": frames[-1]["s"]}))
+                    assert json.loads(await ws.recv())["op"] == 11
+                    await db_session.refresh(trailing)
+                    assert trailing.delivered_at is not None
+    finally:
+        release.set()
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(server_task, 10)
+        finally:
+            listener.close()
+            await locks.close()
+        assert active == 0

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -109,6 +109,15 @@ reproducible resource limits, results and compatibility contract. The
 independent authenticated requests with the production 30-second wait cap and
 five-second fallback, including interleaved Account/Link strategies.
 
+Synthetic Gateway IDENTIFY reads channel metadata in ordered batches of four.
+Startup reads honor Discord and local limiter `Retry-After` responses within
+a shared 30-second provider-read deadline, while the socket reader handles
+heartbeats and disconnects. An expired deadline closes with code 1013; an
+incomplete startup cannot Resume. READY private channels and subsequent guild,
+channel, and thread frames retain their order. Message receipts still require
+heartbeat/Resume acknowledgement. Verify with
+`scripts/test.sh backend tests/test_discord_startup_qualification.py`.
+
 The default liveness interval is one second, with a five-second probe deadline
 including serial-gate waiting. Lock SQL also has a five-second deadline. These
 are application cancellation deadlines, not guarantees about TCP blackhole or


### PR DESCRIPTION
Discord channel metadata reads blocked both initial message delivery and heartbeat processing. Startup fetched every channel serially and skipped rate-limited channels. After READY, several slow new-channel reads could block heartbeats beyond the advertised 45-second interval and trigger reconnection.

Read startup metadata in ordered batches of at most four, honoring Retry-After through the existing provider helper and limiter, with a 30-second provider-read deadline. Reuse one supervised socket-reader path during startup and subsequent metadata reads so heartbeats and disconnects are handled promptly. All ACKs and socket writes remain serialized on the request owner; authorization is refreshed after provider waits. Incomplete startup cannot Resume, and owned children drain before the consumer lease is released.

Controlled real TCP WebSocket/PostgreSQL tests with synthetic provider transport show 100-channel first-message time improving from 3,292 to 1,524 ms with all 100 ordered channel frames retained. Three consecutive 16-second metadata reads caused the baseline to miss its 45-second heartbeat deadline; the candidate acknowledged in 9 ms while the first read remained blocked. These prove controlled protocol behavior, not native Hermes behavior or attribution of every production delay. Cross-channel ordered message blocking still exists; no reordered queue, metadata/authority cache, schema change, heartbeat-interval change, or Hosted V1 modification.

Validation: startup implementation passed full PR CI at 8ac7522c1. Follow-up e7d9b1e63 passed 53 focused startup/steady-state/authorization/limiter/Resume tests, Ruff, formatting, owned/strict/exact-path type gates, unchanged exception audit, dependency and outbound API governance. Tests cover stale/forward ACKs, cancellation, disconnect, 503/timeout, permission removal, partial READY and durable replay. Existing TestClient cleanup diagnostics are retained in evidence; new TCP cases assert task drainage. An evidence-wrapper cleanup failure occurred after checks and was resolved with a stable-script rerun. No product edits occurred between verification runs. Lefthook was unavailable; explicit Docker checks ran independently. Full CI must validate the final follow-up head before merge.
