### PR TITLE
test: measure native OpenClaw handoff latency

### DIFF
--- a/apps/web/e2e/hosted-openclaw-native.pw.ts
+++ b/apps/web/e2e/hosted-openclaw-native.pw.ts
@@ -32,6 +32,9 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 	await page.route("**/v2/deployments/*/runtime-ui/credentials", async (route) => {
 		const { stdout } = await promisify(execFile)("node", [entry, "dashboard", "--json"], {
 			timeout: 20_000,
+		}).catch(() => {
+			// CLI errors may contain newly issued credentials in captured output.
+			throw new Error("Official dashboard handoff failed");
 		});
 		const native = JSON.parse(stdout);
 		const url = new URL(native.browserUrl);
@@ -141,5 +144,7 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 	expect(connections[3]?.connects).toEqual([["bootstrapToken"]]);
 	expect(connections[3]?.device).toBe(initial?.device);
 	expect(issued).toBe(2);
-	console.log(JSON.stringify({ issued, documents, connections }));
+	console.log(
+		JSON.stringify({ issued, documents, helloCount: connections.filter((c) => c.hello).length }),
+	);
 });

--- a/apps/web/e2e/openclaw-handoff-latency.pw.ts
+++ b/apps/web/e2e/openclaw-handoff-latency.pw.ts
@@ -1,0 +1,91 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { expect, test } from "@playwright/test";
+
+const entry = process.env.OPENCLAW_TEST_ENTRY;
+const endpoint = "https://127.0.0.1:19443/";
+
+test("measure official CLI handoff and fresh native browser hello", async ({ browser }) => {
+	test.skip(!entry, "Requires the isolated official OpenClaw gateway fixture");
+	test.setTimeout(240_000);
+	if (!entry) throw new Error("Missing official gateway entry");
+	const command = async (option: "--help" | "--json") => {
+		const start = performance.now();
+		try {
+			const { stdout } = await promisify(execFile)("node", [entry, "dashboard", option], {
+				timeout: 10_000,
+				maxBuffer: 32 * 1024,
+			});
+			return { stdout, ms: performance.now() - start };
+		} catch {
+			// execFile errors can contain a newly issued handoff. Never log them.
+			throw new Error(`Official dashboard ${option} failed`);
+		}
+	};
+	// Warm both command paths once; each timed invocation remains a fresh CLI process.
+	await command("--help");
+	await command("--json");
+	for (let sample = 1; sample <= 3; sample += 1) {
+		const strategies = sample % 2 ? ["help-json", "json"] : ["json", "help-json"];
+		for (const strategy of strategies) {
+			const context = await browser.newContext({ ignoreHTTPSErrors: true });
+			try {
+				const page = await context.newPage();
+				let helloCount = 0;
+				let helloAt = 0;
+				let owner = false;
+				page.on("websocket", (socket) => {
+					socket.on("framereceived", ({ payload }) => {
+						const frame = JSON.parse(String(payload));
+						if (frame.payload?.type === "hello-ok") {
+							helloCount += 1;
+							helloAt = performance.now();
+							owner = frame.payload.auth.scopes.includes("operator.admin");
+						}
+					});
+				});
+				const start = performance.now();
+				const help = strategy === "help-json" ? await command("--help") : null;
+				const json = await command("--json");
+				let native: { ok?: boolean; browserUrl?: string; browserBootstrapExpiresAtMs?: number };
+				try {
+					native = JSON.parse(json.stdout);
+				} catch {
+					throw new Error("Official dashboard returned invalid JSON");
+				}
+				if (!native.ok || !native.browserUrl || !native.browserBootstrapExpiresAtMs)
+					throw new Error("Official dashboard did not issue a bootstrap handoff");
+				const fragment = new URLSearchParams(new URL(native.browserUrl).hash.slice(1));
+				expect(fragment.has("bootstrapToken")).toBe(true);
+				expect(fragment.get("bootstrapProfile")).toBe("owner");
+				const lifetime = native.browserBootstrapExpiresAtMs - Date.now();
+				expect(lifetime).toBeGreaterThan(0);
+				expect(lifetime).toBeLessThanOrEqual(600_000);
+				fragment.set("gatewayUrl", endpoint.replace("https:", "wss:").replace(/\/$/, ""));
+				const handoffAt = performance.now();
+				try {
+					await page.goto(`${endpoint}#${fragment}`);
+				} catch {
+					throw new Error("Official browser navigation failed");
+				}
+				await expect.poll(() => helloCount, { timeout: 30_000 }).toBe(1);
+				expect(owner).toBe(true);
+				console.log(
+					JSON.stringify({
+						sample,
+						strategy,
+						mode: "native_bootstrap",
+						helloCount,
+						helpMs: help ? Math.round(help.ms) : 0,
+						jsonMs: Math.round(json.ms),
+						handoffMs: Math.round(handoffAt - start),
+						browserHelloMs: Math.round(helloAt - handoffAt),
+						totalMs: Math.round(helloAt - start),
+					}),
+				);
+			} finally {
+				await context.close();
+			}
+		}
+	}
+});

