### PR TITLE
Isolate invalid runtime drift evidence and bound summary queries

### DIFF
--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -7,7 +7,8 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, JsonValue, TypeAdapter
-from sqlalchemy import select
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import (
@@ -76,6 +77,8 @@ from app.services.runtime_observation import (
 from app.services.runtime_state_cleanup import cleanup_retired_runtime_state
 
 router = APIRouter(prefix="/v2/runtime", tags=["v2-runtime-observations"])
+
+_DRIFT_STATEMENT_TIMEOUT = "3s"
 _JSON_OBJECT_ADAPTER: TypeAdapter[dict[str, JsonValue]] = TypeAdapter(dict[str, JsonValue])
 
 IdempotencyKey = Annotated[
@@ -731,7 +734,21 @@ async def read_runtime_drift_summaries_endpoint(
     db: AsyncSession = Depends(get_runtime_observation_session),
 ) -> RuntimeDriftSummaryReadResponse:
     """Read ordered, persisted drift evidence without consuming the observation stream."""
-    return await read_runtime_drift_summaries(db, body)
+    # Two bounded SELECTs share the reserved control connection. The transaction
+    # restores this setting on exit; ordinary observation APIs keep their budget.
+    await db.execute(
+        text("SELECT set_config('statement_timeout', :timeout, true)"),
+        {"timeout": _DRIFT_STATEMENT_TIMEOUT},
+    )
+    try:
+        return await read_runtime_drift_summaries(db, body)
+    except DBAPIError as exc:
+        if getattr(exc.orig, "sqlstate", None) != "57014":
+            raise
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Runtime drift evidence is temporarily unavailable",
+        ) from None
 
 
 async def _commit_cursor_expiry_or_rollback(

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -554,7 +554,7 @@ class RuntimeDriftObservationHead(RuntimeObservationResponseModel):
 
 
 class RuntimeDriftObservationSummary(RuntimeObservationResponseModel):
-    status: Literal["missing", "fresh", "expired", "ambiguous"]
+    status: Literal["missing", "fresh", "expired", "ambiguous", "unavailable"]
     head: RuntimeDriftObservationHead | None
 
 

--- a/backend/app/services/runtime_drift_summary.py
+++ b/backend/app/services/runtime_drift_summary.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
 
+from pydantic import ValidationError
 from sqlalchemy import and_, func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
@@ -28,6 +30,8 @@ from app.schemas.runtime_observation import (
 )
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
 from app.services.runtime_source_revision import runtime_source_contract_revision
+
+logger = logging.getLogger(__name__)
 
 
 async def read_runtime_drift_summaries(
@@ -115,6 +119,7 @@ async def read_runtime_drift_summaries(
         binding_states[requested.environment_id] = binding
 
     heads: dict[UUID, RuntimeDriftObservationHead | None] = {}
+    invalid_heads: set[UUID] = set()
     if active:
         fresh = and_(
             V2RuntimeObservationHead.captured_at <= observed_at,
@@ -209,27 +214,31 @@ async def read_runtime_drift_summaries(
                 heads[row.environment_id] = None
                 continue
             # Coalescing advances head metadata, not inbox diagnostic timestamps.
-            heads[row.environment_id] = RuntimeDriftObservationHead.model_validate(
-                {
-                    "runtimeIdentity": {
-                        "generation": row.generation,
-                        "manifestETag": row.manifest_etag,
-                        "applyReceiptId": row.apply_receipt_id,
-                        "bootNonce": row.boot_nonce,
-                        "bootSessionId": row.boot_session_id,
-                    },
-                    "capturedAt": row.captured_at,
-                    "freshnessDeadline": row.freshness_deadline,
-                    "health": row.health,
-                    "diagnostics": {
-                        "activeCliVersion": row.active_cli_version,
-                        "applied": row.applied_diagnostics,
-                        "skills": row.skills,
-                        "agentPlugins": row.agent_plugins,
-                        "userActivity": row.user_activity,
-                    },
-                }
-            )
+            try:
+                heads[row.environment_id] = RuntimeDriftObservationHead.model_validate(
+                    {
+                        "runtimeIdentity": {
+                            "generation": row.generation,
+                            "manifestETag": row.manifest_etag,
+                            "applyReceiptId": row.apply_receipt_id,
+                            "bootNonce": row.boot_nonce,
+                            "bootSessionId": row.boot_session_id,
+                        },
+                        "capturedAt": row.captured_at,
+                        "freshnessDeadline": row.freshness_deadline,
+                        "health": row.health,
+                        "diagnostics": {
+                            "activeCliVersion": row.active_cli_version,
+                            "applied": row.applied_diagnostics,
+                            "skills": row.skills,
+                            "agentPlugins": row.agent_plugins,
+                            "userActivity": row.user_activity,
+                        },
+                    }
+                )
+            except ValidationError:
+                invalid_heads.add(row.environment_id)
+                logger.warning("Runtime drift head invalid environment_id=%s", row.environment_id)
 
     contract = runtime_source_contract_revision()
     items: list[RuntimeDriftSummary] = []
@@ -238,18 +247,28 @@ async def read_runtime_drift_summaries(
         row = by_environment.get(requested.environment_id)
         if binding == "active" and row is not None and row.source_deployment_id is not None:
             revision = row.source_revision if row.source_revision_contract == contract else None
-            source = RuntimeDriftSourceAuthority(
-                status="present" if revision is not None else "unavailable",
-                instanceId=row.instance_id,
-                sourceRevision=revision,
-                etag=expected_runtime_bundle_v2_etag(revision) if revision is not None else None,
-            )
+            try:
+                source = RuntimeDriftSourceAuthority(
+                    status="present" if revision is not None else "unavailable",
+                    instanceId=row.instance_id,
+                    sourceRevision=revision,
+                    etag=expected_runtime_bundle_v2_etag(revision)
+                    if revision is not None
+                    else None,
+                )
+            except ValueError:
+                logger.warning("Runtime drift source invalid environment_id=%s", row.environment_id)
+                source = RuntimeDriftSourceAuthority(
+                    status="unavailable", instanceId=None, sourceRevision=None, etag=None
+                )
         else:
             source = RuntimeDriftSourceAuthority(
                 status="missing", instanceId=None, sourceRevision=None, etag=None
             )
         head = heads.get(requested.environment_id)
-        if head is None:
+        if requested.environment_id in invalid_heads:
+            observation_status = "unavailable"
+        elif head is None:
             observation_status = "ambiguous" if requested.environment_id in heads else "missing"
         else:
             observation_status = "fresh" if head.freshness_deadline > observed_at else "expired"

--- a/backend/tests/test_runtime_drift_summary.py
+++ b/backend/tests/test_runtime_drift_summary.py
@@ -263,7 +263,8 @@ async def test_order_binding_source_and_read_only_batch(
         with pytest.raises(ValidationError):
             RuntimeDriftSourceAuthority.model_validate({**authority, **invalid})
     assert all(r["observation"] == {"status": "missing", "head": None} for r in items)
-    assert len(statements) == 2
+    assert len(statements) == 3
+    assert "set_config" in statements[0]
     assert all(query.startswith("SELECT ") and "FOR UPDATE" not in query for query in statements)
     assert all("consumer_cursors" not in query for query in statements)
 
@@ -404,3 +405,68 @@ async def test_fresh_expired_ambiguous_heads_and_coalesced_user_activity(
             RuntimeDriftObservationHead.model_validate(
                 {**head, "diagnostics": {**diagnostics, **invalid}}
             )
+
+
+@pytest.mark.parametrize("poison", ["diagnostics", "source"])
+async def test_invalid_persisted_item_keeps_healthy_sibling(
+    summary_client, runtime, db_session, poison
+):
+    bindings = [await runtime(), await runtime()]
+    environment_id = uuid.UUID(bindings[0]["environmentId"])
+
+    def corrupt_insert(mapper, connection, target):
+        if target.environment_id == environment_id:
+            target.diagnostics = {"activeCliVersion": ["invalid"]}
+
+    if poison == "diagnostics":
+        event.listen(V2RuntimeObservationInbox, "before_insert", corrupt_insert)
+    try:
+        for binding in bindings:
+            await observe(db_session, binding, datetime.now(UTC))
+    finally:
+        if poison == "diagnostics":
+            event.remove(V2RuntimeObservationInbox, "before_insert", corrupt_insert)
+    if poison == "source":
+        await db_session.execute(
+            update(HostedRuntimeState)
+            .where(HostedRuntimeState.environment_id == environment_id)
+            .values(source_revision="invalid")
+        )
+    await db_session.commit()
+    response = await summary_client.post(ENDPOINT, json={"bindings": bindings})
+    assert response.status_code == 200
+    bad, good = response.json()["items"]
+    assert [item["environmentId"] for item in (bad, good)] == [
+        item["environmentId"] for item in bindings
+    ]
+    if poison == "diagnostics":
+        assert bad["observation"] == {"status": "unavailable", "head": None}
+    else:
+        assert bad["sourceAuthority"]["status"] == "unavailable"
+        assert bad["sourceAuthority"]["sourceRevision"] is None
+    assert good["observation"]["status"] == "fresh"
+    assert good["sourceAuthority"]["status"] == "present"
+
+
+async def test_slow_drift_query_releases_snapshot_for_next_request(
+    summary_client, runtime, engine, monkeypatch
+):
+    from app.routes import runtime_observation_v2
+
+    binding = await runtime()
+    monkeypatch.setattr(runtime_observation_v2, "_DRIFT_STATEMENT_TIMEOUT", "50ms")
+
+    def stall(connection, cursor, statement, parameters, context, executemany):
+        if "FROM v2_runtime_environment_fences" in statement:
+            return "SELECT pg_sleep(1)", ()
+        return statement, parameters
+
+    event.listen(engine.sync_engine, "before_cursor_execute", stall, retval=True)
+    try:
+        response = await summary_client.post(ENDPOINT, json={"bindings": [binding]})
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", stall)
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Runtime drift evidence is temporarily unavailable"}
+    response = await summary_client.post(ENDPOINT, json={"bindings": [binding]})
+    assert response.status_code == 200

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -126,6 +126,27 @@ entries; `observedAt` is the server's freshness evaluation time. This endpoint
 never registers consumers, ACKs, resets cursors, renders sources, or repairs
 persisted revisions.
 
+Failure-isolation review (2026-09-11; draft for owner review): malformed persisted
+head evidence produces `observation: {status: "unavailable", head: null}` for that
+binding. Malformed source authority produces `sourceAuthority.status:
+"unavailable"` with no asserted instance/revision/etag. Valid siblings keep their
+ordered evidence. Unavailable is not missing or healthy, and must not itself
+trigger runtime repair. Deploy readers accepting the additive observation status
+before this writer; generated API types include it.
+
+The endpoint sets a transaction-local three-second statement timeout for its two
+bulk SELECTs. SQLSTATE 57014 returns a sanitized 503 and closes the snapshot;
+external cancellation still propagates. No persistent timeout setting is changed.
+Pool checkout and a stalled database network are separate dependencies; this
+limit is not a guarantee beyond the documented
+[database cleanup contract](backend-development.md).
+
+Done: `scripts/test.sh backend tests/test_runtime_drift_summary.py tests/test_ai_provider_connection_ownership.py`
+passes against the hermetic PostgreSQL runner, including invalid inserted JSON
+without bypassing inbox immutability, a malformed stored source revision, and
+statement cancellation followed by a successful request. This is local regression
+evidence, not live fleet health verification.
+
 Each result reports `binding` (`active`, `retired`, `missing`, or
 `binding_mismatch`). A missing fence is `missing`; a fence or available runtime
 state bound to another deployment is `binding_mismatch`. Only active matching

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -8024,7 +8024,7 @@ export interface components {
              * Status
              * @enum {string}
              */
-            status: "missing" | "fresh" | "expired" | "ambiguous";
+            status: "missing" | "fresh" | "expired" | "ambiguous" | "unavailable";
             head: components["schemas"]["RuntimeDriftObservationHead"] | null;
         };
         /** RuntimeDriftSourceAuthority */


### PR DESCRIPTION
One malformed persisted runtime head or source revision could fail the whole drift-summary batch. Return unavailable evidence only for that binding, preserving ordered healthy siblings. Bound the two summary queries with a transaction-local three-second statement timeout and return sanitized 503 on query cancellation.

Generated client types include the additive unavailable observation status. Deploy the Hosted reader first. Pool checkout and network partition cleanup remain separate limits; this does not promise to mask shared database outages.

Validation: 43 hermetic PostgreSQL tests and Ruff passed, including corrupt persisted evidence, healthy siblings, statement timeout and a successful subsequent request.
