### PR TITLE
feat(mcp): manage session shares

### DIFF
--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -49,6 +49,7 @@ from app.models.session_share import SessionShare
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
 from app.routes.memories import attach_source_machines
 from app.routes.public_sessions import resolve_session_for_view
+from app.schemas.session import SessionShareCreate
 from app.schemas.vault import VaultCreate, VaultItemDelete, VaultItemUpsert
 from app.schemas.vault_requests import VaultSecretRequestCreate
 from app.services import vault_requests
@@ -73,14 +74,19 @@ from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
     SessionContentUnavailable,
-    load_session_messages,
+    load_session_content_projection,
     session_has_uploaded_content,
 )
 from app.services.session_export import session_share_to_markdown, session_to_markdown
 from app.services.session_search import session_search_matches
 from app.services.session_shares import (
+    SessionShareConflict,
+    create_session_share,
+    list_session_share_inventory,
     load_session_share_view,
+    revoke_session_share_link,
     session_share_metadata,
+    session_share_response,
 )
 from app.services.vault import (
     VaultItemsGlobalDeleteConfirmationRequired,
@@ -211,6 +217,21 @@ class _SessionGetArguments(_ToolArguments):
         return value
 
 
+class _SessionShareCreateArguments(_ToolArguments, SessionShareCreate):
+    session_id: UUID
+
+
+class _SessionShareListArguments(_ToolArguments):
+    session_id: UUID | None = None
+    page: StrictInt = Field(default=1, ge=1, le=1_000)
+    limit: StrictInt = Field(default=25, ge=1, le=100)
+
+
+class _SessionShareRevokeArguments(_ToolArguments):
+    share_id: UUID
+    kind: Literal["snapshot", "live"] = "snapshot"
+
+
 class _ProjectListArguments(_ToolArguments):
     limit: StrictInt = Field(default=50, ge=1, le=100)
 
@@ -338,13 +359,17 @@ class _NativeToolSpec:
     input_schema: object
     scopes: tuple[str, ...]
     handler: _NativeToolHandler
+    annotations: JsonObject | None = None
 
     def definition(self, name: str) -> JsonObject:
-        return {
+        definition: JsonObject = {
             "name": name,
             "description": self.description,
             "inputSchema": _JSON_OBJECT_ADAPTER.validate_python(self.input_schema),
         }
+        if self.annotations is not None:
+            definition["annotations"] = self.annotations
+        return definition
 
 
 _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
@@ -526,7 +551,8 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
             "(https://cloud.clawdi.ai/s/{uuid}) or one of their own sessions by UUID. Handles "
             "owned + shared sessions uniformly — you don't need to know which one. Returns a "
             "YAML front-matter block (source/agent/model/project/messages) followed by "
-            "`## User` / `## Assistant` turn headings."
+            "`## User` / `## Assistant` turn headings. Owned sessions include each message's "
+            "stable position for session_share_create scope=through or scope=response."
         ),
         input_schema={
             "type": "object",
@@ -544,6 +570,59 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
         },
         scopes=("sessions:read",),
         handler=lambda arguments, auth, db: _tool_session_get(arguments, auth=auth, db=db),
+    ),
+    "session_share_create": _NativeToolSpec(
+        description=(
+            "Publish an immutable public snapshot of one visible Clawdi session. Call only "
+            "when the user explicitly asks to share or publish the session. By default shares "
+            "the full visible conversation; scope=through freezes the conversation through one "
+            "message position, and scope=response shares one Assistant response. Public shares "
+            "contain only the existing safe user/Assistant projection, never reasoning, system "
+            "messages, hidden events, or tool activity."
+        ),
+        input_schema=_SessionShareCreateArguments.model_json_schema(),
+        scopes=("sessions:read", "sessions:write"),
+        handler=lambda arguments, auth, db: _tool_session_share_create(arguments, auth=auth, db=db),
+        annotations={
+            "title": "Share Session",
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        },
+    ),
+    "session_share_list": _NativeToolSpec(
+        description=(
+            "List active snapshot and legacy live links for visible Clawdi sessions. Optionally "
+            "filter by session UUID. Returns exact link IDs and kinds for session_share_revoke."
+        ),
+        input_schema=_SessionShareListArguments.model_json_schema(),
+        scopes=("sessions:read",),
+        handler=lambda arguments, auth, db: _tool_session_share_list(arguments, auth=auth, db=db),
+        annotations={
+            "title": "List Session shares",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    ),
+    "session_share_revoke": _NativeToolSpec(
+        description=(
+            "Turn off one exact Session share link. Call only when the user explicitly asks to "
+            "stop sharing it. Use the share_id and kind returned by session_share_list; existing "
+            "Session content remains unchanged."
+        ),
+        input_schema=_SessionShareRevokeArguments.model_json_schema(),
+        scopes=("sessions:read", "sessions:write"),
+        handler=lambda arguments, auth, db: _tool_session_share_revoke(arguments, auth=auth, db=db),
+        annotations={
+            "title": "Stop sharing Session",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
     ),
     "project_current_get": _NativeToolSpec(
         description=(
@@ -999,6 +1078,13 @@ async def _tool_memory_delete(
     return _tool_json({"status": "deleted", "memory_id": parsed.memory_id})
 
 
+def _session_environment_fence(auth: AuthContext) -> UUID | None:
+    key = auth.api_key
+    if is_env_bound_api_key(auth) and not is_runtime_deployment_principal(auth) and key:
+        return key.environment_id
+    return None
+
+
 def _user_sessions_stmt(auth: AuthContext):
     """Return account sessions, fencing only legacy environment keys.
 
@@ -1011,11 +1097,7 @@ def _user_sessions_stmt(auth: AuthContext):
         .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
         .where(Session.user_id == auth.user_id)
     )
-    bound_env = (
-        auth.api_key.environment_id
-        if is_env_bound_api_key(auth) and not is_runtime_deployment_principal(auth) and auth.api_key
-        else None
-    )
+    bound_env = _session_environment_fence(auth)
     if bound_env is not None:
         stmt = stmt.where(Session.environment_id == bound_env)
     return stmt
@@ -1029,7 +1111,7 @@ async def _tool_session_search(
     stmt = (
         _user_sessions_stmt(auth)
         .join(matches, matches.c.session_id == Session.id)
-        .add_columns(matches.c.content, matches.c.role)
+        .add_columns(matches.c.content, matches.c.role, matches.c.position)
         .order_by(matches.c.score.desc(), Session.last_activity_at.desc(), Session.id.asc())
         .limit(parsed.limit)
     )
@@ -1037,15 +1119,21 @@ async def _tool_session_search(
     if not rows:
         return _tool_text(f'No sessions matched "{parsed.query}".')
     lines: list[str] = []
-    for session, agent_type, message_content, message_role in rows:
+    for session, agent_type, message_content, message_role, message_position in rows:
         date = session.last_activity_at.date().isoformat() if session.last_activity_at else "-"
         summary = session.summary or session.local_session_id or "(untitled)"
         project = f" · {session.project_path}" if session.project_path else ""
         model = f" · {session.model}" if session.model else ""
         message_match = ""
-        if isinstance(message_content, str) and message_role in ("user", "assistant"):
+        if (
+            isinstance(message_content, str)
+            and message_role in ("user", "assistant")
+            and isinstance(message_position, int)
+        ):
             excerpt = search_excerpt(message_content, parsed.query)
-            message_match = f"\n  - matched {message_role}: {excerpt}"
+            message_match = (
+                f"\n  - matched {message_role} at position {message_position}: {excerpt}"
+            )
         lines.append(
             f"- **{summary}**{project}{model}\n"
             f"  - id: `{session.id}` · {agent_type or 'unknown'} · {date} · "
@@ -1169,7 +1257,7 @@ async def _tool_session_get(
     if not session_has_uploaded_content(session):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content not uploaded")
     try:
-        messages = await load_session_messages(session, file_store, db)
+        projection = await load_session_content_projection(session, file_store, db)
     except SessionContentMissing:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content file not found") from None
     except SessionContentUnavailable:
@@ -1182,8 +1270,83 @@ async def _tool_session_get(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
     return _tool_text(
-        session_to_markdown(session, messages, agent_type=agent_type, public=bool(match))
+        session_to_markdown(
+            session,
+            projection.messages,
+            agent_type=agent_type,
+            public=bool(match),
+            source_positions=None if match else projection.source_positions,
+        )
     )
+
+
+async def _tool_session_share_create(
+    arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
+) -> JsonObject:
+    parsed = _validate_arguments(_SessionShareCreateArguments, arguments)
+    row = (
+        await db.execute(_user_sessions_stmt(auth).where(Session.id == parsed.session_id))
+    ).first()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    session, agent_type = row
+    if not session_has_uploaded_content(session):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content not uploaded")
+    try:
+        share = await create_session_share(
+            db,
+            file_store,
+            session,
+            created_by=auth.user_id,
+            agent_type=agent_type,
+            scope=parsed.scope,
+            position=parsed.position,
+        )
+    except SessionShareConflict as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from None
+    except SessionContentMissing:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content not found") from None
+    except SessionContentUnavailable:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Session storage is temporarily unavailable. Please retry.",
+        ) from None
+    except SessionContentInvalid:
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
+        ) from None
+    return _tool_json(session_share_response(share).model_dump(mode="json"))
+
+
+async def _tool_session_share_list(
+    arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
+) -> JsonObject:
+    parsed = _validate_arguments(_SessionShareListArguments, arguments)
+    inventory = await list_session_share_inventory(
+        db,
+        user_id=auth.user_id,
+        page=parsed.page,
+        page_size=parsed.limit,
+        session_id=parsed.session_id,
+        environment_id=_session_environment_fence(auth),
+    )
+    return _tool_json(inventory.model_dump(mode="json"))
+
+
+async def _tool_session_share_revoke(
+    arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
+) -> JsonObject:
+    parsed = _validate_arguments(_SessionShareRevokeArguments, arguments)
+    revoked = await revoke_session_share_link(
+        db,
+        user_id=auth.user_id,
+        share_id=parsed.share_id,
+        kind=parsed.kind,
+        environment_id=_session_environment_fence(auth),
+    )
+    if not revoked:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session share not found")
+    return _tool_json({"status": "revoked", "share_id": str(parsed.share_id), "kind": parsed.kind})
 
 
 def _project_payload(project: Project) -> JsonObject:

--- a/backend/app/routes/session_shares.py
+++ b/backend/app/routes/session_shares.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
-from sqlalchemy import func, literal, or_, select, union_all
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_user_auth_unbound
-from app.core.config import settings
 from app.core.database import get_session
 from app.models.session import AgentEnvironment, Session
-from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
 from app.models.session_share import SessionShare
 from app.schemas.common import Paginated
 from app.schemas.session import (
@@ -38,8 +35,11 @@ from app.services.session_shares import (
     SessionShareConflict,
     SessionShareView,
     create_session_share,
+    list_session_share_inventory,
     load_session_share_view,
+    revoke_session_share_link,
     session_share_metadata,
+    session_share_response,
     session_share_url,
 )
 
@@ -67,20 +67,6 @@ async def _owned_session(
     return session, agent_type
 
 
-def _share_response(share: SessionShare) -> SessionShareResponse:
-    _, _, _, _, message_count = session_share_metadata(share)
-    return SessionShareResponse(
-        id=str(share.id),
-        session_id=str(share.session_id),
-        scope=share.scope,
-        start_position=share.start_position,
-        end_position=share.end_position,
-        message_count=message_count,
-        share_url=session_share_url(share.id),
-        created_at=share.created_at,
-    )
-
-
 @router.get("/session-shares")
 async def list_all_session_shares(
     page: int = Query(default=1, ge=1),
@@ -90,79 +76,14 @@ async def list_all_session_shares(
     db: AsyncSession = Depends(get_session),
 ) -> Paginated[SessionShareListItemResponse]:
     """List every active Session link owned by the signed-in user."""
-    snapshot_rows = (
-        select(
-            SessionShare.id.label("id"),
-            literal("snapshot").label("kind"),
-            Session.id.label("session_id"),
-            Session.summary.label("session_summary"),
-            Session.local_session_id.label("local_session_id"),
-            SessionShare.scope.label("scope"),
-            SessionShare.public_metadata["message_count"].as_integer().label("message_count"),
-            SessionShare.created_at.label("created_at"),
-        )
-        .join(Session, Session.id == SessionShare.session_id)
-        .where(Session.user_id == auth.user_id, SessionShare.revoked_at.is_(None))
-    )
-    live_rows = (
-        select(
-            SessionPermission.id.label("id"),
-            literal("live").label("kind"),
-            Session.id.label("session_id"),
-            Session.summary.label("session_summary"),
-            Session.local_session_id.label("local_session_id"),
-            literal("session").label("scope"),
-            Session.message_count.label("message_count"),
-            SessionPermission.created_at.label("created_at"),
-        )
-        .join(Session, Session.id == SessionPermission.session_id)
-        .where(
-            Session.user_id == auth.user_id,
-            SessionPermission.kind == PERMISSION_KIND_LINK,
-            SessionPermission.revoked_at.is_(None),
-            or_(
-                SessionPermission.expires_at.is_(None),
-                SessionPermission.expires_at > func.now(),
-            ),
-        )
-    )
-    if session_id is not None:
-        snapshot_rows = snapshot_rows.where(Session.id == session_id)
-        live_rows = live_rows.where(Session.id == session_id)
-    active_links = union_all(snapshot_rows, live_rows).subquery()
-    total = int((await db.execute(select(func.count()).select_from(active_links))).scalar_one())
-    rows = (
-        await db.execute(
-            select(active_links)
-            .order_by(active_links.c.created_at.desc(), active_links.c.id.desc())
-            .limit(page_size)
-            .offset((page - 1) * page_size)
-        )
-    ).all()
-    items = [
-        SessionShareListItemResponse(
-            id=str(row.id),
-            kind=row.kind,
-            session_id=str(row.session_id),
-            session_title=(row.session_summary or "").strip()
-            or f"Session {row.local_session_id[:8]}",
-            scope=row.scope,
-            message_count=row.message_count,
-            share_url=(
-                session_share_url(row.id)
-                if row.kind == "snapshot"
-                else f"{settings.web_origin}/s/{row.session_id}"
-            ),
-            created_at=row.created_at,
-        )
-        for row in rows
-    ]
-    return Paginated[SessionShareListItemResponse](
-        items=items,
-        total=total,
+    inventory = await list_session_share_inventory(
+        db,
+        user_id=auth.user_id,
         page=page,
         page_size=page_size,
+        session_id=session_id,
     )
+    return inventory
 
 
 @router.get("/sessions/{session_id}/shares")
@@ -184,7 +105,7 @@ async def list_session_shares(
             )
         ).scalars()
     )
-    return SessionSharesResponse(shares=[_share_response(share) for share in shares])
+    return SessionSharesResponse(shares=[session_share_response(share) for share in shares])
 
 
 @router.post("/sessions/{session_id}/shares", status_code=status.HTTP_201_CREATED)
@@ -220,7 +141,7 @@ async def create_share(
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
-    return _share_response(share)
+    return session_share_response(share)
 
 
 @router.delete("/session-shares/{share_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -231,38 +152,14 @@ async def revoke_share(
     db: AsyncSession = Depends(get_session),
 ) -> None:
     """Revoke one owned snapshot or legacy live link by its exact inventory ID."""
-    if kind == "live":
-        permission = (
-            await db.execute(
-                select(SessionPermission)
-                .join(Session, Session.id == SessionPermission.session_id)
-                .where(
-                    SessionPermission.id == share_id,
-                    SessionPermission.kind == PERMISSION_KIND_LINK,
-                    Session.user_id == auth.user_id,
-                )
-                .with_for_update(of=SessionPermission)
-            )
-        ).scalar_one_or_none()
-        if permission is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "Session share not found")
-        if permission.revoked_at is None:
-            permission.revoked_at = datetime.now(UTC)
-            await db.commit()
-        return
-    share = (
-        await db.execute(
-            select(SessionShare)
-            .join(Session, Session.id == SessionShare.session_id)
-            .where(SessionShare.id == share_id, Session.user_id == auth.user_id)
-            .with_for_update(of=SessionShare)
-        )
-    ).scalar_one_or_none()
-    if share is None:
+    revoked = await revoke_session_share_link(
+        db,
+        user_id=auth.user_id,
+        share_id=share_id,
+        kind=kind,
+    )
+    if not revoked:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session share not found")
-    if share.revoked_at is None:
-        share.revoked_at = datetime.now(UTC)
-        await db.commit()
 
 
 async def _public_share(db: AsyncSession, share_id: UUID) -> SessionShare:

--- a/backend/app/services/session_export.py
+++ b/backend/app/services/session_export.py
@@ -3,9 +3,9 @@
 Same output regardless of whether the caller is the OWNER fetching
 their own session via `GET /v1/sessions/{id}/export.md` or a PUBLIC
 visitor hitting `GET /v1/public/sessions/{token}/export.md`.
-Sharing the serializer keeps the agent-facing `.md` body byte-for-byte
-identical across both paths, which is what `session_get` MCP tool
-relies on to give the same agent context regardless of access mode.
+Sharing the serializer keeps the public and owner export formats aligned.
+The `session_get` MCP tool may additionally annotate owner-only message
+headings with stable source positions for scoped sharing.
 
 The Markdown body opens with a YAML front-matter block. That's the
 signal to an LLM (or an MCP wrapper) that this isn't a random web
@@ -49,9 +49,16 @@ def _build_session_share_url(share_id: UUID) -> str:
     return f"{settings.web_origin}/s/{share_id}"
 
 
-def _message_body_lines(messages: Sequence[JsonValue]) -> list[str]:
+def _message_body_lines(
+    messages: Sequence[JsonValue],
+    *,
+    source_positions: Sequence[int] | None = None,
+) -> list[str]:
+    if source_positions is not None and len(source_positions) != len(messages):
+        raise ValueError("message positions must align with messages")
+
     body_lines: list[str] = []
-    for message in messages:
+    for index, message in enumerate(messages):
         if not isinstance(message, dict):
             continue
         role_value = message.get("role")
@@ -66,6 +73,8 @@ def _message_body_lines(messages: Sequence[JsonValue]) -> list[str]:
         heading_parts: list[str] = [f"## {role.capitalize()}"]
         if role == "assistant" and model:
             heading_parts.append(f"({model})")
+        if source_positions is not None:
+            heading_parts.append(f"· position {source_positions[index]}")
         if timestamp:
             heading_parts.append(f"· {timestamp}")
         body_lines.extend((" ".join(heading_parts), ""))
@@ -171,13 +180,15 @@ def session_to_markdown(
     *,
     agent_type: str | None = None,
     public: bool = False,
+    source_positions: Sequence[int] | None = None,
 ) -> str:
     """Serialize one session to Markdown with a YAML front-matter header.
 
     The header carries provenance + summary fields an agent can use to
     decide whether to ingest the body (agent type, model, project, turn
-    counts). The body renders each message as `## <Role> · <timestamp>`
-    followed by the message content as-is.
+    counts). The body renders each message as a role heading followed by
+    the message content as-is. Callers may include stable source positions
+    in those headings when the reader needs to address an exact message.
 
     Plain Markdown — no HTML, no shadcn wrappers — so `WebFetch` returns
     clean readable text and an MCP `session_get` call yields tokens an
@@ -228,7 +239,11 @@ def session_to_markdown(
 
     # Content stays raw: adapters already normalized it and many messages
     # contain Markdown fences that must not be nested inside another fence.
-    return "\n".join(front_matter_lines + body_lines + _message_body_lines(messages))
+    return "\n".join(
+        front_matter_lines
+        + body_lines
+        + _message_body_lines(messages, source_positions=source_positions)
+    )
 
 
 def session_to_json(

--- a/backend/app/services/session_shares.py
+++ b/backend/app/services/session_shares.py
@@ -8,12 +8,15 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import select
+from sqlalchemy import func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.session import Session
+from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
 from app.models.session_share import SessionShare
+from app.schemas.common import Paginated
+from app.schemas.session import SessionShareListItemResponse, SessionShareResponse
 from app.services.file_store import FileStore
 from app.services.session_content import (
     SessionContentInvalid,
@@ -26,6 +29,7 @@ from app.services.session_content import (
 )
 
 SessionShareScope = Literal["session", "through", "response"]
+SessionShareKind = Literal["snapshot", "live"]
 log = logging.getLogger(__name__)
 
 
@@ -54,6 +58,149 @@ def session_share_snapshot_key(session: Session) -> str:
     if not session.content_hash:
         raise SessionContentMissing("session snapshot has no content hash")
     return f"session-share-sources/{session.user_id}/{session.id}/{session.content_hash}.json"
+
+
+def session_share_response(share: SessionShare) -> SessionShareResponse:
+    _, _, _, _, message_count = session_share_metadata(share)
+    return SessionShareResponse(
+        id=str(share.id),
+        session_id=str(share.session_id),
+        scope=share.scope,
+        start_position=share.start_position,
+        end_position=share.end_position,
+        message_count=message_count,
+        share_url=session_share_url(share.id),
+        created_at=share.created_at,
+    )
+
+
+async def list_session_share_inventory(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    page: int,
+    page_size: int,
+    session_id: UUID | None = None,
+    environment_id: UUID | None = None,
+) -> Paginated[SessionShareListItemResponse]:
+    """List active snapshot and legacy live links inside one visibility fence."""
+    snapshot_rows = (
+        select(
+            SessionShare.id.label("id"),
+            literal("snapshot").label("kind"),
+            Session.id.label("session_id"),
+            Session.summary.label("session_summary"),
+            Session.local_session_id.label("local_session_id"),
+            SessionShare.scope.label("scope"),
+            SessionShare.public_metadata["message_count"].as_integer().label("message_count"),
+            SessionShare.created_at.label("created_at"),
+        )
+        .join(Session, Session.id == SessionShare.session_id)
+        .where(Session.user_id == user_id, SessionShare.revoked_at.is_(None))
+    )
+    live_rows = (
+        select(
+            SessionPermission.id.label("id"),
+            literal("live").label("kind"),
+            Session.id.label("session_id"),
+            Session.summary.label("session_summary"),
+            Session.local_session_id.label("local_session_id"),
+            literal("session").label("scope"),
+            Session.message_count.label("message_count"),
+            SessionPermission.created_at.label("created_at"),
+        )
+        .join(Session, Session.id == SessionPermission.session_id)
+        .where(
+            Session.user_id == user_id,
+            SessionPermission.kind == PERMISSION_KIND_LINK,
+            SessionPermission.revoked_at.is_(None),
+            or_(
+                SessionPermission.expires_at.is_(None),
+                SessionPermission.expires_at > func.now(),
+            ),
+        )
+    )
+    if session_id is not None:
+        snapshot_rows = snapshot_rows.where(Session.id == session_id)
+        live_rows = live_rows.where(Session.id == session_id)
+    if environment_id is not None:
+        snapshot_rows = snapshot_rows.where(Session.environment_id == environment_id)
+        live_rows = live_rows.where(Session.environment_id == environment_id)
+
+    active_links = union_all(snapshot_rows, live_rows).subquery()
+    total = int((await db.execute(select(func.count()).select_from(active_links))).scalar_one())
+    rows = (
+        await db.execute(
+            select(active_links)
+            .order_by(active_links.c.created_at.desc(), active_links.c.id.desc())
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+    ).all()
+    return Paginated[SessionShareListItemResponse](
+        items=[
+            SessionShareListItemResponse(
+                id=str(row.id),
+                kind=row.kind,
+                session_id=str(row.session_id),
+                session_title=(row.session_summary or "").strip()
+                or f"Session {row.local_session_id[:8]}",
+                scope=row.scope,
+                message_count=row.message_count,
+                share_url=(
+                    session_share_url(row.id)
+                    if row.kind == "snapshot"
+                    else f"{settings.web_origin}/s/{row.session_id}"
+                ),
+                created_at=row.created_at,
+            )
+            for row in rows
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+async def revoke_session_share_link(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    share_id: UUID,
+    kind: SessionShareKind,
+    environment_id: UUID | None = None,
+) -> bool:
+    """Revoke one exact link; return False when it is outside the visibility fence."""
+    if kind == "live":
+        stmt = (
+            select(SessionPermission)
+            .join(Session, Session.id == SessionPermission.session_id)
+            .where(
+                SessionPermission.id == share_id,
+                SessionPermission.kind == PERMISSION_KIND_LINK,
+                Session.user_id == user_id,
+            )
+            .with_for_update(of=SessionPermission)
+        )
+        if environment_id is not None:
+            stmt = stmt.where(Session.environment_id == environment_id)
+        link = (await db.execute(stmt)).scalar_one_or_none()
+    else:
+        stmt = (
+            select(SessionShare)
+            .join(Session, Session.id == SessionShare.session_id)
+            .where(SessionShare.id == share_id, Session.user_id == user_id)
+            .with_for_update(of=SessionShare)
+        )
+        if environment_id is not None:
+            stmt = stmt.where(Session.environment_id == environment_id)
+        link = (await db.execute(stmt)).scalar_one_or_none()
+    if link is None:
+        return False
+    if link.revoked_at is None:
+        link.revoked_at = datetime.now(UTC)
+        await db.commit()
+    return True
 
 
 def _scope_selection(

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -392,7 +392,82 @@ async def test_clawdi_mcp_initializes_and_lists_native_tools(monkeypatch):
         "memory_extract",
         "session_search",
         "session_get",
+        "session_share_create",
+        "session_share_list",
+        "session_share_revoke",
     } <= names
+    tools = {tool["name"]: tool for tool in listed.json()["result"]["tools"]}
+    assert tools["session_share_create"]["annotations"] == {
+        "title": "Share Session",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    }
+    assert tools["session_share_revoke"]["annotations"]["destructiveHint"] is True
+
+
+@pytest.mark.asyncio
+async def test_clawdi_mcp_manages_session_share_lifecycle(client: httpx.AsyncClient):
+    from tests.test_session_shares import _seed_session
+
+    session_id, _, _ = await _seed_session(client)
+
+    async def call(tool: str, arguments: dict[str, object], request_id: int) -> dict:
+        response = await client.post(
+            "/v1/mcp/clawdi",
+            json={
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            },
+        )
+        assert response.status_code == 200, response.text
+        return response.json()["result"]
+
+    owned = await call("session_get", {"reference": session_id}, 1)
+    assert "## User · position 0" in owned["content"][0]["text"]
+    assert "## Assistant (test-model) · position 1" in owned["content"][0]["text"]
+
+    created = await call(
+        "session_share_create",
+        {"session_id": session_id, "scope": "response", "position": 1},
+        2,
+    )
+    created_payload = json.loads(created["content"][0]["text"])
+    assert created_payload["scope"] == "response"
+    assert created_payload["message_count"] == 1
+
+    shared = await call("session_get", {"reference": created_payload["share_url"]}, 3)
+    shared_markdown = shared["content"][0]["text"]
+    assert "Original answer" in shared_markdown
+    assert "Original question" not in shared_markdown
+    assert "· position" not in shared_markdown
+
+    listed = await call("session_share_list", {"session_id": session_id}, 4)
+    listed_payload = json.loads(listed["content"][0]["text"])
+    assert listed_payload["total"] == 1
+    assert listed_payload["items"][0] == {
+        "id": created_payload["id"],
+        "kind": "snapshot",
+        "session_id": session_id,
+        "session_title": "Immutable share",
+        "scope": "response",
+        "message_count": 1,
+        "share_url": created_payload["share_url"],
+        "created_at": created_payload["created_at"],
+    }
+
+    revoked = await call(
+        "session_share_revoke",
+        {"share_id": created_payload["id"], "kind": "snapshot"},
+        5,
+    )
+    assert json.loads(revoked["content"][0]["text"])["status"] == "revoked"
+    unavailable = await call("session_get", {"reference": created_payload["share_url"]}, 6)
+    assert unavailable["isError"] is True
+    assert "revoked" in unavailable["content"][0]["text"]
 
 
 @pytest.mark.asyncio
@@ -750,14 +825,16 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
     assert body_response.status_code == 200, body_response.text
     body_text = body_response.json()["result"]["content"][0]["text"]
     assert "Unrelated title" in body_text
-    assert "matched assistant: The visible body contains a deployment handoff phrase." in body_text
+    assert (
+        "matched assistant at position 0: The visible body contains a deployment handoff phrase."
+    ) in body_text
 
     assert reordered_response.status_code == 200, reordered_response.text
     reordered_text = reordered_response.json()["result"]["content"][0]["text"]
     assert "Unrelated title" in reordered_text
-    assert "matched assistant: The visible body contains a deployment handoff phrase." in (
-        reordered_text
-    )
+    assert (
+        "matched assistant at position 0: The visible body contains a deployment handoff phrase."
+    ) in reordered_text
 
     assert typo_response.status_code == 200, typo_response.text
     assert (
@@ -1339,6 +1416,9 @@ async def test_clawdi_mcp_connector_tools_follow_scoped_key_permissions(
     tool_names = [tool["name"] for tool in listed.json()["result"]["tools"]]
     assert "COMPOSIO_DANGEROUS" not in tool_names
     assert "memory_search" not in tool_names
+    assert "session_share_list" in tool_names
+    assert "session_share_create" not in tool_names
+    assert "session_share_revoke" not in tool_names
 
     assert called.status_code == 200, called.text
     result = called.json()["result"]
@@ -1542,6 +1622,7 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
     assert "connector_calendar" in names
     assert "session_search" in names
     assert "session_get" in names
+    assert {"session_share_create", "session_share_list", "session_share_revoke"} <= set(names)
     assert {"memory_search", "memory_create", "memory_extract"} <= set(names)
     search_text = searched.json()["result"]["content"][0]["text"]
     assert "Alpha hosted runtime work" in search_text
@@ -1551,6 +1632,14 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
     assert memory.json()["result"]["content"][0]["text"] == "No memories found."
     identity_only_names = {tool["name"] for tool in identity_only_listed.json()["result"]["tools"]}
     assert "session_search" not in identity_only_names
+    assert (
+        not {
+            "session_share_create",
+            "session_share_list",
+            "session_share_revoke",
+        }
+        & identity_only_names
+    )
     assert "connector_calendar" not in identity_only_names
     assert not {"memory_search", "memory_create", "memory_extract"} & identity_only_names
     assert (


### PR DESCRIPTION
## Summary

- add native `session_share_create`, `session_share_list`, and `session_share_revoke` MCP tools
- reuse the existing immutable Session share service, public-safe projection, inventory, and revocation paths
- expose stable owner-only message positions through `session_get` and Session search matches so scoped shares are addressable
- preserve legacy environment fences and strict Hosted cross-Agent Session visibility
- publish standard MCP tool annotations and scope-gate read/write operations

## Design

- no new tables, share protocol, or action multiplexer
- REST and MCP share responses use the same Pydantic schemas and service functions
- public shares continue to omit reasoning, system/developer messages, hidden events, and tool activity
- tool descriptions require explicit user intent before publishing or revoking

## Verification

- `uv run --project backend ruff format ...`
- `uv run --project backend ruff check ...`
- `uv run basedpyright app/routes/mcp_bridge.py app/routes/session_shares.py app/services/session_export.py app/services/session_shares.py`
- `git diff --check origin/main..HEAD`
- isolated PostgreSQL/Docker: `tests/test_settings_and_mcp.py tests/test_session_shares.py tests/test_public_sessions.py tests/test_cli_oauth_auth.py -q`