--- a/apps/web/playwright.openclaw.config.ts
+++ b/apps/web/playwright.openclaw.config.ts
@@ -3,12 +3,17 @@ import hosted from "./playwright.hosted.config";
 
 export default defineConfig({
 	...hosted,
-	testMatch: "hosted-openclaw-native.pw.ts",
+	testMatch: ["hosted-openclaw-native.pw.ts", "openclaw-handoff-latency.pw.ts"],
+	workers: 1,
+	// Handoff fragments are credentials; do not persist browser traces or screenshots.
 	// Hosted APIs are stubbed in-page; only the real Vite product server is needed.
 	webServer: Array.isArray(hosted.webServer) ? hosted.webServer.slice(0, 1) : hosted.webServer,
 	use: {
 		...hosted.use,
 		ignoreHTTPSErrors: true,
+		trace: "off",
+		screenshot: "off",
+		video: "off",
 		// The isolated ingress uses a self-signed loopback certificate.
 		launchOptions: { args: ["--disable-features=LocalNetworkAccessChecks"] },
 	},

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -65,6 +65,25 @@ bun run --cwd apps/web test
 validated env module. If you bypass that Bun config, seed
 `VITE_CLERK_PUBLISHABLE_KEY` yourself.
 
+### Official OpenClaw browser verification
+
+Run `bash scripts/test-openclaw-native.sh` for the pinned official gateway and
+Control UI in a disposable 4-CPU/4-GiB Docker container. The product scenario
+checks bootstrap authentication, retained iframe/WebSocket identity across
+sections, native device reuse after revisits/reload, and explicit reconnect.
+The latency scenario alternates three pairs of `dashboard --help` plus
+`dashboard --json` versus direct JSON after one warmup per command. It records
+CLI phase durations and fresh Chromium navigation to native `hello-ok`.
+
+This measures local official CLI/browser behavior with plugins disabled; it
+does not measure a remote control plane, production ingress or customer devices.
+Hosted API responses in the product scenario are fixtures. Timing output omits
+issued credentials and URLs; browser traces, screenshots and video are disabled.
+Do not infer latency from the number of credential requests alone.
+
+Done: both native tests pass, each of the six latency samples reports one
+owner-authorized `hello-ok`, and the runner removes its container and image.
+
 ## Route admission
 
 Protected routes use Clerk request middleware and a Start server function calling


### PR DESCRIPTION
Add a reproducible real-OpenClaw CLI/browser timing scenario for https://github.com/Clawdi-AI/clawdi-hosted/pull/2198. After command warmup it alternates three help+JSON/direct-JSON pairs in one bounded container, using fresh Chromium contexts and requiring an operator.admin hello-ok in every sample. Record command, issuance and native-browser phase durations without printing issued credentials. Disable credential-bearing browser traces/screenshots/video in this dedicated fixture.

Both real native browser scenarios passed, including existing authenticated-connection and device-credential reuse. Biome and documentation links passed. No frontend product behavior changes. These are isolated local measurements with plugins disabled, not a production endpoint or customer-browser benchmark.
