### PR TITLE
fix(cli): clarify Vault skill discovery and connector routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### Changed
+
+- CLI 0.14.74 recognizes credential tasks in the Clawdi skill and reuses ready,
+  authorized integrations, including connected Composio services, without
+  requiring duplicate credentials or account migration.
+
 ### Added
 
 - CLI 0.14.73 keeps readable Vault credentials synchronized as JSON files under

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.73",
+      "version": "0.14.74",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.73",
+	"version": "0.14.74",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdi
-description: "Use Clawdi Cloud for API keys, tokens, passwords, or safely storing/providing credentials needed by a task; missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
+description: "API keys, tokens, memory, sessions, Projects, integrations. Use Clawdi Cloud when a task needs passwords or safe credential storage/provision, missing user memory or Project/Vault context, past conversations, Clawdi share URLs, or connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Do not invoke solely because a project, person, repo, or tool is named."
 ---
 
 # Clawdi Cloud

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdi
-description: "Use Clawdi Cloud for missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
+description: "Use Clawdi Cloud for API keys, tokens, passwords, or safely storing/providing credentials needed by a task; missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
 ---
 
 # Clawdi Cloud
@@ -79,6 +79,11 @@ Agent-bound keys retain their narrower bound-Project read scope. Treat not-found
 an access boundary as well as a possible unknown UUID; never bypass it with another tool.
 
 ## Vault
+
+Vault stores credentials for authorized tools and services; it is not a universal service
+alternative. Reuse ready, authorized mechanisms before requesting missing credentials. An
+already-connected, capable Composio integration does not require duplicate credentials in Vault
+or account migration. Request credentials only when the chosen task path actually needs them.
 
 Vault read tools expose metadata and exact references:
 
@@ -179,7 +184,10 @@ already exposed by the runtime, and authorized API or SDK credentials. If an ins
 authenticated official CLI can perform the task, use it directly. Check availability and
 authentication non-destructively and prefer structured output.
 
-Otherwise choose the lowest-setup reliable option for the task. Consult the service's official
+Otherwise reuse a ready, authorized direct integration when it can perform the task. If none
+is usable and Composio is already connected and capable, use it without demanding a new key,
+login, installation, or account migration merely to avoid the connector. For remaining setup
+choices, choose the lowest-setup reliable option for the task. Consult the service's official
 documentation when installation, authentication, commands, or schemas are uncertain or likely
 to have changed:
 
@@ -189,7 +197,7 @@ to have changed:
   official, and no elevation or persistent host change is required.
 - Use the official API or SDK with a verified contract and credentials already authorized for
   the runtime, including through an exact Vault reference.
-- Use the Clawdi connector when no direct option can perform the operation.
+- Use the Clawdi connector when no direct option is usable for the operation.
 
 Before a side effect, establish the exact service account and organization, Project, or tenant.
 Use connection details from Composio discovery, or explicitly list accounts with

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdi
-description: "Use Clawdi Cloud for API keys, tokens, passwords, or safely storing/providing credentials needed by a task; missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
+description: "API keys, tokens, memory, sessions, Projects, integrations. Use Clawdi Cloud when a task needs passwords or safe credential storage/provision, missing user memory or Project/Vault context, past conversations, Clawdi share URLs, or connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Do not invoke solely because a project, person, repo, or tool is named."
 ---
 
 # Clawdi Cloud

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdi
-description: "Use Clawdi Cloud for missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
+description: "Use Clawdi Cloud for API keys, tokens, passwords, or safely storing/providing credentials needed by a task; missing user memory, past sessions, Project or Vault context, Clawdi share URLs, and connected-service fallback such as Gmail, GitHub, Notion, Drive, or Calendar. Prefer an authenticated official service CLI; otherwise choose a trusted direct MCP, safely installable official CLI, official API or SDK, or the Clawdi connector as fallback. Do not invoke solely because a project, person, repo, or tool is named."
 ---
 
 # Clawdi Cloud
@@ -64,6 +64,11 @@ their narrower bound-Project read scope. Treat not-found as an access boundary a
 as a possible unknown UUID; do not bypass it through another tool.
 
 ## Vault
+
+Vault stores credentials for authorized tools and services; it is not a universal service
+alternative. Reuse ready, authorized mechanisms before requesting missing credentials. An
+already-connected, capable Composio integration does not require duplicate credentials in Vault
+or account migration. Request credentials only when the chosen task path actually needs them.
 
 - `vault_list` — List attached Vaults and key counts for visible Projects.
 - `vault_get` — List key names, provenance, and exact references for an attached Vault.
@@ -140,7 +145,10 @@ already exposed by the runtime, and authorized API or SDK credentials. If an ins
 authenticated official CLI can perform the task, use it directly. Check availability and
 authentication non-destructively and prefer structured output.
 
-Otherwise choose the lowest-setup reliable option for the task. Consult the service's official
+Otherwise reuse a ready, authorized direct integration when it can perform the task. If none
+is usable and Composio is already connected and capable, use it without demanding a new key,
+login, installation, or account migration merely to avoid the connector. For remaining setup
+choices, choose the lowest-setup reliable option for the task. Consult the service's official
 documentation when installation, authentication, commands, or schemas are uncertain or likely
 to have changed:
 
@@ -150,7 +158,7 @@ to have changed:
   official, and no elevation or persistent host change is required.
 - Use the official API or SDK with a verified contract and credentials already authorized for
   the runtime, including through an exact Vault reference.
-- Use the Clawdi connector when no direct option can perform the operation.
+- Use the Clawdi connector when no direct option is usable for the operation.
 
 Before a side effect, establish the exact service account and organization, Project, or tenant.
 Use connection details from Composio discovery, or explicitly list accounts with

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "985754bda48a5c13b3e1e5aff71a70f625d13ea6e0db56d79e346715030386f7",
+					digest: "c612838e760ba65d0f305829d55410cd9521456e802cd168b6f516a9459b5b65",
 				}),
 			],
 		]),

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "f74f31286fc1338693ae01676733e870b026d3042445e8d7f13c7884be7a134d",
+					digest: "985754bda48a5c13b3e1e5aff71a70f625d13ea6e0db56d79e346715030386f7",
 				}),
 			],
 		]),


### PR DESCRIPTION
Credential requests could miss the Clawdi skill, and connector routing could ask for a new API key even when an authorized Composio connection already handled the task. Both packaged skills now keep credentials and existing capabilities visible in compact discovery descriptions, and reuse ready integrations before requesting credentials. Vault file delivery and permission boundaries stay intact.

Publishes CLI `0.14.74` with the updated bundled skill digest, matching lockfile version and changelog. Docker validation passed: existing skill/digest tests, both skill validators, CLI typecheck/build, publish manifest and packaged skill byte checks. No API, runtime protocol, or tenant image change.
