### PR TITLE
Prepare protected native OpenClaw browser recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.75 teaches Connected and Hosted agents to create, list, and revoke
+  Session shares through MCP. Connected agents retain the CLI fallback; Hosted
+  agents use MCP only.
 - CLI 0.14.74 recognizes credential tasks in the Clawdi skill and reuses ready,
   authorized integrations, including connected Composio services, without
   requiring duplicate credentials or account migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,18 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### Fixed
+
+- CLI 0.14.76 gives managed OpenClaw MCP discovery and slow tool calls an
+  explicit timeout budget so tools remain available when discovery takes longer
+  than OpenClaw’s default 1.5 seconds.
+
 ### Changed
 
+- Request new credentials and updates to existing keys through the same Vault link.
+  Existing Vault values are kept until saving; intervening changes reject the whole batch.
+  Local delivery checks the content version so existing key names cannot mask stale values.
+  This update expires existing pending request links; saved credentials are preserved.
 - CLI 0.14.75 teaches Connected and Hosted agents to create, list, and revoke
   Session shares through MCP. Connected agents retain the CLI fallback; Hosted
   agents use MCP only.

--- a/apps/web/e2e/auth/clerk-fixture.ts
+++ b/apps/web/e2e/auth/clerk-fixture.ts
@@ -56,6 +56,16 @@ let state = initial;
 const resources = new Set<() => void>();
 const statuses = new Set<() => void>();
 export let signOutCalls = 0;
+const heldTokens = new Map<string, ReturnType<typeof Promise.withResolvers<void>>>();
+export let heldTokenCalls = 0;
+export function holdSessionToken(sessionId: string) {
+	heldTokens.set(sessionId, Promise.withResolvers<void>());
+}
+export function releaseSessionToken(sessionId: string) {
+	const held = heldTokens.get(sessionId);
+	heldTokens.delete(sessionId);
+	held?.resolve();
+}
 
 export function emitSdk(update: Partial<SdkState>) {
 	state = { ...state, ...update };
@@ -119,6 +129,11 @@ export function useSession() {
 			id: sessionId,
 			user: { id: auth.userId },
 			getToken: async () => {
+				const held = heldTokens.get(sessionId);
+				if (held) {
+					heldTokenCalls += 1;
+					await held.promise;
+				}
 				if (state.tokenFailure) throw new TypeError("Token refresh unavailable");
 				return state.nullToken ? null : token;
 			},

--- a/apps/web/e2e/auth/lifecycle.browser.tsx
+++ b/apps/web/e2e/auth/lifecycle.browser.tsx
@@ -24,7 +24,10 @@ import SharePage from "@/pages/share/project-share-page";
 import {
 	activateSession,
 	emitSdk,
+	heldTokenCalls,
+	holdSessionToken,
 	releaseActivation,
+	releaseSessionToken,
 	serverAuth,
 	signOutCalls,
 } from "./clerk-fixture";
@@ -214,6 +217,11 @@ window.authTest = {
 	},
 	emitSdk,
 	activateSession,
+	holdSessionToken,
+	releaseSessionToken,
+	get heldTokenCalls() {
+		return heldTokenCalls;
+	},
 	releaseActivation,
 	commits,
 	navigate: (to) => router.navigate({ to }),
@@ -259,6 +267,9 @@ declare global {
 		authTest: {
 			admissions: number;
 			emitSdk: typeof emitSdk;
+			holdSessionToken: typeof holdSessionToken;
+			releaseSessionToken: typeof releaseSessionToken;
+			heldTokenCalls: number;
 			activateSession: typeof activateSession;
 			releaseActivation: typeof releaseActivation;
 			commits: typeof commits;

--- a/apps/web/e2e/auth/lifecycle.pw.ts
+++ b/apps/web/e2e/auth/lifecycle.pw.ts
@@ -1,6 +1,125 @@
 import { expect, type Page, test } from "@playwright/test";
 import type {} from "./lifecycle.browser";
 
+for (const phase of ["getToken", "POST", "HEAD"] as const) {
+	test(`OpenClaw grant retires ${phase} work when the owner changes`, async ({ page, context }) => {
+		test.skip(process.env.VITE_CLAWDI_HOSTED !== "true", "Hosted agent lifecycle");
+		const { includedBasicDeployment, mutationDeploymentReadFixture, stubHostedApi } = await import(
+			"../hosted-stub-api"
+		);
+		const endpoint = "https://runtime.example/";
+		const deployment = mutationDeploymentReadFixture({
+			...includedBasicDeployment,
+			config_info: { ...includedBasicDeployment.config_info, runtime: "openclaw" },
+			openclaw_control_ui_url: endpoint,
+		});
+		if (deployment.runtime_ui_endpoint?.runtime !== "openclaw")
+			throw new Error("Runtime endpoint missing");
+		deployment.runtime_ui_endpoint.browser_session_url = `${endpoint}.well-known/openclaw/browser-session`;
+		await stubHostedApi(page, { deployments: [deployment] });
+		const held = Promise.withResolvers<void>();
+		let holding = false;
+		let pending = false;
+		let aborted = false;
+		let issued = 0;
+		const posts: string[] = [];
+		page.on("requestfailed", (request) => {
+			if (request.url().endsWith("browser-session") && request.method() === phase) aborted = true;
+		});
+		await page.route(
+			"http://127.0.0.1:50021/v2/deployments/*/runtime-ui/credentials",
+			async (route) => {
+				issued += 1;
+				await route.fulfill({
+					json: {
+						runtime: "openclaw",
+						auth_mode: "openclaw_token",
+						url: endpoint,
+						deployment_resource_version: deployment.resource.metadata.resourceVersion,
+						token: "fixture-token",
+						handoff_url: `${endpoint}#bootstrapToken=attempt-${issued}&bootstrapProfile=owner`,
+					},
+				});
+			},
+		);
+		await context.route(`${endpoint}**`, async (route) => {
+			const method = route.request().method();
+			if (route.request().url().endsWith("browser-session")) {
+				if (method === "POST") posts.push(route.request().headers().authorization ?? "missing");
+				if (holding && method === phase && !pending) {
+					pending = true;
+					await held.promise;
+				}
+				if (route.request().failure()) return;
+				await route.fulfill({
+					status: 204,
+					headers: {
+						"Access-Control-Allow-Origin": "http://127.0.0.1:3111",
+						"Access-Control-Allow-Credentials": "true",
+						"Access-Control-Allow-Headers": "Authorization, If-Match",
+						"Access-Control-Allow-Methods": "POST, HEAD, OPTIONS",
+					},
+					body: "",
+				});
+			} else {
+				// Document-only lifecycle fixture; native auth is verified by the paired gateway suite.
+				await route.fulfill({
+					contentType: "text/html",
+					body: "<!doctype html><p>Lifecycle document</p>",
+				});
+			}
+		});
+		try {
+			await page.goto("/e2e/auth/");
+			await page.evaluate(
+				(id) => window.authTest.navigate(`/agents/${id}/console`),
+				deployment.agent_id,
+			);
+			const iframe = page.locator('iframe[title="OpenClaw Control UI"]');
+			await expect(iframe).toHaveCount(1);
+			expect(posts).toEqual(["Bearer user-a:session-a"]);
+			if (phase === "getToken")
+				await page.evaluate(() => window.authTest.holdSessionToken("session-a"));
+			else holding = true;
+			await page.getByRole("button", { name: "Reconnect", exact: true }).click();
+			if (phase === "getToken")
+				await expect
+					.poll(() => page.evaluate(() => window.authTest.heldTokenCalls))
+					.toBeGreaterThan(0);
+			else await expect.poll(() => pending).toBe(true);
+			await expect(iframe).toHaveCount(0);
+			await page.evaluate(() =>
+				window.authTest.emitSdk({ userId: "user-b", sessionId: "session-b" }),
+			);
+			await expect(iframe).toHaveAttribute(
+				"src",
+				`${endpoint}#bootstrapToken=attempt-2&bootstrapProfile=owner`,
+			);
+			expect(issued).toBe(2);
+			held.resolve();
+			await page.evaluate(() => window.authTest.releaseSessionToken("session-a"));
+			if (phase !== "getToken") await expect.poll(() => aborted).toBe(true);
+			await expect(iframe).toHaveAttribute(
+				"src",
+				`${endpoint}#bootstrapToken=attempt-2&bootstrapProfile=owner`,
+			);
+			expect(posts.filter((post) => post === "Bearer user-b:session-b")).toHaveLength(1);
+			expect(issued).toBe(2);
+			expect(
+				await page.evaluate(() =>
+					Object.keys(localStorage).some(
+						(key) =>
+							key.startsWith("clawdi.openclaw-native-handoff-loaded.v1.") && key.includes("user-a"),
+					),
+				),
+			).toBe(false);
+		} finally {
+			held.resolve();
+			await page.evaluate(() => window.authTest.releaseSessionToken("session-a"));
+		}
+	});
+}
+
 async function start(page: Page, bootstrap?: string) {
 	await page.route("http://127.0.0.1:8000/**", (route) =>
 		route.fulfill({

--- a/apps/web/e2e/hosted-openclaw-native.pw.ts
+++ b/apps/web/e2e/hosted-openclaw-native.pw.ts
@@ -19,7 +19,10 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 	const deployment = mutationDeploymentReadFixture({
 		...includedBasicDeployment,
 		openclaw_control_ui_url: endpoint,
-		config_info: { ...includedBasicDeployment.config_info, runtime: "openclaw" },
+		config_info: {
+			...includedBasicDeployment.config_info,
+			runtime: "openclaw",
+		},
 	});
 	const otherAgent = mutationDeploymentReadFixture({
 		...includedBasicDeployment,
@@ -56,6 +59,7 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 		hello: string | null;
 		device: string | null;
 		closed: boolean;
+		errors: string[];
 	}> = [];
 	page.on("websocket", (socket) => {
 		if (!socket.url().startsWith("wss://127.0.0.1:19443")) return;
@@ -64,6 +68,7 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 			hello: null as string | null,
 			device: null as string | null,
 			closed: false,
+			errors: [] as string[],
 		};
 		connections.push(connection);
 		socket.on("framesent", ({ payload }) => {
@@ -75,6 +80,7 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 		});
 		socket.on("framereceived", ({ payload }) => {
 			const frame = JSON.parse(String(payload));
+			if (frame.error?.details?.code) connection.errors.push(frame.error.details.code);
 			if (frame.payload?.type === "hello-ok") {
 				expect(frame.payload.auth.scopes).toContain("operator.admin");
 				connection.hello = frame.payload.server.connId;
@@ -142,4 +148,187 @@ test("official OpenClaw authenticates before reveal and reuses native auth acros
 	expect(connections[3]?.device).toBe(initial?.device);
 	expect(issued).toBe(2);
 	console.log(JSON.stringify({ issued, documents, connections }));
+	// A Clawdi load hint survives independently of the official device credential.
+	// Remove only the isolated browser's token, preserving its device identity.
+	const currentDocument = await (await iframe.elementHandle())?.contentFrame();
+	if (!currentDocument) throw new Error("Official UI frame is missing");
+	const removed = await currentDocument.evaluate(() => {
+		const keys = Object.keys(localStorage).filter((key) =>
+			key.startsWith("openclaw.device.auth.v1:"),
+		);
+		for (const key of keys) localStorage.removeItem(key);
+		return keys.length;
+	});
+	expect(removed).toBeGreaterThan(0);
+	const recovery = page.waitForResponse(
+		(response) => response.url() === `${endpoint}.well-known/openclaw/browser-bootstrap`,
+	);
+	await page.goto(`/agents/${otherAgent.agent_id}`);
+	await page.goto(`/agents/${deployment.agent_id}`);
+	await expect(iframe).toBeHidden();
+	expect((await recovery).status()).toBe(404);
+	expect(connections[4]?.hello).toBeNull();
+	expect(connections[4]?.errors).toContain("AUTH_TOKEN_MISSING");
+	expect(issued).toBe(2);
+	console.log("Missing device credential", JSON.stringify(connections[4]));
+	// A test-only issuer isolates the official UI's recovery contract. This is not
+	// a production authentication boundary: the paired hosted implementation must
+	// authorize a runtime-origin owner grant before it may issue this response.
+	let recoveries = 0;
+	let releaseRecovery = () => {};
+	const recoveryAllowed = new Promise<void>((resolve) => {
+		releaseRecovery = resolve;
+	});
+	await page.route(`${endpoint}.well-known/openclaw/browser-bootstrap`, async (route) => {
+		await recoveryAllowed;
+		const { stdout } = await promisify(execFile)("node", [entry, "dashboard", "--json"], {
+			timeout: 20_000,
+		});
+		const params = new URLSearchParams(new URL(JSON.parse(stdout).browserUrl).hash.slice(1));
+		recoveries += 1;
+		await route.fulfill({
+			json: {
+				bootstrapToken: params.get("bootstrapToken"),
+				bootstrapProfile: "owner",
+			},
+			headers: { "Cache-Control": "no-store" },
+		});
+	});
+	const recoveryRequested = page.waitForRequest(
+		`${endpoint}.well-known/openclaw/browser-bootstrap`,
+	);
+	await page.reload();
+	await recoveryRequested;
+	const recoveringDocument = await (await iframe.elementHandle())?.contentFrame();
+	if (!recoveringDocument) throw new Error("Recovering UI frame is missing");
+	const retainedDocument = await recoveringDocument.evaluateHandle(() => window.document);
+	releaseRecovery();
+	await expect
+		.poll(() => connections.findLast((connection) => connection.hello), {
+			timeout: 30_000,
+		})
+		.not.toBe(connections[3]);
+	const recovered = connections.at(-1);
+	expect(recovered?.hello).toBeTruthy();
+	expect(recovered?.connects).toEqual([["bootstrapToken"]]);
+	expect(recovered?.device).toBe(initial?.device);
+	expect(recoveries).toBe(1);
+	await navigate("/console");
+	expect(await retainedDocument.evaluate((original) => original === window.document)).toBe(true);
+	await retainedDocument.dispose();
+	expect(connections.at(-1)).toBe(recovered);
+	expect(recovered?.closed).toBe(false);
+	if (!recovered?.device) throw new Error("Recovered device identity is missing");
+	await promisify(execFile)(
+		"node",
+		[entry, "devices", "revoke", "--device", recovered.device, "--role", "operator", "--json"],
+		{ timeout: 20_000 },
+	);
+	const revokedIndex = connections.length;
+	await page.goto(`/agents/${deployment.agent_id}`);
+	await expect.poll(() => connections[revokedIndex]?.errors.length).toBeGreaterThan(0);
+	await expect.poll(() => connections[revokedIndex]?.closed).toBe(true);
+	expect(connections[revokedIndex]?.errors).toEqual(["AUTH_DEVICE_TOKEN_MISMATCH"]);
+	expect(connections[revokedIndex]?.hello).toBeNull();
+	expect(recoveries).toBe(1);
+	console.log("Revoked device credential", JSON.stringify(connections.slice(revokedIndex)), {
+		recoveries,
+	});
 });
+
+for (const failure of ["expired", "consumed"] as const) {
+	test(`official OpenClaw characterizes ${failure} bootstrap recovery`, async ({
+		page,
+		browser,
+	}) => {
+		test.skip(!entry, "Requires the isolated official OpenClaw gateway fixture");
+		test.setTimeout(90_000);
+		if (!entry) throw new Error("Missing official gateway entry");
+		// Backdate only the isolated issuing CLI process. The browser and gateway
+		// retain real time, so expiration is checked by the real gateway.
+		const clock = "data:text/javascript,const now=Date.now();Date.now=()=>now-660000";
+		const { stdout } = await promisify(execFile)(
+			"node",
+			[...(failure === "expired" ? ["--import", clock] : []), entry, "dashboard", "--json"],
+			{ timeout: 20_000 },
+		);
+		const native = JSON.parse(stdout);
+		const fragment = new URLSearchParams(new URL(native.browserUrl).hash.slice(1));
+		fragment.set("gatewayUrl", endpoint.replace("https:", "wss:").replace(/\/$/, ""));
+		const handoff = `${endpoint}#${fragment}`;
+		if (failure === "consumed") {
+			const consumer = await browser.newContext({ ignoreHTTPSErrors: true });
+			try {
+				const consumingPage = await consumer.newPage();
+				let consumed = false;
+				consumingPage.on("websocket", (socket) =>
+					socket.on("framereceived", ({ payload }) => {
+						if (JSON.parse(String(payload)).payload?.type === "hello-ok") consumed = true;
+					}),
+				);
+				await consumingPage.goto(handoff);
+				await expect.poll(() => consumed, { timeout: 30_000 }).toBe(true);
+			} finally {
+				await consumer.close();
+			}
+		}
+		const deployment = mutationDeploymentReadFixture({
+			...includedBasicDeployment,
+			openclaw_control_ui_url: endpoint,
+			config_info: {
+				...includedBasicDeployment.config_info,
+				runtime: "openclaw",
+			},
+		});
+		await stubHostedApi(page, { deployments: [deployment] });
+		let issued = 0;
+		await page.route("**/v2/deployments/*/runtime-ui/credentials", async (route) => {
+			issued += 1;
+			await route.fulfill({
+				json: {
+					runtime: "openclaw",
+					auth_mode: "openclaw_token",
+					url: endpoint,
+					deployment_resource_version: deployment.resource.metadata.resourceVersion,
+					token: "isolated-test-gateway-secret",
+					handoff_url: handoff,
+				},
+			});
+		});
+		const errors: string[] = [];
+		let hello = false;
+		let closed = false;
+		let recoveryRequests = 0;
+		page.on("request", (request) => {
+			if (request.url().endsWith("/.well-known/openclaw/browser-bootstrap")) recoveryRequests += 1;
+		});
+		page.on("websocket", (socket) => {
+			socket.on("framereceived", ({ payload }) => {
+				const frame = JSON.parse(String(payload));
+				if (frame.error?.details?.code) errors.push(frame.error.details.code);
+				if (frame.payload?.type === "hello-ok") hello = true;
+			});
+			socket.on("close", () => {
+				closed = true;
+			});
+		});
+		await page.goto(`/agents/${deployment.agent_id}`);
+		await expect.poll(() => errors.length, { timeout: 30_000 }).toBeGreaterThan(0);
+		await expect.poll(() => closed).toBe(true);
+		expect(hello).toBe(false);
+		expect(recoveryRequests).toBe(0);
+		console.log(
+			`${failure} bootstrap`,
+			JSON.stringify({ errors, hello, recoveryRequests, issued }),
+		);
+		// The failed document still writes today's load hint; the next visit loses
+		// the rejected fragment and reaches the missing-credential recovery route.
+		const recovery = page.waitForResponse(
+			(response) => response.url() === `${endpoint}.well-known/openclaw/browser-bootstrap`,
+		);
+		await page.reload();
+		expect((await recovery).status()).toBe(404);
+		expect(issued).toBe(1);
+		expect(hello).toBe(false);
+	});
+}

--- a/apps/web/e2e/hosted-openclaw-recovery.pw.ts
+++ b/apps/web/e2e/hosted-openclaw-recovery.pw.ts
@@ -1,0 +1,214 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { expect, test } from "@playwright/test";
+import {
+	includedBasicDeployment,
+	mutationDeploymentReadFixture,
+	stubHostedApi,
+} from "./hosted-stub-api";
+
+const endpoint = "https://agent-42-18789.prod.clawdi.test:19444/";
+const cookieName = "__Secure-clawdi_openclaw_owner";
+
+test("protected runtime owner recovery authenticates the retained native document", async ({
+	page,
+	context,
+}) => {
+	test.skip(
+		process.env.OPENCLAW_PAIRED !== "1",
+		"Requires paired hosted boundary and real Traefik",
+	);
+	test.setTimeout(120_000);
+	const entry = process.env.OPENCLAW_TEST_ENTRY;
+	if (!entry) throw new Error("Official OpenClaw fixture is missing");
+	const deployment = mutationDeploymentReadFixture({
+		...includedBasicDeployment,
+		openclaw_control_ui_url: endpoint,
+		config_info: { ...includedBasicDeployment.config_info, runtime: "openclaw" },
+	});
+	if (deployment.runtime_ui_endpoint?.runtime !== "openclaw")
+		throw new Error("Runtime endpoint missing");
+	deployment.runtime_ui_endpoint.browser_session_url = `${endpoint}.well-known/openclaw/browser-session`;
+	await stubHostedApi(page, { deployments: [deployment] });
+	let initialHandoffs = 0;
+	await page.route("**/v2/deployments/*/runtime-ui/credentials", async (route) => {
+		const { stdout } = await promisify(execFile)("node", [entry, "dashboard", "--json"], {
+			timeout: 20_000,
+		});
+		const params = new URLSearchParams(new URL(JSON.parse(stdout).browserUrl).hash.slice(1));
+		params.set("gatewayUrl", endpoint.replace("https:", "wss:").replace(/\/$/, ""));
+		initialHandoffs += 1;
+		await route.fulfill({
+			json: {
+				runtime: "openclaw",
+				auth_mode: "openclaw_token",
+				url: endpoint,
+				deployment_resource_version: deployment.resource.metadata.resourceVersion,
+				token: "isolated-test-gateway-secret",
+				handoff_url: `${endpoint}#${params}`,
+			},
+		});
+	});
+	await context.addCookies([
+		{
+			name: "native-probe",
+			value: "preserved",
+			domain: "agent-42-18789.prod.clawdi.test",
+			path: "/",
+			secure: true,
+			httpOnly: true,
+			sameSite: "Strict",
+		},
+	]);
+	const connections: Array<{ auth: string[]; hello: string | null; closed: boolean }> = [];
+	page.on("websocket", (socket) => {
+		if (!socket.url().startsWith(endpoint.replace("https:", "wss:").replace(/\/$/, ""))) return;
+		const connection = { auth: [] as string[], hello: null as string | null, closed: false };
+		connections.push(connection);
+		socket.on("framesent", ({ payload }) => {
+			const frame = JSON.parse(String(payload));
+			if (frame.method === "connect") connection.auth = Object.keys(frame.params.auth ?? {});
+		});
+		socket.on("framereceived", ({ payload }) => {
+			const frame = JSON.parse(String(payload));
+			if (frame.payload?.type === "hello-ok") {
+				expect(frame.payload.auth.scopes).toContain("operator.admin");
+				connection.hello = frame.payload.server.connId;
+			}
+		});
+		socket.on("close", () => {
+			connection.closed = true;
+		});
+	});
+	let documents = 0;
+	page.on("request", (request) => {
+		if (request.isNavigationRequest() && request.url().startsWith(endpoint)) documents += 1;
+	});
+	const iframe = page.locator('iframe[title="OpenClaw Control UI"]');
+	const transport: Array<{ path: string; method: string; status: number }> = [];
+	page.on("response", (response) => {
+		if (response.url().startsWith(endpoint))
+			transport.push({
+				path: new URL(response.url()).pathname,
+				method: response.request().method(),
+				status: response.status(),
+			});
+	});
+	await page.goto(`/agents/${deployment.agent_id}`);
+	try {
+		await expect.poll(() => connections[0]?.hello, { timeout: 35_000 }).toBeTruthy();
+	} catch (error) {
+		console.log(
+			JSON.stringify({
+				transport,
+				documents,
+				initialHandoffs,
+				frames: await iframe.count(),
+				page: (await page.locator("body").innerText()).slice(0, 800),
+			}),
+		);
+		throw error;
+	}
+	await expect(iframe).toBeHidden();
+	expect(
+		transport.filter((entry) => entry.method === "POST" && entry.path.endsWith("browser-session")),
+	).toHaveLength(1);
+	expect(
+		transport.filter((entry) => entry.method === "HEAD" && entry.path.endsWith("browser-session")),
+	).toHaveLength(1);
+	expect(connections[0]?.auth).toEqual(["bootstrapToken"]);
+	const grant = (await context.cookies()).find((cookie) => cookie.name === cookieName);
+	expect(grant).toMatchObject({
+		domain: "agent-42-18789.prod.clawdi.test",
+		path: "/.well-known/openclaw/",
+		secure: true,
+		httpOnly: true,
+		sameSite: "Strict",
+	});
+	const frame = await (await iframe.elementHandle())?.contentFrame();
+	if (!frame) throw new Error("Native frame missing");
+	await frame.evaluate(() => {
+		for (const key of Object.keys(localStorage))
+			if (key.startsWith("openclaw.device.auth.v1:")) localStorage.removeItem(key);
+	});
+	await page.request.post("http://127.0.0.1:19445/fixture/hold");
+	const recoveryRequested = page.waitForRequest(
+		`${endpoint}.well-known/openclaw/browser-bootstrap`,
+	);
+	await page.reload();
+	await recoveryRequested;
+	const recoveringFrame = await (await iframe.elementHandle())?.contentFrame();
+	if (!recoveringFrame) throw new Error("Recovering native frame missing");
+	const originalDocument = await recoveringFrame.evaluateHandle(() => window.document);
+	await page.request.post("http://127.0.0.1:19445/fixture/release");
+	await expect.poll(() => connections[2]?.hello, { timeout: 35_000 }).toBeTruthy();
+	expect(connections).toHaveLength(3);
+	expect(connections[1]?.auth).toEqual([]);
+	expect(connections[2]?.auth).toEqual(["bootstrapToken"]);
+	expect(initialHandoffs).toBe(1);
+	expect(documents).toBe(2);
+	const recovered = connections[2];
+	await expect(iframe).toBeHidden();
+	await page
+		.getByTestId("app-sidebar")
+		.locator(`a[href="/agents/${deployment.agent_id}/console"]`)
+		.click();
+	await expect(iframe).toBeVisible();
+	expect(connections.at(-1)).toBe(recovered);
+	expect(recovered?.closed).toBe(false);
+	expect(await originalDocument.evaluate((original) => original === window.document)).toBe(true);
+	await originalDocument.dispose();
+	expect(documents).toBe(2);
+	await page.reload();
+	try {
+		await expect.poll(() => connections[3]?.hello, { timeout: 35_000 }).toBeTruthy();
+	} catch (error) {
+		console.log(JSON.stringify({ connections, documents, transport: transport.slice(-8) }));
+		throw error;
+	}
+	expect(connections[3]?.auth).toEqual(["deviceToken"]);
+	expect(initialHandoffs).toBe(1);
+	const issuer = await (await page.request.get("http://127.0.0.1:19445/fixture")).json();
+	expect(issuer.issued).toBe(1);
+	// A same-site dashboard request still cannot invoke the same-origin issuer.
+	const denied = await page.evaluate(async (url) => {
+		try {
+			return (await fetch(url, { credentials: "include" })).status;
+		} catch {
+			return "cors-denied";
+		}
+	}, `${endpoint}.well-known/openclaw/browser-bootstrap`);
+	expect([403, "cors-denied"]).toContain(denied);
+	for (const suffix of ["unknown", "browser-bootstrap/", "..%2f..%2f", "%2f..%2f"]) {
+		await page.request.get(`${endpoint}.well-known/openclaw/${suffix}`);
+	}
+	const observation = await (
+		await page.request.get("http://127.0.0.1:19446/__native_fixture__")
+	).json();
+	expect(observation.privateHeaders).toBe(0);
+	expect(observation.nativeCookie).toBeGreaterThan(0);
+	expect(observation.forwardedNonLoopback).toBeGreaterThan(0);
+	// A failed grant at an unchanged resource version remains an explicit retry.
+	let rejected = false;
+	await page.route(`${endpoint}.well-known/openclaw/browser-session`, async (route) => {
+		if (!rejected && route.request().method() === "POST") {
+			rejected = true;
+			await route.fulfill({
+				status: 503,
+				headers: {
+					"Access-Control-Allow-Origin": "https://cloud.clawdi.test:19444",
+					"Access-Control-Allow-Credentials": "true",
+				},
+				body: "",
+			});
+		} else await route.continue();
+	});
+	await page.reload();
+	await expect(page.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
+	await expect(iframe).toHaveCount(0);
+	expect(initialHandoffs).toBe(1);
+	await page.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect.poll(() => connections[4]?.hello, { timeout: 35_000 }).toBeTruthy();
+	expect(initialHandoffs).toBe(2);
+	console.log(JSON.stringify({ initialHandoffs, documents, connections, issuer, observation }));
+});

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -308,7 +308,7 @@ function hostedUser(canUsePlanCBilling = true) {
 const emptyPage = { items: [], total: 0, page: 1, page_size: 25 };
 
 // Must match the API hosts configured in playwright.hosted.config.ts.
-const CLOUD_API = "http://127.0.0.1:8000";
+const CLOUD_API = process.env.E2E_HOSTED_CLOUD_API_URL ?? "http://127.0.0.1:8000";
 const DEPLOY_API = process.env.E2E_HOSTED_DEPLOY_API_URL ?? "http://127.0.0.1:8001";
 
 export const basicPlan = {

--- a/apps/web/e2e/openclaw-native/gateway.mjs
+++ b/apps/web/e2e/openclaw-native/gateway.mjs
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { request } from "node:http";
+import { createServer as createHttpServer, request } from "node:http";
 import { createServer } from "node:https";
 import { connect } from "node:net";
 
@@ -15,8 +15,15 @@ writeFileSync(
 			mode: "local",
 			port: 18789,
 			bind: "loopback",
+			// The paired test's real Traefik ingress connects over loopback.
+			trustedProxies: ["127.0.0.1"],
 			auth: { mode: "token", token: "isolated-test-gateway-secret" },
-			controlUi: { allowedOrigins: ["https://127.0.0.1:19443"] },
+			controlUi: {
+				allowedOrigins: [
+					"https://127.0.0.1:19443",
+					"https://agent-42-18789.prod.clawdi.test:19444",
+				],
+			},
 		},
 		plugins: { enabled: false },
 	}),
@@ -47,35 +54,58 @@ gateway.on("error", (error) => {
 });
 gateway.on("exit", (code) => {
 	server.close();
+	nativeProxy.close();
 	process.exitCode = code ?? 1;
 });
 // Test-only ingress permits embedding. Official HTML/JS and native WS payloads
 // are untouched. This is not evidence of production ingress configuration.
+const observations = { privateHeaders: 0, nativeCookie: 0, forwardedNonLoopback: 0 };
+function observe(req) {
+	const forwarded = req.headers["x-forwarded-for"];
+	if (typeof forwarded === "string" && !forwarded.startsWith("127.") && forwarded !== "::1")
+		observations.forwardedNonLoopback += 1;
+	if (
+		req.headers.cookie?.includes("__Secure-clawdi_openclaw_owner=") ||
+		req.headers.authorization === "Bearer dev-bypass" ||
+		req.headers["x-clawdi-openclaw-route-proof"]
+	)
+		observations.privateHeaders += 1;
+	if (req.headers.cookie?.includes("native-probe=preserved")) observations.nativeCookie += 1;
+}
+function serve(req, res) {
+	if (req.url === "/__native_fixture__") {
+		res.setHeader("Content-Type", "application/json");
+		res.end(JSON.stringify(observations));
+		return;
+	}
+	observe(req);
+	const upstream = request(
+		{ host: "127.0.0.1", port: 18789, path: req.url, method: req.method, headers: req.headers },
+		(response) => {
+			const headers = { ...response.headers };
+			delete headers["x-frame-options"];
+			if (headers["content-security-policy"])
+				headers["content-security-policy"] = headers["content-security-policy"].replace(
+					/frame-ancestors[^;]*(;|$)/g,
+					"",
+				);
+			res.writeHead(response.statusCode ?? 502, headers);
+			response.pipe(res);
+		},
+	);
+	upstream.on("error", () => {
+		res.writeHead(502);
+		res.end();
+	});
+	req.pipe(upstream);
+}
 const server = createServer(
 	{ key: readFileSync(`${state}/key.pem`), cert: readFileSync(`${state}/cert.pem`) },
-	(req, res) => {
-		const upstream = request(
-			{ host: "127.0.0.1", port: 18789, path: req.url, method: req.method, headers: req.headers },
-			(response) => {
-				const headers = { ...response.headers };
-				delete headers["x-frame-options"];
-				if (headers["content-security-policy"])
-					headers["content-security-policy"] = headers["content-security-policy"].replace(
-						/frame-ancestors[^;]*(;|$)/g,
-						"",
-					);
-				res.writeHead(response.statusCode ?? 502, headers);
-				response.pipe(res);
-			},
-		);
-		upstream.on("error", () => {
-			res.writeHead(502);
-			res.end();
-		});
-		req.pipe(upstream);
-	},
+	serve,
 );
-server.on("upgrade", (req, socket, head) => {
+const nativeProxy = createHttpServer(serve);
+function upgrade(req, socket, head) {
+	observe(req);
 	const upstream = connect(18789, "127.0.0.1", () => {
 		upstream.write(
 			`${req.method} ${req.url} HTTP/${req.httpVersion}\r\n${Object.entries(req.headers)
@@ -89,7 +119,9 @@ server.on("upgrade", (req, socket, head) => {
 	upstream.on("error", () => socket.destroy());
 	socket.on("error", () => upstream.destroy());
 	socket.on("close", () => upstream.destroy());
-});
+}
+server.on("upgrade", upgrade);
+nativeProxy.on("upgrade", upgrade);
 server.on("error", (error) => {
 	console.error(error);
 	gateway.kill();
@@ -97,6 +129,9 @@ server.on("error", (error) => {
 });
 process.on("SIGTERM", () => {
 	server.close();
+	nativeProxy.close();
 	gateway.kill();
 });
 server.listen(19443, "127.0.0.1");
+
+nativeProxy.listen(19446, "127.0.0.1");

--- a/apps/web/e2e/vault-request.pw.ts
+++ b/apps/web/e2e/vault-request.pw.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const token = "a".repeat(43);
+const token = `v2_${"a".repeat(43)}`;
 const context = {
 	id: "11111111-1111-4111-8111-111111111111",
 	vault_id: "22222222-2222-4222-8222-222222222222",
@@ -10,93 +10,102 @@ const context = {
 	slug: "production-api",
 	section: "",
 	fields: ["API_KEY", "API_SECRET"],
+	update_fields: [],
 	status: "pending",
 	expires_at: "2099-01-01T00:00:00Z",
 	supplied_at: null,
 	references: {},
-	local_command: "",
+	content_version: 1,
 };
 
-test("public batch request keeps capability out of URLs and saves all fields once", async ({
-	page,
-	context: browserContext,
-}) => {
-	await browserContext.grantPermissions(["clipboard-read", "clipboard-write"]);
-	const suppliedId = "44444444-4444-4444-8444-444444444444";
-	const message = `I've saved the requested credentials. Please check Vault request ${suppliedId}; once its status is supplied, continue our previous task using existing authorized capabilities. Do not include secret values in chat.`;
-	let submissions = 0;
-	const requestedUrls: string[] = [];
-	page.on("request", (request) => requestedUrls.push(request.url()));
-	await page.route("**/v1/vault/requests/**", async (route) => {
-		const request = route.request();
-		expect(request.method()).toBe("POST");
-		expect(request.headers().referer).toBeUndefined();
-		expect(request.postDataJSON().token).toBe(token);
-		if (request.url().endsWith("/supply")) {
-			submissions++;
-			expect(request.postDataJSON().fields).toEqual({
-				API_KEY: "fake-key",
-				API_SECRET: "line1\nline2",
-			});
-			return route.fulfill({
-				json: {
-					...context,
-					id: suppliedId,
-					status: "supplied",
-					supplied_at: "2026-09-10T00:00:00Z",
+for (const update_fields of [[], ["API_KEY"]]) {
+	test(`public ${update_fields.length ? "mixed" : "new"} batch keeps capability private and saves once`, async ({
+		page,
+		context: browserContext,
+	}, testInfo) => {
+		await browserContext.grantPermissions(["clipboard-read", "clipboard-write"]);
+		const suppliedId = "44444444-4444-4444-8444-444444444444";
+		const message = `I've saved the requested credentials. Please check Vault request ${suppliedId}; once its status is supplied, continue our previous task using existing authorized capabilities. Do not include secret values in chat.`;
+		let submissions = 0;
+		const requestedUrls: string[] = [];
+		page.on("request", (request) => requestedUrls.push(request.url()));
+		await page.route("**/v1/vault/requests/**", async (route) => {
+			const request = route.request();
+			expect(request.method()).toBe("POST");
+			expect(request.headers().referer).toBeUndefined();
+			expect(request.postDataJSON().token).toBe(token);
+			if (request.url().endsWith("/supply")) {
+				submissions++;
+				expect(request.postDataJSON().fields).toEqual({
+					API_KEY: "fake-key",
+					API_SECRET: "line1\nline2",
+				});
+				return route.fulfill({
+					json: {
+						...context,
+						id: suppliedId,
+						status: "supplied",
+						supplied_at: "2026-09-10T00:00:00Z",
+					},
+				});
+			}
+			return route.fulfill({ json: { ...context, update_fields } });
+		});
+		const response = await page.goto(`/vault-request#${token}`);
+		expect(response?.headers()["cache-control"]).toContain("no-store");
+		await expect(page.getByText("Production API · Agent workspace")).toBeVisible();
+		await expect(page).toHaveURL(/\/vault-request$/);
+		await expect(page.getByRole("button", { name: "Copy message for agent" })).toHaveCount(0);
+		await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("");
+		await expect(page.getByLabel("API_SECRET", { exact: true })).toHaveValue("");
+		await expect(page.getByText("Update", { exact: true })).toHaveCount(update_fields.length);
+		const screenshot = testInfo.outputPath("request-form.png");
+		await page.screenshot({ path: screenshot });
+		await testInfo.attach("request-form", { path: screenshot, contentType: "image/png" });
+		await page.getByLabel("API_KEY", { exact: true }).fill("fake-key");
+		await page.getByLabel("API_SECRET", { exact: true }).fill("line1\nline2");
+		await page.getByRole("button", { name: "Save secrets" }).click();
+		await expect(page.getByRole("status")).toContainText("Your secrets are saved");
+		expect(submissions).toBe(1);
+		expect(requestedUrls.some((url) => url.includes(token))).toBe(false);
+		await expect(page.getByRole("textbox")).toHaveCount(0);
+		await expect(page.getByText(message, { exact: true })).toBeVisible();
+		await page.getByRole("button", { name: "Copy message for agent" }).click();
+		await expect(page.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
+		expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(message);
+
+		// Hold a denied write pending to verify success is never reported before settlement.
+		await page.evaluate(() => {
+			Object.defineProperty(navigator, "clipboard", {
+				configurable: true,
+				value: {
+					writeText: () =>
+						new Promise<void>((_resolve, reject) => {
+							window.addEventListener(
+								"deny-copy",
+								() => reject(new DOMException("Denied", "NotAllowedError")),
+								{ once: true },
+							);
+						}),
 				},
 			});
-		}
-		return route.fulfill({ json: context });
-	});
-	const response = await page.goto(`/vault-request#${token}`);
-	expect(response?.headers()["cache-control"]).toContain("no-store");
-	await expect(page.getByText("Production API · Agent workspace")).toBeVisible();
-	await expect(page).toHaveURL(/\/vault-request$/);
-	await expect(page.getByRole("button", { name: "Copy message for agent" })).toHaveCount(0);
-	await page.getByLabel("API_KEY", { exact: true }).fill("fake-key");
-	await page.getByLabel("API_SECRET", { exact: true }).fill("line1\nline2");
-	await page.getByRole("button", { name: "Save secrets" }).click();
-	await expect(page.getByRole("status")).toContainText("Your secrets are saved");
-	expect(submissions).toBe(1);
-	expect(requestedUrls.some((url) => url.includes(token))).toBe(false);
-	await expect(page.getByRole("textbox")).toHaveCount(0);
-	await expect(page.getByText(message, { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Copy message for agent" }).click();
-	await expect(page.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
-	expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(message);
-
-	// Hold a denied write pending to verify success is never reported before settlement.
-	await page.evaluate(() => {
-		Object.defineProperty(navigator, "clipboard", {
-			configurable: true,
-			value: {
-				writeText: () =>
-					new Promise<void>((_resolve, reject) => {
-						window.addEventListener(
-							"deny-copy",
-							() => reject(new DOMException("Denied", "NotAllowedError")),
-							{ once: true },
-						);
-					}),
-			},
 		});
-	});
-	await page.getByRole("button", { name: "Copied", exact: true }).click();
-	await expect(page.getByRole("button", { name: "Copying…" })).toBeDisabled();
-	await expect(page.getByRole("button", { name: "Copied", exact: true })).toHaveCount(0);
-	await page.evaluate(() => window.dispatchEvent(new Event("deny-copy")));
-	await expect(page.getByRole("alert")).toContainText("copy the message above manually");
-	await expect(page.getByText(message, { exact: true })).toBeVisible();
+		await page.getByRole("button", { name: "Copied", exact: true }).click();
+		await expect(page.getByRole("button", { name: "Copying…" })).toBeDisabled();
+		await expect(page.getByRole("button", { name: "Copied", exact: true })).toHaveCount(0);
+		await page.evaluate(() => window.dispatchEvent(new Event("deny-copy")));
+		await expect(page.getByRole("alert")).toContainText("copy the message above manually");
+		await expect(page.getByText(message, { exact: true })).toBeVisible();
 
-	await page.evaluate(() =>
-		Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined }),
-	);
-	await page.getByRole("button", { name: "Copy message for agent" }).click();
-	await expect(page.getByRole("alert")).toContainText("copy the message above manually");
-	await expect(page.getByRole("button", { name: "Copied", exact: true })).toHaveCount(0);
-	expect(submissions).toBe(1);
-});
+		await page.evaluate(() =>
+			Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined }),
+		);
+		await page.getByRole("button", { name: "Copy message for agent" }).click();
+		await expect(page.getByRole("alert")).toContainText("copy the message above manually");
+		await expect(page.getByRole("button", { name: "Copied", exact: true })).toHaveCount(0);
+		expect(submissions).toBe(1);
+	});
+}
 
 test("expired capability offers no secret form", async ({ page }) => {
 	await page.route("**/v1/vault/requests/inspect", (route) =>
@@ -108,13 +117,33 @@ test("expired capability offers no secret form", async ({ page }) => {
 	await expect(page.getByRole("textbox")).toHaveCount(0);
 });
 
-for (const status of ["missing", "error"]) {
+for (const status of ["missing", "invalid", "error"]) {
 	test(`${status} request offers no agent message`, async ({ page }) => {
 		await page.route("**/v1/vault/requests/inspect", (route) =>
 			route.fulfill({ status: 500, json: { detail: "Unavailable" } }),
 		);
-		await page.goto(status === "missing" ? "/vault-request" : `/vault-request#${token}`);
+		await page.goto(
+			status === "missing"
+				? "/vault-request"
+				: `/vault-request#${status === "invalid" ? "a".repeat(43) : token}`,
+		);
 		await expect(page.getByRole("alert")).toBeVisible();
 		await expect(page.getByRole("button", { name: "Copy message for agent" })).toHaveCount(0);
 	});
 }
+
+test("an intervening change clears the mixed form without claiming success", async ({ page }) => {
+	await page.route("**/v1/vault/requests/inspect", (route) =>
+		route.fulfill({ json: { ...context, update_fields: ["API_KEY"] } }),
+	);
+	await page.route("**/v1/vault/requests/supply", (route) =>
+		route.fulfill({ status: 410, json: { detail: "Secret request unavailable" } }),
+	);
+	await page.goto(`/vault-request#${token}`);
+	await page.getByLabel("API_KEY", { exact: true }).fill("synthetic-update");
+	await page.getByLabel("API_SECRET", { exact: true }).fill("synthetic-new");
+	await page.getByRole("button", { name: "Save secrets" }).click();
+	await expect(page.getByRole("alert")).toContainText("new link");
+	await expect(page.getByRole("textbox")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Copy message for agent" })).toHaveCount(0);
+});

--- a/apps/web/playwright.hosted.config.ts
+++ b/apps/web/playwright.hosted.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
 			timeout: 120_000,
 			env: {
 				...process.env,
-				VITE_CLAWDI_API_URL: "http://127.0.0.1:8000",
+				VITE_CLAWDI_API_URL: process.env.E2E_HOSTED_CLOUD_API_URL ?? "http://127.0.0.1:8000",
 				VITE_CLAWDI_HOSTED: "true",
 				VITE_CLAWDI_DEPLOY_API_URL: deployApiURL,
 				VITE_CLAWDI_LEGACY_DASHBOARD_URL: "https://legacy.example/dashboard",

--- a/apps/web/playwright.openclaw.config.ts
+++ b/apps/web/playwright.openclaw.config.ts
@@ -3,9 +3,11 @@ import hosted from "./playwright.hosted.config";
 
 export default defineConfig({
 	...hosted,
-	testMatch: "hosted-openclaw-native.pw.ts",
+	testMatch: ["hosted-openclaw-native.pw.ts", "hosted-openclaw-recovery.pw.ts"],
 	// Hosted APIs are stubbed in-page; only the real Vite product server is needed.
-	webServer: Array.isArray(hosted.webServer) ? hosted.webServer.slice(0, 1) : hosted.webServer,
+	webServer: Array.isArray(hosted.webServer)
+		? hosted.webServer.slice(0, 1).map((server) => ({ ...server, ignoreHTTPSErrors: true }))
+		: hosted.webServer,
 	use: {
 		...hosted.use,
 		ignoreHTTPSErrors: true,

--- a/apps/web/src/components/vault/secret-requests.tsx
+++ b/apps/web/src/components/vault/secret-requests.tsx
@@ -8,7 +8,7 @@ const labels = {
 	pending: "Awaiting input",
 	supplied: "Supplied",
 	expired: "Expired",
-	conflict: "Field already exists",
+	conflict: "Credentials changed",
 };
 
 export function VaultSecretRequests({

--- a/apps/web/src/hosted/agents/openclaw-browser-session.ts
+++ b/apps/web/src/hosted/agents/openclaw-browser-session.ts
@@ -1,0 +1,33 @@
+/** Establish and verify the separately scoped runtime-origin recovery cookie. */
+export async function primeOpenClawBrowserSession(
+	url: string,
+	endpoint: string,
+	token: string,
+	resourceVersion: string,
+	signal: AbortSignal,
+): Promise<void> {
+	const expected = new URL(".well-known/openclaw/browser-session", endpoint);
+	if (
+		expected.protocol !== "https:" ||
+		expected.href !== url ||
+		expected.pathname !== "/.well-known/openclaw/browser-session"
+	) {
+		throw new Error("Invalid browser session endpoint.");
+	}
+	const options = {
+		credentials: "include",
+		cache: "no-store",
+		redirect: "error",
+		signal: AbortSignal.any([signal, AbortSignal.timeout(45_000)]),
+	} as const;
+	const bootstrap = await fetch(url, {
+		...options,
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}`, "If-Match": `"${resourceVersion}"` },
+	});
+	if (bootstrap.status !== 204) throw new Error("Browser session could not be established.");
+	// Set-Cookie is not observable by JavaScript. Verify delivery with a request
+	// that has only the browser's cookie, before loading the official document.
+	const verified = await fetch(url, { ...options, method: "HEAD" });
+	if (verified.status !== 204) throw new Error("Browser session cookie is unavailable.");
+}

--- a/apps/web/src/hosted/agents/use-runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/use-runtime-ui-credentials.ts
@@ -1,5 +1,6 @@
 import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { primeOpenClawBrowserSession } from "@/hosted/agents/openclaw-browser-session";
 import {
 	forgetOpenClawNativeHandoffLoaded,
 	hasOpenClawNativeHandoffLoaded,
@@ -9,13 +10,18 @@ import {
 } from "@/hosted/agents/runtime-ui-credentials";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
-import { useSessionIdentity } from "@/lib/auth-client";
+import { useAuthToken, useSessionIdentity } from "@/lib/auth-client";
 
 /** Credentials belong to the mounted console, never to a cross-route cache. */
 export function useRuntimeUiCredentials(deployment: HostedDeployment, endpoint: string | null) {
 	const client = useBillingClient();
 	const { id, metadata, spec } = deployment.resource;
 	const identity = useSessionIdentity();
+	const { getToken } = useAuthToken();
+	const browserSessionUrl =
+		deployment.runtime_ui_endpoint?.runtime === "openclaw"
+			? deployment.runtime_ui_endpoint.browser_session_url
+			: null;
 	const storageScope = JSON.stringify([identity, id]);
 	const [nativeHandoffLoaded, setNativeHandoffLoaded] = useState(false);
 	const [credentials, setCredentials] = useState<RuntimeUiCredentials | null>(null);
@@ -26,15 +32,18 @@ export function useRuntimeUiCredentials(deployment: HostedDeployment, endpoint: 
 	const active = useRef(false);
 	const revision = useRef(0);
 	const requestedVersion = useRef<string | null>(null);
+	const requestAbort = useRef<AbortController | null>(null);
 
 	useLayoutEffect(() => {
 		active.current = true;
 		return () => {
 			active.current = false;
+			requestAbort.current?.abort();
 		};
 	}, []);
 
 	const clear = useCallback(() => {
+		requestAbort.current?.abort();
 		forgetOpenClawNativeHandoffLoaded(runtimeUiLocalStorage(), storageScope);
 		setNativeHandoffLoaded(false);
 		revision.current += 1;
@@ -62,6 +71,34 @@ export function useRuntimeUiCredentials(deployment: HostedDeployment, endpoint: 
 			pending.current = Promise.resolve()
 				.then(async () => {
 					if (!current()) return null;
+					const abort = new AbortController();
+					requestAbort.current?.abort();
+					requestAbort.current = abort;
+					if (browserSessionUrl) {
+						const token = await getToken();
+						if (!current()) return null;
+						await primeOpenClawBrowserSession(
+							browserSessionUrl,
+							endpoint,
+							token,
+							metadata.resourceVersion,
+							abort.signal,
+						);
+						if (!current()) return null;
+					}
+					if (
+						!fresh &&
+						spec.runtime === "openclaw" &&
+						hasOpenClawNativeHandoffLoaded(
+							runtimeUiLocalStorage(),
+							storageScope,
+							endpoint,
+							metadata.generation,
+						)
+					) {
+						setNativeHandoffLoaded(true);
+						return null;
+					}
 					const result = await client.getRuntimeUiCredentials(id, metadata.resourceVersion);
 					if (!current()) return null;
 					const resolved = resolveRuntimeUiCredentials(result, endpoint, metadata.resourceVersion);
@@ -82,7 +119,18 @@ export function useRuntimeUiCredentials(deployment: HostedDeployment, endpoint: 
 				});
 			return pending.current;
 		},
-		[client, id, metadata.resourceVersion, spec.runtime, endpoint, credentials, storageScope],
+		[
+			client,
+			id,
+			metadata.resourceVersion,
+			metadata.generation,
+			spec.runtime,
+			endpoint,
+			credentials,
+			storageScope,
+			browserSessionUrl,
+			getToken,
+		],
 	);
 
 	useEffect(() => {
@@ -96,17 +144,6 @@ export function useRuntimeUiCredentials(deployment: HostedDeployment, endpoint: 
 			!isLoading &&
 			requestedVersion.current !== metadata.resourceVersion
 		) {
-			if (
-				hasOpenClawNativeHandoffLoaded(
-					runtimeUiLocalStorage(),
-					storageScope,
-					endpoint,
-					metadata.generation,
-				)
-			) {
-				setNativeHandoffLoaded(true);
-				return;
-			}
 			void load();
 		}
 	}, [

--- a/apps/web/src/pages/vault-request.tsx
+++ b/apps/web/src/pages/vault-request.tsx
@@ -10,7 +10,7 @@ import { env } from "@/lib/env";
 type RequestContext = components["schemas"]["VaultSecretRequestStatus"];
 const client = createClient<paths>({ baseUrl: env.VITE_CLAWDI_API_URL });
 const UNAVAILABLE =
-	"This link has expired or is no longer available. Ask your agent for a new link.";
+	"This request has changed or its link has expired. Ask your agent for a new link.";
 
 export function VaultRequestPage() {
 	const token = useRef("");
@@ -42,7 +42,7 @@ export function VaultRequestPage() {
 		// Remove the capability from browser history before making any request.
 		if (!token.current) token.current = window.location.hash.slice(1);
 		window.history.replaceState(null, "", window.location.pathname);
-		if (!/^[A-Za-z0-9_-]{43}$/.test(token.current)) {
+		if (!/^v2_[A-Za-z0-9_-]{43}$/.test(token.current)) {
 			setPhase("unavailable");
 			return;
 		}
@@ -187,11 +187,21 @@ export function VaultRequestPage() {
 								</p>
 							</div>
 							<p className="text-sm text-muted-foreground">
-								Only these fields will be added. Anyone with Vault access can use them.
+								Only these fields will be saved. Anyone with Vault access can use them.
 							</p>
+							{!!context.update_fields.length && (
+								<p className="text-sm text-muted-foreground">
+									Fields marked Update replace existing values when you save.
+								</p>
+							)}
 							{context.fields.map((name) => (
 								<div className="space-y-2" key={name}>
-									<Label htmlFor={`secret-${name}`}>{name}</Label>
+									<div className="flex items-center justify-between gap-2">
+										<Label htmlFor={`secret-${name}`}>{name}</Label>
+										{context.update_fields.includes(name) && (
+											<span className="text-xs font-medium text-muted-foreground">Update</span>
+										)}
+									</div>
 									<Textarea
 										id={`secret-${name}`}
 										value={values[name] ?? ""}

--- a/backend/alembic/versions/e7b4c2a9d610_vault_request_field_baselines.py
+++ b/backend/alembic/versions/e7b4c2a9d610_vault_request_field_baselines.py
@@ -1,0 +1,40 @@
+"""Allow request-local optimistic updates of existing Vault fields.
+
+Revision ID: e7b4c2a9d610
+Revises: d3e5f7a9b1c2
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e7b4c2a9d610"
+down_revision = "d3e5f7a9b1c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vault_secret_requests",
+        sa.Column("field_baselines", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column("vault_secret_requests", sa.Column("conflicted_at", sa.DateTime(timezone=True)))
+    # Preserve historical records, but no pre-cutover capability remains usable.
+    op.execute("UPDATE vault_secret_requests SET field_baselines = '{}'::jsonb")
+    op.execute(
+        "UPDATE vault_secret_requests SET expires_at = LEAST(expires_at, now()) "
+        "WHERE supplied_at IS NULL"
+    )
+    # No default: every new insert must explicitly supply its complete snapshot.
+    op.alter_column("vault_secret_requests", "field_baselines", nullable=False)
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE vault_secret_requests SET expires_at = LEAST(expires_at, now()) "
+        "WHERE supplied_at IS NULL"
+    )
+    op.drop_column("vault_secret_requests", "conflicted_at")
+    op.drop_column("vault_secret_requests", "field_baselines")

--- a/backend/app/models/vault.py
+++ b/backend/app/models/vault.py
@@ -135,5 +135,9 @@ class VaultSecretRequest(Base, TimestampMixin):
     token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
     section: Mapped[str] = mapped_column(String(200), nullable=False)
     fields: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
+    # Every requested field has a baseline; null records absence.
+    # Never expose these request-local snapshots through API or runtime metadata.
+    field_baselines: Mapped[dict[str, str | None]] = mapped_column(JSONB, nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     supplied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    conflicted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -692,9 +692,11 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
     ),
     "vault_request_create": _NativeToolSpec(
         description=(
-            "Request a batch of missing environment fields in one exact owned Vault. "
+            "Request a batch of new or updated Vault fields in one exact owned Vault. "
             "Returns a one-time write-only URL to show the user; never ask for secrets in chat. "
-            "Existing fields are rejected. Runtime requests must target their own Workspace, not "
+            "Existing Vault values are kept until submission and are never shown by the link. "
+            "Changes to requested fields conflict; overlapping pending requests are rejected. "
+            "Runtime requests must target their own Workspace, not "
             "other readable linked Projects. The URL expires and is consumed only after saving."
         ),
         input_schema=_VaultRequestCreateArguments.model_json_schema(),
@@ -705,7 +707,10 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
         description=(
             "Check a Vault request: pending, supplied, expired, or conflict. Returns references, "
             "never values. After supply, continue the task using existing authorized capabilities; "
-            "this remote MCP does not save credentials to local files."
+            "verify local index Vault/section/fields and content_version >= "
+            "this status content_version "
+            "before claiming local delivery. "
+            "This remote MCP does not save credentials to local files."
         ),
         input_schema=_VaultRequestStatusArguments.model_json_schema(),
         scopes=("vault:read",),
@@ -1528,9 +1533,7 @@ async def _tool_vault_get(
                 "slug": vault_slug,
             },
             "keys": keys,
-            "requests": [
-                row.model_dump(mode="json", exclude={"local_command"}) for row in requests
-            ],
+            "requests": [row.model_dump(mode="json") for row in requests],
         }
     )
 
@@ -1699,7 +1702,7 @@ async def _tool_vault_request_create(
 ) -> JsonObject:
     parsed = _validate_arguments(_VaultRequestCreateArguments, arguments)
     result = await vault_requests.create_request(db, auth, parsed)
-    return _tool_json(result.model_dump(mode="json", exclude={"local_command"}))
+    return _tool_json(result.model_dump(mode="json"))
 
 
 async def _tool_vault_request_status(
@@ -1707,6 +1710,4 @@ async def _tool_vault_request_status(
 ) -> JsonObject:
     parsed = _validate_arguments(_VaultRequestStatusArguments, arguments)
     row = await vault_requests.owned_request(db, auth, parsed.request_id)
-    return _tool_json(
-        (await vault_requests.describe(db, row)).model_dump(mode="json", exclude={"local_command"})
-    )
+    return _tool_json((await vault_requests.describe(db, row)).model_dump(mode="json"))

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -382,9 +382,11 @@ async def copy_vault_items(
     if target.id == source.id:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Source and target are the same vault")
 
+    await db.execute(select(Vault.id).where(Vault.id == target.id).with_for_update())
     source_by_name = await vault_service.load_vault_items_by_name(db, source.id, body.section)
     target_by_name = await vault_service.load_vault_items_by_name(db, target.id, body.section)
     copied = 0
+    copied_fields: set[str] = set()
     for field_name in body.fields:
         item = source_by_name.get(field_name)
         if item is None:
@@ -413,10 +415,12 @@ async def copy_vault_items(
             # duplicate row.
             target_by_name[target_name] = created
         copied += 1
+        copied_fields.add(target_name)
 
     if copied:
         from app.services.runtime_vaults import notify_vault_changed
 
+        await vault_service.conflict_vault_requests(db, target.id, body.section, copied_fields)
         await notify_vault_changed(db, target.id, values_changed=True)
     await db.commit()
     return VaultItemsCopyResponse(status="ok", copied=copied)

--- a/backend/app/schemas/vault.py
+++ b/backend/app/schemas/vault.py
@@ -9,7 +9,7 @@ VAULT_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,198}[a-z0-9])?$")
 VAULT_ITEM_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
-def _clean_segment(value: str, *, field_name: str, allow_empty: bool = False) -> str:
+def clean_vault_segment(value: str, *, field_name: str, allow_empty: bool = False) -> str:
     cleaned = value.strip()
     if not cleaned:
         if allow_empty:
@@ -55,13 +55,13 @@ class VaultItemUpsert(BaseModel):
     @field_validator("section", mode="after")
     @classmethod
     def validate_section(cls, value: str) -> str:
-        return _clean_segment(value, field_name="section", allow_empty=True)
+        return clean_vault_segment(value, field_name="section", allow_empty=True)
 
     @field_validator("fields", mode="after")
     @classmethod
     def validate_field_names(cls, value: dict[str, str]) -> dict[str, str]:
         return {
-            _clean_segment(field_name, field_name="field name"): field_value
+            clean_vault_segment(field_name, field_name="field name"): field_value
             for field_name, field_value in value.items()
         }
 
@@ -78,7 +78,7 @@ class VaultItemDelete(BaseModel):
     @field_validator("section", mode="after")
     @classmethod
     def validate_section(cls, value: str) -> str:
-        return _clean_segment(value, field_name="section", allow_empty=True)
+        return clean_vault_segment(value, field_name="section", allow_empty=True)
 
     @field_validator("fields", mode="after")
     @classmethod
@@ -154,7 +154,7 @@ class VaultItemsCopy(BaseModel):
     @field_validator("section", mode="after")
     @classmethod
     def validate_section(cls, value: str) -> str:
-        return _clean_segment(value, field_name="section", allow_empty=True)
+        return clean_vault_segment(value, field_name="section", allow_empty=True)
 
 
 class VaultItemsCopyResponse(BaseModel):
@@ -244,6 +244,7 @@ class RuntimeVault(BaseModel):
     slug: str
     project_ids: list[UUID]
     revision: str
+    content_version: int = Field(ge=0)
     fields: list[RuntimeVaultField] | None = None
 
 

--- a/backend/app/schemas/vault_requests.py
+++ b/backend/app/schemas/vault_requests.py
@@ -1,11 +1,10 @@
-import re
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.schemas.vault import VaultCreate, VaultItemUpsert
+from app.schemas.vault import VaultCreate, VaultItemUpsert, clean_vault_segment
 
 
 class VaultSecretRequestCreate(BaseModel):
@@ -31,11 +30,10 @@ class VaultSecretRequestCreate(BaseModel):
     @field_validator("fields")
     @classmethod
     def validate_fields(cls, fields: list[str]) -> list[str]:
-        if len(set(fields)) != len(fields) or any(
-            not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,199}", field) for field in fields
-        ):
-            raise ValueError("Fields must be distinct environment variable names")
-        return fields
+        cleaned = [clean_vault_segment(field, field_name="field name") for field in fields]
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("Fields must be distinct after normalization")
+        return cleaned
 
 
 class VaultSecretRequestStatus(BaseModel):
@@ -47,11 +45,12 @@ class VaultSecretRequestStatus(BaseModel):
     slug: str
     section: str
     fields: list[str]
+    update_fields: list[str]
+    content_version: int = Field(ge=0)
     status: Literal["pending", "supplied", "expired", "conflict"]
     expires_at: datetime
     supplied_at: datetime | None
     references: dict[str, str]
-    local_command: str
 
 
 class VaultSecretRequestCreated(VaultSecretRequestStatus):
@@ -60,7 +59,7 @@ class VaultSecretRequestCreated(VaultSecretRequestStatus):
 
 class VaultSecretRequestToken(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    token: str = Field(pattern=r"^[A-Za-z0-9_-]{43}$")
+    token: str = Field(pattern=r"^v2_[A-Za-z0-9_-]{43}$")
 
 
 class VaultSecretRequestSupply(VaultSecretRequestToken):

--- a/backend/app/services/runtime_vaults.py
+++ b/backend/app/services/runtime_vaults.py
@@ -113,14 +113,23 @@ async def vault_snapshot_metadata(
     for vault, project_id in rows:
         if vault.id not in inventory:
             inventory[vault.id] = RuntimeVault(
-                id=vault.id, name=vault.name, slug=vault.slug, project_ids=[], revision=""
+                id=vault.id,
+                name=vault.name,
+                slug=vault.slug,
+                project_ids=[],
+                revision="",
+                content_version=vault.runtime_revision,
             )
             revisions[str(vault.id)] = vault.runtime_revision
         inventory[vault.id].project_ids.append(project_id)
     for entry in inventory.values():
         entry.revision = hashlib.sha256(
             json.dumps(
-                [entry.model_dump(mode="json"), revisions[str(entry.id)]], sort_keys=True
+                [
+                    entry.model_dump(mode="json", exclude={"content_version"}),
+                    revisions[str(entry.id)],
+                ],
+                sort_keys=True,
             ).encode()
         ).hexdigest()
     metadata = [entry.model_dump(mode="json") for entry in inventory.values()]

--- a/backend/app/services/vault.py
+++ b/backend/app/services/vault.py
@@ -1,7 +1,10 @@
+from collections.abc import Iterable
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, or_, select, true
+from sqlalchemy import func, or_, select, true, update
+from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -16,6 +19,7 @@ from app.models.vault import (
     VaultItem,
     VaultProjectAttachment,
     VaultProjectSlugAlias,
+    VaultSecretRequest,
 )
 from app.schemas.vault import VaultCreate, VaultItemDelete, VaultItemUpsert
 from app.services.vault_crypto import encrypt
@@ -152,15 +156,38 @@ async def get_vault_for_write(
 
 
 async def load_vault_items_by_name(
-    db: AsyncSession, vault_id: UUID, section: str
+    db: AsyncSession, vault_id: UUID, section: str, *, lock_fields: list[str] | None = None
 ) -> dict[str, VaultItem]:
-    result = await db.execute(
-        select(VaultItem).where(
-            VaultItem.vault_id == vault_id,
-            VaultItem.section == section,
+    query = select(VaultItem).where(VaultItem.vault_id == vault_id, VaultItem.section == section)
+    if lock_fields is not None:
+        query = (
+            query.where(VaultItem.item_name.in_(lock_fields))
+            .order_by(VaultItem.id)
+            .with_for_update(nowait=True)
         )
-    )
+    result = await db.execute(query.execution_options(populate_existing=True))
     return {item.item_name: item for item in result.scalars().all()}
+
+
+async def conflict_vault_requests(
+    db: AsyncSession, vault_id: UUID, section: str, fields: Iterable[str]
+) -> None:
+    """Fence affected capabilities in the same transaction, under the Vault lock."""
+    await db.execute(
+        update(VaultSecretRequest)
+        .where(
+            VaultSecretRequest.vault_id == vault_id,
+            VaultSecretRequest.section == section,
+            VaultSecretRequest.supplied_at.is_(None),
+            VaultSecretRequest.conflicted_at.is_(None),
+            VaultSecretRequest.fields.has_any(array(list(fields))),
+        )
+        .values(
+            conflicted_at=datetime.now(UTC),
+            expires_at=func.least(VaultSecretRequest.expires_at, datetime.now(UTC)),
+        )
+        .execution_options(synchronize_session="fetch")
+    )
 
 
 async def upsert_owned_vault_items(
@@ -179,6 +206,7 @@ async def upsert_owned_vault_items(
         project_id=project_id,
         vault_id=vault_id,
     )
+    await db.execute(select(Vault.id).where(Vault.id == vault.id).with_for_update())
     existing_by_name = await load_vault_items_by_name(db, vault.id, body.section)
 
     for field_name, plaintext in body.fields.items():
@@ -200,6 +228,7 @@ async def upsert_owned_vault_items(
 
     from app.services.runtime_vaults import notify_vault_changed
 
+    await conflict_vault_requests(db, vault.id, body.section, body.fields)
     await notify_vault_changed(db, vault.id, values_changed=True)
     await db.commit()
     return len(body.fields)
@@ -222,6 +251,7 @@ async def delete_owned_vault_items(
         project_id=project_id,
         vault_id=vault_id,
     )
+    await db.execute(select(Vault.id).where(Vault.id == vault.id).with_for_update())
     existing_by_name = await load_vault_items_by_name(db, vault.id, body.section)
     items_to_delete = [
         existing_by_name[field_name]
@@ -240,6 +270,9 @@ async def delete_owned_vault_items(
     if items_to_delete:
         from app.services.runtime_vaults import notify_vault_changed
 
+        await conflict_vault_requests(
+            db, vault.id, body.section, (item.item_name for item in items_to_delete)
+        )
         await notify_vault_changed(db, vault.id, values_changed=True)
     await db.commit()
     return len(items_to_delete)

--- a/backend/app/services/vault_requests.py
+++ b/backend/app/services/vault_requests.py
@@ -1,8 +1,7 @@
-"""Write-only capabilities for exact, initially absent Vault fields."""
+"""Write-only capabilities for exact Vault fields at their requested state."""
 
 import hashlib
 import secrets
-import shlex
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 from urllib.parse import quote
@@ -10,7 +9,7 @@ from uuid import UUID
 
 from fastapi import HTTPException
 from sqlalchemy import select, true
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext
@@ -44,6 +43,23 @@ def unavailable() -> HTTPException:
     return HTTPException(410, "Secret request unavailable")
 
 
+def field_baseline(item: VaultItem | None) -> str | None:
+    if item is None:
+        return None
+    return hashlib.sha256(item.id.bytes + item.nonce + item.encrypted_value).hexdigest()
+
+
+def fields_conflict(row: VaultSecretRequest, existing: dict[str, VaultItem]) -> bool:
+    return (
+        row.conflicted_at is not None
+        or set(row.field_baselines) != set(row.fields)
+        or any(
+            field_baseline(existing.get(field)) != row.field_baselines[field]
+            for field in row.fields
+        )
+    )
+
+
 async def request_context(db: AsyncSession, row: VaultSecretRequest) -> tuple[Vault, Project]:
     context = (
         await db.execute(
@@ -57,6 +73,7 @@ async def request_context(db: AsyncSession, row: VaultSecretRequest) -> tuple[Va
                 Project.archived_at.is_(None),
             )
             .with_for_update()
+            .execution_options(populate_existing=True)
         )
     ).one_or_none()
     if context is None:
@@ -66,14 +83,23 @@ async def request_context(db: AsyncSession, row: VaultSecretRequest) -> tuple[Va
 
 async def describe(db: AsyncSession, row: VaultSecretRequest) -> VaultSecretRequestStatus:
     vault, project = await request_context(db, row)
+    # Owner reads can load the request before waiting on a concurrent Vault writer.
+    # Autoflush preserves this transaction's own successful submission first.
+    await db.execute(
+        select(VaultSecretRequest)
+        .where(VaultSecretRequest.id == row.id)
+        .execution_options(populate_existing=True)
+    )
     existing = await load_vault_items_by_name(db, row.vault_id, row.section)
     state: Literal["pending", "supplied", "expired", "conflict"] = (
         "supplied" if row.supplied_at else "pending"
     )
     if not row.supplied_at:
-        if row.expires_at <= datetime.now(UTC):
+        if row.conflicted_at is not None:
+            state = "conflict"
+        elif row.expires_at <= datetime.now(UTC):
             state = "expired"
-        elif any(field in existing for field in row.fields):
+        elif fields_conflict(row, existing):
             state = "conflict"
     references = {
         field: exact_vault_reference(row.project_id, vault.slug, row.section, field)
@@ -88,16 +114,12 @@ async def describe(db: AsyncSession, row: VaultSecretRequest) -> VaultSecretRequ
         slug=vault.slug,
         section=row.section,
         fields=row.fields,
+        update_fields=[field for field in row.fields if row.field_baselines.get(field) is not None],
+        content_version=vault.runtime_revision,
         status=state,
         expires_at=row.expires_at,
         supplied_at=row.supplied_at,
         references=references,
-        local_command=(
-            f"clawdi vault materialize --vault {row.vault_id} "
-            f"--project {row.project_id}"
-            + (f" --section={shlex.quote(row.section)}" if row.section else "")
-            + " --out <absolute-env-path>"
-        ),
     )
 
 
@@ -140,20 +162,27 @@ async def create_request(
                 VaultSecretRequest.vault_id == vault.id,
                 VaultSecretRequest.section == body.section,
                 VaultSecretRequest.supplied_at.is_(None),
+                VaultSecretRequest.conflicted_at.is_(None),
                 VaultSecretRequest.expires_at > datetime.now(UTC),
             )
         )
     ).all()
-    if any(field in existing for field in body.fields) or any(
-        set(body.fields).intersection(row.fields) for row in pending
-    ):
-        raise HTTPException(409, "Fields already supplied or requested")
-    token = secrets.token_urlsafe(32)
+    for row in pending:
+        if not set(body.fields).intersection(row.fields):
+            continue
+        if not fields_conflict(row, existing):
+            raise HTTPException(409, "Fields already requested")
+        # Retire the conflicted reservation in the successor's transaction.
+        now = datetime.now(UTC)
+        row.conflicted_at = now
+        row.expires_at = min(row.expires_at, now)
+    token = "v2_" + secrets.token_urlsafe(32)
     row = VaultSecretRequest(
         vault_id=vault.id,
         project_id=body.project_id,
         section=body.section,
         fields=body.fields,
+        field_baselines={field: field_baseline(existing.get(field)) for field in body.fields},
         token_hash=hashlib.sha256(token.encode()).hexdigest(),
         expires_at=datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds),
     )
@@ -184,7 +213,7 @@ async def owned_request(
 async def token_request(db: AsyncSession, token: str) -> VaultSecretRequest:
     identity = (
         await db.execute(
-            select(VaultSecretRequest.id, Vault.user_id)
+            select(VaultSecretRequest.id, VaultSecretRequest.vault_id, Vault.user_id)
             .join(Vault, Vault.id == VaultSecretRequest.vault_id)
             .where(VaultSecretRequest.token_hash == hashlib.sha256(token.encode()).hexdigest())
         )
@@ -195,44 +224,69 @@ async def token_request(db: AsyncSession, token: str) -> VaultSecretRequest:
         await assert_user_authority_active(db, identity.user_id)
     except (PrincipalSuspendedError, PrincipalTerminatedError):
         raise unavailable() from None
+    # Every mutation locks Vault before request rows, including durable conflict fences.
+    await db.execute(select(Vault.id).where(Vault.id == identity.vault_id).with_for_update())
     row = await db.scalar(
         select(VaultSecretRequest)
         .where(VaultSecretRequest.id == identity.id)
         .with_for_update()
         .execution_options(populate_existing=True)
     )
-    if row is None or row.supplied_at is not None or row.expires_at <= datetime.now(UTC):
+    if (
+        row is None
+        or row.supplied_at is not None
+        or row.conflicted_at is not None
+        or row.expires_at <= datetime.now(UTC)
+    ):
         raise unavailable()
     return row
 
 
 async def supply(db: AsyncSession, body: VaultSecretRequestSupply) -> VaultSecretRequestStatus:
-    row = await token_request(db, body.token)
-    context = await describe(db, row)
-    if context.status != "pending":
-        raise unavailable()
-    if set(body.fields) != set(row.fields):
-        raise HTTPException(422, "Supply exactly the requested fields")
-    for field in row.fields:
-        ciphertext, nonce = encrypt(body.fields[field])
-        item = VaultItem(
-            vault_id=row.vault_id,
-            section=row.section,
-            item_name=field,
-            encrypted_value=ciphertext,
-            nonce=nonce,
+    try:
+        row = await token_request(db, body.token)
+        context = await describe(db, row)
+        if context.status != "pending":
+            raise unavailable()
+        if set(body.fields) != set(row.fields):
+            raise HTTPException(422, "Supply exactly the requested fields")
+        # Lock only requested rows and recheck their state before changing any value.
+        existing = await load_vault_items_by_name(
+            db, row.vault_id, row.section, lock_fields=row.fields
         )
-        db.add(item)
-        try:
+        if fields_conflict(row, existing):
+            raise unavailable()
+        for field in row.fields:
+            ciphertext, nonce = encrypt(body.fields[field])
+            item = existing.get(field)
+            if item is None:
+                db.add(
+                    VaultItem(
+                        vault_id=row.vault_id,
+                        section=row.section,
+                        item_name=field,
+                        encrypted_value=ciphertext,
+                        nonce=nonce,
+                    )
+                )
+            else:
+                item.encrypted_value = ciphertext
+                item.nonce = nonce
             await db.flush()
-        except IntegrityError:
-            # A regular Vault write may have won the unique field constraint.
-            await db.rollback()
-            raise HTTPException(409, "Requested field already supplied") from None
-    from app.services.runtime_vaults import notify_vault_changed
+        from app.services.runtime_vaults import notify_vault_changed
 
-    await notify_vault_changed(db, row.vault_id, values_changed=True)
-    row.supplied_at = datetime.now(UTC)
-    result = await describe(db, row)
-    await db.commit()
-    return result
+        await notify_vault_changed(db, row.vault_id, values_changed=True)
+        row.supplied_at = datetime.now(UTC)
+        result = await describe(db, row)
+        await db.commit()
+        return result
+    except DBAPIError as exc:
+        await db.rollback()
+        # Conflicting writes abort the entire batch; only a successful commit consumes it.
+        if isinstance(exc, IntegrityError) or getattr(exc.orig, "sqlstate", None) in {
+            "55P03",
+            "40P01",
+            "40001",
+        }:
+            raise HTTPException(409, "Requested fields changed") from None
+        raise

--- a/backend/tests/test_runtime_vaults.py
+++ b/backend/tests/test_runtime_vaults.py
@@ -135,12 +135,16 @@ async def test_snapshot_scope_revision_mutations_and_fanout(
         payload = material.json()
         assert payload["complete"] is True and len(payload["vaults"]) == 1
         assert len(payload["vaults"][0]["project_ids"]) == 2
+        assert payload["vaults"][0]["content_version"] == 2
+        assert first.json()["vaults"][0]["content_version"] == 2
         assert {field["value"] for field in payload["vaults"][0]["fields"]} == {"first", "other"}
         # Legacy Agent-bound keys must neither read linked Projects nor reuse their material ETag.
         auth.api_key.managed = False
         legacy = await client.get("/v1/runtime/vaults")
         assert legacy.status_code == 200
         assert legacy.json()["vaults"][0]["project_ids"] == [str(agents[0].default_project_id)]
+        assert legacy.json()["vaults"][0]["content_version"] == 2
+        assert legacy.json()["vaults"][0]["revision"] != payload["vaults"][0]["revision"]
         assert (
             await client.post(
                 "/v1/runtime/vaults/material", json={"etag": first.headers["etag"], "revisions": {}}
@@ -175,6 +179,7 @@ async def test_snapshot_scope_revision_mutations_and_fanout(
                 json={"etag": etag, "revisions": {vault_id: payload["vaults"][0]["revision"]}},
             )
             assert reuse.status_code == 200 and reuse.json()["vaults"][0]["fields"] is None
+            assert reuse.json()["vaults"][0]["content_version"] == 2
             assert not any("vault_items" in statement for statement in sql)
             print(
                 f"runtime-vault fixture conditional + reuse: {len(sql)} snapshot DB statements; "
@@ -210,6 +215,7 @@ async def test_snapshot_scope_revision_mutations_and_fanout(
         )
         updated = await client.get("/v1/runtime/vaults", headers={"If-None-Match": etag})
         assert updated.status_code == 200 and updated.headers["etag"] != etag
+        assert updated.json()["vaults"][0]["content_version"] == 3
         auth.api_key = None
         assert (
             await client.request(

--- a/backend/tests/test_vault_requests.py
+++ b/backend/tests/test_vault_requests.py
@@ -1,12 +1,11 @@
 import asyncio
 import hashlib
-import shlex
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.auth import AuthContext
@@ -16,7 +15,7 @@ from app.schemas.vault_requests import VaultSecretRequestSupply
 from app.services.vault_requests import owned_request, supply
 
 
-async def make_request(client, *, fields=None, section=""):
+async def make_request(client, *, fields=None, section="", existing=None):
     vault = (await client.post("/v1/vault", json={"slug": "requested", "name": "Requested"})).json()
     detail = (
         await client.get("/v1/vault/detail", params={"slug": "requested", "vault_id": vault["id"]})
@@ -28,6 +27,11 @@ async def make_request(client, *, fields=None, section=""):
         "fields": fields or ["API_KEY", "API_SECRET"],
         "section": section,
     }
+    if existing:
+        response = await client.put(
+            "/v1/vault/requested/items", json={"section": section, "fields": existing}
+        )
+        assert response.status_code == 200, response.text
     response = await client.post("/v1/vault/requests", json=body)
     assert response.status_code == 200, response.text
     return body, response.json()
@@ -36,11 +40,11 @@ async def make_request(client, *, fields=None, section=""):
 @pytest.mark.asyncio
 async def test_capability_atomic_fields_replay_and_plaintext_boundary(cli_client, db_session):
     body, created = await make_request(cli_client)
-    assert not any(arg.startswith("--section") for arg in shlex.split(created["local_command"]))
     token = created["url"].split("#")[1]
     row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
     assert row.token_hash == hashlib.sha256(token.encode()).hexdigest()
     assert token not in row.token_hash
+    assert row.field_baselines == {"API_KEY": None, "API_SECRET": None}
     assert (await cli_client.get("/v1/vault/requested/items")).json() == {}
     assert (await cli_client.post("/v1/vault/requests", json=body)).status_code == 409
     for prefix in ("/v1", "/api"):
@@ -66,7 +70,9 @@ async def test_capability_atomic_fields_replay_and_plaintext_boundary(cli_client
         assert (
             await cli_client.post(f"/v1/vault/requests/{action}", json=payload)
         ).status_code == 410
-    assert (await cli_client.post("/v1/vault/requests", json=body)).status_code == 409
+    update = await cli_client.post("/v1/vault/requests", json=body)
+    assert update.status_code == 200, update.text
+    assert update.json()["update_fields"] == body["fields"]
     material = await cli_client.post(
         "/v1/vault/material", json={"vault_id": body["vault_id"], "project_id": body["project_id"]}
     )
@@ -80,7 +86,7 @@ async def test_capability_atomic_fields_replay_and_plaintext_boundary(cli_client
 async def test_expired_invalid_detached_and_intervening_write(client, db_session):
     body, created = await make_request(client, fields=["TOKEN"])
     token = created["url"].split("#")[1]
-    invalid = await client.post("/v1/vault/requests/inspect", json={"token": "a" * 43})
+    invalid = await client.post("/v1/vault/requests/inspect", json={"token": "v2_" + "a" * 43})
     assert invalid.status_code == 410
     row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
     row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -339,36 +345,437 @@ async def test_bound_request_listing_defaults_to_its_project(cli_client, db_sess
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("section", ["production", "-production"])
-async def test_request_command_selects_only_its_named_section(cli_client, section):
-    body, created = await make_request(cli_client, fields=["TOKEN"], section=section)
+async def test_mixed_request_preserves_old_values_and_exposes_only_update_names(
+    cli_client, db_session, seed_user
+):
+    body, created = await make_request(
+        cli_client, fields=["NEW", "TOKEN"], existing={"TOKEN": "old-secret"}, section="live"
+    )
+    token = created["url"].split("#")[1]
+    row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
+    baseline = row.field_baselines["TOKEN"]
+    assert isinstance(baseline, str)
+    assert row.field_baselines["NEW"] is None
+    assert created["content_version"] == 1
+    target = {"vault_id": body["vault_id"], "project_id": body["project_id"], "section": "live"}
+    assert (await cli_client.post("/v1/vault/material", json=target)).json()["values"] == {
+        "TOKEN": "old-secret"
+    }
+    for response in (
+        await cli_client.post("/v1/vault/requests/inspect", json={"token": token}),
+        await cli_client.get(f"/v1/vault/requests/{created['id']}"),
+    ):
+        assert response.json()["update_fields"] == ["TOKEN"]
+        assert baseline not in response.text and "old-secret" not in response.text
+        assert "field_baselines" not in response.text
+    mcp = await _tool_vault_request_status(
+        {"request_id": created["id"]}, auth=AuthContext(user=seed_user), db=db_session
+    )
+    assert baseline not in str(mcp) and "old-secret" not in str(mcp)
+    # Neither other fields in this section nor the same name in another section invalidate it.
+    for section, fields in (("live", {"OTHER": "keep"}), ("other", {"TOKEN": "elsewhere"})):
+        assert (
+            await cli_client.put(
+                "/v1/vault/requested/items", json={"section": section, "fields": fields}
+            )
+        ).status_code == 200
+    response = await cli_client.post(
+        "/api/vault/requests/supply",
+        json={"token": token, "fields": {"NEW": "added", "TOKEN": "replacement"}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "supplied"
+    assert response.json()["content_version"] == 4
+    assert (await cli_client.post("/v1/vault/material", json=target)).json()["values"] == {
+        "NEW": "added",
+        "TOKEN": "replacement",
+        "OTHER": "keep",
+    }
+    # Status reports current content, including writes after this request was supplied.
+    await cli_client.put(
+        "/v1/vault/requested/items", json={"section": "live", "fields": {"OTHER": "later"}}
+    )
+    assert (await cli_client.get(f"/v1/vault/requests/{created['id']}")).json()[
+        "content_version"
+    ] == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["update", "delete", "recreate", "new", "incomplete"])
+async def test_mixed_request_conflicts_atomically(cli_client, db_session, change):
+    body, created = await make_request(
+        cli_client, fields=["NEW", "TOKEN"], existing={"TOKEN": "old"}
+    )
+    row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
+    if change == "incomplete":
+        row.field_baselines = {"TOKEN": row.field_baselines["TOKEN"]}
+        await db_session.commit()
+    if change in ("delete", "recreate"):
+        assert (
+            await cli_client.request(
+                "DELETE", "/v1/vault/requested/items", json={"fields": ["TOKEN"]}
+            )
+        ).status_code == 200
+    if change in ("update", "recreate", "new"):
+        field = "NEW" if change == "new" else "TOKEN"
+        # Re-encrypting even the same plaintext must invalidate the baseline.
+        assert (
+            await cli_client.put("/v1/vault/requested/items", json={"fields": {field: "old"}})
+        ).status_code == 200
+    target = {"vault_id": body["vault_id"], "project_id": body["project_id"]}
+    before = (await cli_client.post("/v1/vault/material", json=target)).json()["values"]
+    response = await cli_client.post(
+        "/v1/vault/requests/supply",
+        json={"token": created["url"].split("#")[1], "fields": {"NEW": "wrong", "TOKEN": "wrong"}},
+    )
+    assert response.status_code == 410, response.text
+    assert (await cli_client.get(f"/v1/vault/requests/{created['id']}")).json()[
+        "status"
+    ] == "conflict"
+    assert (await cli_client.post("/v1/vault/material", json=target)).json()["values"] == before
+    await db_session.refresh(row)
+    assert row.supplied_at is None
+
+
+@pytest.mark.asyncio
+async def test_request_uses_normalized_vault_names_for_existing_and_new_keys(cli_client):
+    body, created = await make_request(
+        cli_client,
+        fields=[" api-key ", "api.token", "new.key"],
+        existing={"api-key": "old-key", "api.token": "old-token"},
+    )
+    assert created["fields"] == ["api-key", "api.token", "new.key"]
+    assert created["update_fields"] == ["api-key", "api.token"]
+    assert (await cli_client.post("/v1/vault/requests", json=body)).status_code == 409
+    for fields in (
+        ["api-key", " api-key "],
+        ["unsupported/key"],
+        [" "],
+        ["x" * 201],
+        [f"key-{index}" for index in range(33)],
+    ):
+        invalid = await cli_client.post("/v1/vault/requests", json={**body, "fields": fields})
+        assert invalid.status_code == 422, invalid.text
+
+    async def resolve_fields(expected):
+        for field, value in expected.items():
+            resolved = await cli_client.post(
+                "/v1/vault/resolve",
+                params={
+                    "vault_slug": body["slug"],
+                    "project_id": body["project_id"],
+                    "field": field,
+                },
+            )
+            assert resolved.status_code == 200, resolved.text
+            assert resolved.json()["value"] == value
+
+    await resolve_fields({"api-key": "old-key", "api.token": "old-token"})
+    values = {"api-key": "new-key", "api.token": "new-token", "new.key": "new-value"}
+    response = await cli_client.post(
+        "/v1/vault/requests/supply",
+        json={"token": created["url"].split("#")[1], "fields": values},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "supplied"
+    await resolve_fields(values)
+
+
+async def wait_for_database_lock(engine, pid):
+    async with engine.connect() as observer:
+        async with asyncio.timeout(5):
+            while not await observer.scalar(
+                text("SELECT cardinality(pg_blocking_pids(:pid)) > 0"), {"pid": pid}
+            ):
+                await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+@pytest.mark.parametrize("operation", ["upsert", "delete", "copy"])
+@pytest.mark.parametrize("supply_first", [False, True])
+async def test_request_serializes_with_vault_mutations(
+    cli_client, db_session, engine, seed_user, monkeypatch, operation, supply_first
+):
+    from app.routes.vault import copy_vault_items
+    from app.schemas.vault import VaultItemDelete, VaultItemsCopy, VaultItemUpsert
+    from app.services import vault_requests
+    from app.services.vault import delete_owned_vault_items, upsert_owned_vault_items
+
+    body, created = await make_request(
+        cli_client, fields=["NEW", "TOKEN"], existing={"TOKEN": "old"}
+    )
+    vault_id = uuid.UUID(body["vault_id"])
+    auth = AuthContext(user=seed_user)
+    source_id = None
+    if operation == "copy":
+        source = (
+            await cli_client.post("/v1/vault", json={"slug": "source", "name": "Source"})
+        ).json()
+        source_id = uuid.UUID(source["id"])
+        await cli_client.put("/v1/vault/source/items", json={"fields": {"TOKEN": "operator"}})
+    # Release the fixture connection before independent transactions contend.
+    await db_session.commit()
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def mutate(session):
+        args = {"project_id": uuid.UUID(body["project_id"]), "vault_id": vault_id}
+        if operation == "upsert":
+            await upsert_owned_vault_items(
+                session, auth, "requested", VaultItemUpsert(fields={"TOKEN": "operator"}), **args
+            )
+        elif operation == "delete":
+            await delete_owned_vault_items(
+                session,
+                auth,
+                "requested",
+                VaultItemDelete(fields=["TOKEN"]),
+                global_delete=False,
+                **args,
+            )
+        else:
+            await copy_vault_items(
+                "source",
+                VaultItemsCopy(target_slug="requested", fields=["TOKEN"]),
+                project_id=None,
+                vault_id=source_id,
+                target_vault_id=vault_id,
+                auth=auth,
+                db=session,
+            )
+
+    async def redeem(session):
+        try:
+            await supply(
+                session,
+                VaultSecretRequestSupply(
+                    token=created["url"].split("#")[1],
+                    fields={"NEW": "supplied", "TOKEN": "supplied"},
+                ),
+            )
+            return 200
+        except HTTPException as exc:
+            await session.rollback()
+            return exc.status_code
+
+    tasks = []
+    try:
+        async with sessions() as first, sessions() as second:
+            pid = await second.scalar(text("SELECT pg_backend_pid()"))
+            if supply_first:
+                locked, release = asyncio.Event(), asyncio.Event()
+                original = vault_requests.describe
+
+                async def hold_supply(session, row):
+                    result = await original(session, row)
+                    if session is first and not row.supplied_at:
+                        locked.set()
+                        await release.wait()
+                    return result
+
+                monkeypatch.setattr(vault_requests, "describe", hold_supply)
+                winner = asyncio.create_task(redeem(first))
+                tasks.append(winner)
+                await asyncio.wait_for(locked.wait(), 5)
+                waiter = asyncio.create_task(mutate(second))
+                tasks.append(waiter)
+                await wait_for_database_lock(engine, pid)
+                release.set()
+                assert await asyncio.wait_for(winner, 5) == 200
+                await asyncio.wait_for(waiter, 5)
+            else:
+                await first.execute(select(Vault.id).where(Vault.id == vault_id).with_for_update())
+                waiter = asyncio.create_task(redeem(second))
+                tasks.append(waiter)
+                await wait_for_database_lock(engine, pid)
+                await mutate(first)
+                assert await asyncio.wait_for(waiter, 5) == 410
+        async with sessions() as check:
+            row = await check.get(VaultSecretRequest, uuid.UUID(created["id"]))
+            assert (row.supplied_at is not None) == supply_first
+            items = (
+                await check.scalars(select(VaultItem).where(VaultItem.vault_id == vault_id))
+            ).all()
+            from app.services.vault_crypto import decrypt
+
+            values = {item.item_name: decrypt(item.encrypted_value, item.nonce) for item in items}
+            assert values == {
+                **({"TOKEN": "operator"} if operation != "delete" else {}),
+                **({"NEW": "supplied"} if supply_first else {}),
+            }
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await db_session.rollback()
+        await db_session.execute(
+            delete(Vault).where(Vault.id.in_([vault_id, *([source_id] if source_id else [])]))
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_conflicted_request_can_be_replaced_without_reviving_retired_capability(
+    cli_client, db_session
+):
+    body, created = await make_request(cli_client, fields=["TOKEN", "NEW"])
+    assert (await cli_client.post("/v1/vault/requests", json=body)).status_code == 409
+    await cli_client.put("/v1/vault/requested/items", json={"fields": {"TOKEN": "operator"}})
+    assert (await cli_client.get(f"/v1/vault/requests/{created['id']}")).json()[
+        "status"
+    ] == "conflict"
+    successor = await cli_client.post("/v1/vault/requests", json=body)
+    assert successor.status_code == 200, successor.text
+    assert successor.json()["update_fields"] == ["TOKEN"]
+    assert (await cli_client.post("/v1/vault/requests", json=body)).status_code == 409
+    # Restore the predecessor's absent baseline. Neither retired link may revive.
+    await cli_client.request("DELETE", "/v1/vault/requested/items", json={"fields": ["TOKEN"]})
+    latest = await cli_client.post("/v1/vault/requests", json=body)
+    assert latest.status_code == 200, latest.text
+    assert latest.json()["update_fields"] == []
+    for obsolete in (created, successor.json()):
+        for action in ("inspect", "supply"):
+            payload = {"token": obsolete["url"].split("#")[1]}
+            if action == "supply":
+                payload["fields"] = {"TOKEN": "obsolete", "NEW": "obsolete"}
+            assert (
+                await cli_client.post(f"/v1/vault/requests/{action}", json=payload)
+            ).status_code == 410
+        row = await db_session.get(
+            VaultSecretRequest, uuid.UUID(obsolete["id"]), populate_existing=True
+        )
+        assert row.conflicted_at is not None and row.supplied_at is None
     supplied = await cli_client.post(
         "/v1/vault/requests/supply",
         json={
-            "token": created["url"].split("#")[1],
-            "fields": {"TOKEN": "requested-value"},
+            "token": latest.json()["url"].split("#")[1],
+            "fields": {"TOKEN": "current", "NEW": "current"},
         },
     )
     assert supplied.status_code == 200, supplied.text
-    await cli_client.put(
-        "/v1/vault/requested/items",
-        json={
-            "section": "other",
-            "fields": {"TOKEN": "unrelated-value", "OTHER": "keep"},
-        },
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("recreate", [False, True])
+async def test_baseline_detects_ciphertext_and_identity_changes(cli_client, db_session, recreate):
+    _, created = await make_request(cli_client, fields=["NEW", "TOKEN"], existing={"TOKEN": "old"})
+    item = await db_session.scalar(
+        select(VaultItem).where(VaultItem.vault_id == uuid.UUID(created["vault_id"]))
     )
-    status = (await cli_client.get(f"/v1/vault/requests/{created['id']}")).json()
-    for command in (created["local_command"], status["local_command"]):
-        args = shlex.split(command)
-        selected_sections = [arg.split("=", 1)[1] for arg in args if arg.startswith("--section=")]
-        assert selected_sections == [section]
-        material = await cli_client.post(
-            "/v1/vault/material",
-            json={
-                "vault_id": body["vault_id"],
-                "project_id": body["project_id"],
-                "section": selected_sections[0],
-            },
+    if recreate:
+        # Same ciphertext with a different row identity is still a different incarnation.
+        item.id = uuid.uuid4()
+    else:
+        from app.services.vault_crypto import encrypt
+
+        item.encrypted_value, item.nonce = encrypt("old")
+    await db_session.commit()
+    response = await cli_client.post(
+        "/v1/vault/requests/supply",
+        json={"token": created["url"].split("#")[1], "fields": {"TOKEN": "wrong", "NEW": "wrong"}},
+    )
+    assert response.status_code == 410
+    assert (await cli_client.get(f"/v1/vault/requests/{created['id']}")).json()[
+        "status"
+    ] == "conflict"
+
+
+@pytest.mark.asyncio
+async def test_request_migration_expires_pending_and_requires_explicit_snapshots(engine):
+    import importlib.util
+    from pathlib import Path
+
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    path = (
+        Path(__file__).parents[1] / "alembic/versions/e7b4c2a9d610_vault_request_field_baselines.py"
+    )
+    spec = importlib.util.spec_from_file_location("request_baselines", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    def verify(connection):
+        from sqlalchemy.exc import IntegrityError
+
+        connection.execute(
+            text(
+                "CREATE TEMP TABLE vault_secret_requests (id integer, "
+                "expires_at timestamptz DEFAULT now() + interval '1 hour', "
+                "supplied_at timestamptz) ON COMMIT DROP"
+            )
         )
-        assert material.status_code == 200, material.text
-        assert material.json()["values"] == {"TOKEN": "requested-value"}
+        connection.execute(text("INSERT INTO vault_secret_requests (id) VALUES (1)"))
+        connection.execute(
+            text("INSERT INTO vault_secret_requests (id, supplied_at) VALUES (2, now())")
+        )
+        saved = connection.execute(
+            text("SELECT expires_at, supplied_at FROM vault_secret_requests WHERE id = 2")
+        ).one()
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+        assert connection.execute(
+            text(
+                "SELECT id, field_baselines, expires_at > now() "
+                "FROM vault_secret_requests ORDER BY id"
+            )
+        ).all() == [(1, {}, False), (2, {}, True)]
+        # Inserts must provide snapshots: neither omission nor null has a fallback.
+        for statement in (
+            "INSERT INTO vault_secret_requests (id) VALUES (3)",
+            "INSERT INTO vault_secret_requests (id, field_baselines) VALUES (3, NULL)",
+        ):
+            with pytest.raises(IntegrityError), connection.begin_nested():
+                connection.execute(text(statement))
+        connection.execute(
+            text(
+                "INSERT INTO vault_secret_requests (id, field_baselines) "
+                "VALUES (3, CAST(:baseline AS jsonb))"
+            ),
+            {"baseline": '{"NEW":null}'},
+        )
+        assert connection.execute(
+            text("SELECT expires_at > now() FROM vault_secret_requests WHERE id = 3")
+        ).scalar_one()
+        migration.downgrade()
+        assert connection.execute(
+            text("SELECT id, expires_at > now() FROM vault_secret_requests ORDER BY id")
+        ).all() == [(1, False), (2, True), (3, False)]
+        assert (
+            connection.execute(
+                text("SELECT expires_at, supplied_at FROM vault_secret_requests WHERE id = 2")
+            ).one()
+            == saved
+        )
+
+    async with engine.begin() as connection:
+        await connection.run_sync(verify)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_status_refreshes_terminal_state_after_concurrent_write(
+    cli_client, db_session, engine
+):
+    from app.services.vault_requests import describe
+
+    _, created = await make_request(cli_client, fields=["TOKEN"])
+    vault_id = uuid.UUID(created["vault_id"])
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessions() as reader:
+            row = await reader.get(VaultSecretRequest, uuid.UUID(created["id"]))
+            assert row.conflicted_at is None
+            await cli_client.put(
+                "/v1/vault/requested/items", json={"fields": {"TOKEN": "intervening"}}
+            )
+            await cli_client.request(
+                "DELETE", "/v1/vault/requested/items", json={"fields": ["TOKEN"]}
+            )
+            assert (await describe(reader, row)).status == "conflict"
+    finally:
+        await db_session.rollback()
+        await db_session.execute(delete(Vault).where(Vault.id == vault_id))
+        await db_session.commit()

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.75",
+      "version": "0.14.76",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.74",
+      "version": "0.14.75",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -49,7 +49,8 @@ creation deadline discards late results from the synchronous SDK worker, which
 cannot be forcibly cancelled. Authentication precedes forwarding and retains its
 existing short network budgets.
 
-Discovery and other MCP methods retain a 30-second forwarding deadline. Backend
+The stdio proxy gives discovery and other MCP methods a 30-second forwarding
+deadline; this is not a server-side cap for every remote MCP endpoint. Backend
 Composio discovery has a 25-second total deadline, including cold session creation
 and any reload after invalidation. Listing drains all cursor pages in a single
 initialized client within 15 seconds and at most 100 pages, leaving 5 seconds
@@ -60,9 +61,28 @@ result metadata, since page metadata has no standardized merge semantics.
 
 The locked JavaScript MCP SDK 1.30 defaults **outgoing client requests** to 60
 seconds; this does not impose a timer on incoming stdio server handlers. MCP
-clients invoking slow tools must set their own request timeout to at least
-420 seconds (for SDK clients, pass `{ timeout: 420_000 }` as the `callTool`
-request options). Clawdi cannot override another client's deadline.
+clients invoking slow tools through the forwarding path described above must
+set their own request timeout to at least 420 seconds (for SDK clients, pass
+`{ timeout: 420_000 }` as the `callTool` request options). Clawdi cannot override
+another client's deadline.
+
+Managed OpenClaw MCP entries explicitly set only `requestTimeoutMs: 420000`,
+using that slow-tool caller budget. OpenClaw 2026.9.3 uses the explicit request
+budget for both the complete paginated tool catalog and subsequent requests;
+without it, catalog discovery defaults to 1500 ms even though requests default to 60
+seconds. There is no independent catalog timeout setting, so an unresponsive
+catalog can wait up to 420 seconds. Initialization retains the native default
+(30 seconds in OpenClaw 2026.9.3); no connection timeout override is written.
+Hermes keeps its existing native settings.
+
+The official contracts are [catalog timeout selection](https://github.com/openclaw/openclaw/blob/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7/src/agents/agent-bundle-mcp-runtime.ts#L156-L177),
+[transport defaults](https://github.com/openclaw/openclaw/blob/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7/src/agents/mcp-transport-config.ts#L62-L104),
+and [CLI seconds-to-milliseconds configuration](https://github.com/openclaw/openclaw/blob/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7/src/cli/mcp-cli.ts#L1275-L1293).
+The request timeout field is also supported by the audited July 1
+[schema](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/config/zod-schema.ts#L386-L409)
+and [catalog override](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/agents/agent-bundle-mcp-runtime.ts#L285-L305).
+That older runtime applies the catalog timeout per page; 2026.9.3 bounds the
+complete pagination operation.
 
 Timeout or transport loss does not confirm cancellation or failure of an external
 side effect. The proxy never automatically retries tool calls. Check the provider
@@ -595,19 +615,31 @@ task authorizes creation. Ask for the exact target when ambiguity affects purpos
 access. Linked Vaults may be synced read-only; never request/upsert outside the write
 boundary or create duplicates to sidestep access.
 
-Use MCP `vault_request_create` to reserve up to 32 missing environment fields in one
-owned Vault/Project attachment. It returns a URL with a 256-bit capability in its
-fragment. Show that exact URL to the user. The public form supplies only the requested
-names, in one transaction; viewing it does not redeem it. Tokens are hashed at rest,
-expire after one hour by default (five minutes to one day configurable), and cannot
-read or replace supplied secrets. `vault_request_status` returns metadata and exact
-references. MCP request metadata omits legacy CLI commands, including `vault_get` recent
-requests; REST retains them for compatibility. Pending requests appear separately on the
-Vault detail page and are never returned as empty secret values. Use a fresh request for remaining missing fields after
-expiry; existing pending requests and supplied fields are rejected.
+Use MCP `vault_request_create` to request up to 32 new or updated Vault fields in one
+owned Vault/Project attachment. Names follow ordinary Vault validation, including dots
+and hyphens; duplicates after trimming are rejected. Show the returned URL unchanged.
+Its fragment contains a `v2_` capability with 256 random bits, hashed at rest and valid
+for one hour by default (five minutes to one day configurable). Viewing does not consume
+it; saving exactly the requested fields in one successful transaction does. The page
+marks updates without showing existing values.
+
+Changes to any requested field conflict with the entire batch; unrelated edits do not.
+A conflicted request can be replaced immediately, while true pending overlap is rejected.
+`vault_request_status` and recent requests return metadata and exact references, never
+secret values or local commands. After expiry or conflict, reassess the authorized fields
+before requesting again; never delete a key to request an update.
+
+The request migration expires every pre-cutover pending link, preserving saved values and
+history. Request snapshots are mandatory on new inserts. Deploy the current backend and
+page together; users with expired links need a fresh request.
 
 After supply in a managed runtime or configured connected macOS/Linux Agent, verify `vault_request_status` and inspect only
-`.clawdi/vaults/index.json` under the native workspace. Existing runtime watch delivers readable
+`.clawdi/vaults/index.json` under the native workspace. Match the Vault ID, section and field
+names, and require local `content_version >= status.content_version` before claiming delivery.
+The API requires `content_version`. Incomplete owned cache metadata must refresh before
+delivery can be confirmed, even when the field names already exist.
+This is the existing Vault content counter; opaque `revision` remains a cache/visibility
+identity and must not be compared across Agents. Existing runtime watch delivers readable
 Workspace/linked-Project Vaults into separate generated section JSON files. Load the
 selected file inside the authorized process/SDK without exposing values to model context
 just to save them. Do not invoke the tenant CLI or edit generated files. See
@@ -616,7 +648,7 @@ fallback and isolated verification. Connected setup uses `--agent <type> --vault
 the existing Agent registration; `--yes` alone never guesses a target. See the
 [skill workflow](../packages/cli/skills/clawdi/SKILL.md#save-and-refresh-credentials-locally).
 
-The CLI remains an optional compatible adapter for an explicit absolute local file:
+The standalone CLI also supports explicit absolute local dotenv files:
 
 ```bash
 clawdi vault materialize --vault <vault-uuid> --project <project-uuid> --out /absolute/project/.env

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1408,6 +1408,17 @@ and let OpenClaw reuse its own persisted device credential, without requesting
 or replaying a bootstrap token. This requires a new native connection after
 the old iframe is retired; it is distinct from retaining the already-authenticated
 connection across sections. The marker does not acknowledge authentication.
+When Hosted advertises an applied `browser_session_url`, Clawdi first establishes
+its independent runtime-origin owner grant and verifies cookie delivery with a
+HEAD request. The first launch still uses the official handoff fragment. On a
+later clean-URL visit, a supporting official UI can recover a missing device
+credential through its same-origin browser-bootstrap endpoint. The official UI
+performs the real owner handshake in that same document; the parent does not
+create a parallel device or infer authentication from load. Endpoints without
+the advertised route retain the existing handoff and Reconnect behavior.
+The tested official UI does not automatically recover an expired/consumed
+initial bootstrap or a revoked device token in the current document; those
+errors still require Reconnect.
 Storage failure falls back to requesting a handoff; Reconnect clears the hint.
 New-window access stays disabled until the current iframe loads; it then opens
 the clean endpoint for native access or the exact reusable legacy `#token=` URL.
@@ -1431,6 +1442,18 @@ inventory/credential transport and uses a local TLS ingress that permits iframe
 embedding; it does not replace official UI code or native WebSocket auth.
 This verifies application behavior, not a deployed ingress configuration or
 authentication readiness from an iframe load event.
+
+For the paired protected issuer and same-site browser cookie path, point the
+same harness at the matching Hosted source checkout:
+
+```bash
+CLAWDI_OPENCLAW_HOSTED_SOURCE=/path/to/clawdi-hosted scripts/test-openclaw-native.sh
+```
+
+Done: real Traefik, the Hosted grant handler, Chromium, and official OpenClaw
+recover a missing native credential before Console reveal, retain the recovered
+connection across the reveal, and reuse the device credential on reload. Clerk
+identity and persistence seams are synthetic; no live tenant is involved.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -2090,8 +2090,12 @@ explicitly linked, readable user Projects. Legacy Agent-bound keys remain limite
 own Workspace, including on the batch material endpoint. Vault IDs deduplicate multiple attachments. Each Vault/section gets a
 JSON object preserving exact field names; section identity is SHA-256 of its name because
 the database has no section ID. Renaming a section replaces its file. `index.json` contains
-only IDs, names, references and filenames; invalid environment names are marked with a
-null `env_name`, not normalized into colliding names. Pending supply requests are not items.
+only metadata: IDs, names, references, filenames, opaque `revision`, and required
+`content_version` from the existing Vault content counter. After a supplied request, match
+Vault/section/fields and require local `content_version >= status.content_version`. Network snapshots without a valid counter
+are rejected. Incomplete owned cache metadata refreshes from the current API, reusing
+intact sections without rewriting secret JSON. Invalid environment names have a null `env_name`,
+not normalized colliding names. Pending supply requests are not items.
 
 The native workspace's `.clawdi/vaults` directory is 0700 and its files 0600, owned by the runtime
 user. Hosted runtime pins directory ancestors without following symlinks and performs IO

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.74",
+	"version": "0.14.75",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.75",
+	"version": "0.14.76",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -44,12 +44,23 @@ It preserves metadata; find the exact ID before changing it.
 - Use `session_list` to browse recent sessions or filter by time, Agent, or Project.
 - Use `session_search` to find past agent conversations by keyword and obtain session UUIDs.
 - Use `session_get` to read a session by UUID or Clawdi share URL.
+- Use `session_share_create` to publish an immutable snapshot only when the user explicitly asks
+  to share a Session, part of it, or one Assistant response.
+- Use `session_share_list` to inspect active links and obtain their exact IDs and kinds.
+- Use `session_share_revoke` to stop sharing one exact link only when the user asks.
 
 Call `session_get` when the user provides a Clawdi share URL or session UUID and wants its
 contents. For a request to open a specific unnamed past conversation, use `session_search`
 to find the UUID and then read the selected match.
 
 Do NOT call WebFetch on `cloud.clawdi.ai/s/...` URLs — `session_get` is the right tool and avoids the WebFetch permission prompt.
+
+For `session_share_create`, omit `position` for the full `session` scope. For `through` or
+`response`, use the stable message `position` returned by `session_get` or `session_search`,
+never a filtered array index; `response` must target an Assistant message. Public snapshots
+include only the existing safe user/Assistant projection, never reasoning, system/developer
+messages, hidden events, or tool activity. Before revoking, use `session_share_list` unless the
+user already supplied the exact `share_id` and `kind`; never infer a link ID or kind.
 
 CLI fallback: `clawdi session search "query" --json`, then `clawdi session read <cloud-session-id> --json`.
 `session list` is local; `session export <cloud-session-id>` exports owner Markdown without

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -128,18 +128,22 @@ their bound Project, and field deletion is rejected when a Vault is attached to 
 Projects. Whole-Vault deletion, attach/detach, and credential profiles remain
 foreground operator workflows; never bypass that boundary through raw HTTP or daemon RPC.
 
-### Request missing credentials
+### Request new or updated credentials
 
 Use `vault_request_create` with exact `project_id`, `vault_id`, canonical `slug`, optional
-`section`, and a batch of environment field names in `fields`. A Vault is a key bundle:
-request related keys together under one link. Supplied or already-pending fields are rejected.
+`section`, and a batch of Vault field names in `fields`. A Vault is a key bundle:
+request related new and existing keys together under one link. Include existing keys only
+when the user authorized updating them; do not delete them first. Existing Vault values
+remain unchanged until successful submission and are never shown or prefilled. Overlapping pending requests
+are rejected; a change to any requested field conflicts with the entire batch.
 Show the returned `url` unchanged to the user; do not ask them to paste secrets into chat.
 Opening the link does not consume it. Saving all requested fields consumes it once.
 
 Check `vault_request_status` with its `request_id` after the user finishes. `pending` is not
 a secret value; `supplied` means the exact references are ready. On `expired` or `conflict`,
-inspect the Vault and request only still-missing fields; never replace an existing value to
-retry. If creation times out, use `vault_get` to find recent request IDs before retrying.
+inspect current Vault metadata and reassess the authorized fields before creating a fresh
+request; do not blindly retry an overwrite. If creation times out, use `vault_get` to find
+recent request IDs before retrying.
 If submission times out, inspect status before repeating a mutation.
 
 ### Save and refresh credentials locally
@@ -157,9 +161,12 @@ edit, move or commit them. Hosted agents must not invoke/install the tenant Claw
 Connected operators configure delivery with `clawdi setup --agent <type> --vault-workspace <path>`;
 that changes only the Vault destination, never every repository scanned by the daemon.
 
-After a credential request is supplied, wait for the expected fields in index metadata before
-claiming delivery. If delivery is unavailable, report that state and any missing workspace
-binding instead of inventing a destination. Preserve unrelated local configuration.
+After `vault_request_status` reports `supplied`, match its Vault ID, section and field names
+in the index and require the local Vault `content_version` to be at least the status
+`content_version`. The API requires this counter; existing names alone do not prove delivery.
+If the owned index is incomplete or behind, wait for runtime reconciliation and report
+unverified delivery. Do not read secret values to check freshness. Report missing workspace bindings instead of inventing a
+destination. Preserve unrelated local configuration.
 
 ### Optional CLI environment files
 

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -11,7 +11,8 @@ Use Clawdi Cloud tools through the `clawdi` MCP server. Treat the live tool sche
 
 Third-party tool routing below applies unchanged in Hosted. Do not inspect, run, or suggest
 Clawdi host-management commands such as `clawdi setup`, `clawdi wallet`, `clawdi vault`, or
-`clawdi ai-provider`.
+`clawdi ai-provider`. Do not use any `clawdi` CLI command as a Cloud capability fallback;
+use the Clawdi MCP tools exposed to the Hosted runtime.
 
 ## Context Routing
 
@@ -46,10 +47,22 @@ already supplied the exact memory ID; never infer which stored item to mutate.
 - Use `session_list` to browse recent sessions or filter by time, Agent, or Project.
 - Use `session_search` to find past agent conversations by keyword and obtain session UUIDs.
 - Use `session_get` to read a session by UUID or Clawdi share URL.
+- Use `session_share_create` to publish an immutable snapshot only when the user explicitly asks
+  to share a Session, part of it, or one Assistant response.
+- Use `session_share_list` to inspect active links and obtain their exact IDs and kinds.
+- Use `session_share_revoke` to stop sharing one exact link only when the user asks.
 
 Call `session_get` when the user provides a Clawdi share URL or session UUID and wants its
 contents. Use `session_search` to locate a requested unnamed conversation. Do not use a
 generic web fetcher for Clawdi share URLs.
+
+For `session_share_create`, omit `position` for the full `session` scope. For `through` or
+`response`, use the stable message `position` returned by `session_get` or `session_search`,
+never a filtered array index; `response` must target an Assistant message. Public snapshots
+include only the existing safe user/Assistant projection, never reasoning, system/developer
+messages, hidden events, or tool activity. Before revoking, use `session_share_list` unless the
+user already supplied the exact `share_id` and `kind`; never infer a link ID or kind. Hosted
+Session sharing uses these MCP tools only, not CLI commands.
 
 ## Projects
 

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -113,18 +113,22 @@ own Workspace (the runtime-bound Project). Field deletion is rejected when a Vau
 attached to multiple Projects. Whole-Vault deletion, attach/detach, and credential profiles remain
 unavailable through Agent MCP; do not bypass that boundary through raw HTTP.
 
-### Request missing credentials
+### Request new or updated credentials
 
 Use `vault_request_create` with exact `project_id`, `vault_id`, canonical `slug`, optional
-`section`, and a batch of environment field names in `fields`. A Vault is a key bundle:
-request related keys together under one link. Supplied or already-pending fields are rejected.
+`section`, and a batch of Vault field names in `fields`. A Vault is a key bundle:
+request related new and existing keys together under one link. Include existing keys only
+when the user authorized updating them; do not delete them first. Existing Vault values
+remain unchanged until successful submission and are never shown or prefilled. Overlapping pending requests
+are rejected; a change to any requested field conflicts with the entire batch.
 Show the returned `url` unchanged to the user; do not ask them to paste secrets into chat.
 Opening the link does not consume it. Saving all requested fields consumes it once.
 
 Check `vault_request_status` with its `request_id` after the user finishes. `pending` is not
 a secret value; `supplied` means the exact references are ready. On `expired` or `conflict`,
-inspect the Vault and request only still-missing fields; never replace an existing value to
-retry. If creation times out, use `vault_get` to find recent request IDs before retrying.
+inspect current Vault metadata and reassess the authorized fields before creating a fresh
+request; do not blindly retry an overwrite. If creation times out, use `vault_get` to find
+recent request IDs before retrying.
 If submission times out, inspect status before repeating a mutation.
 
 ### Use runtime-supplied credentials
@@ -144,10 +148,12 @@ unrelated configuration in its `.clawdi` parent. Connected installations use thi
 layout on macOS/Linux only after an explicit workspace binding; do not assume an arbitrary
 repo is bound. Files remain readable by authorized programs running as the same user.
 
-After a credential request is supplied, inspect index metadata for the requested fields.
-Pending requests are metadata only, never empty pseudo-secrets. If delivery is delayed,
-report that state without claiming the credentials are saved. Runtime refreshes files;
-already-running processes must explicitly reload them. Offline delivery retains last good
+After `vault_request_status` reports `supplied`, match its Vault ID, section and field names
+in the index and require the local Vault `content_version` to be at least the status
+`content_version`. The API requires this counter; existing names alone do not prove delivery.
+If the owned index is incomplete or behind, wait for runtime reconciliation and report
+unverified delivery. Do not read secret values to check freshness. Pending requests are metadata only, never empty pseudo-secrets.
+Runtime refreshes files; already-running processes must explicitly reload them. Offline delivery retains last good
 files; confirmed access removal removes generated files. Authorized code can read these
 files, so do not claim that subsequent plaintext exposure is impossible.
 

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -27,6 +27,28 @@ describe("bundled Clawdi skill context routing", () => {
 			expect(skill.split("---")[1]).toContain("Gmail");
 		}
 	});
+
+	it("documents Session sharing without leaking Connected CLI fallbacks into Hosted", () => {
+		for (const skill of [genericSkill, hostedSkill]) {
+			const sessions = section(skill, "Sessions");
+			for (const tool of [
+				"`session_share_create`",
+				"`session_share_list`",
+				"`session_share_revoke`",
+			]) {
+				expect(sessions).toContain(tool);
+			}
+			expect(sessions).toContain("stable message `position`");
+			expect(sessions).toContain("safe user/Assistant projection");
+			expect(sessions).toContain("exact `share_id` and `kind`");
+		}
+
+		expect(section(genericSkill, "Sessions")).toContain("CLI fallback");
+		expect(section(hostedSkill, "Sessions")).not.toMatch(/`clawdi\s/);
+		expect(section(hostedSkill, "Hosted Boundary")).toContain(
+			"Do not use any `clawdi` CLI command as a Cloud capability fallback",
+		);
+	});
 });
 
 function section(content: string, heading: string): string {

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "ab41317bcca444e80162cc6eeae59fca059587e0a1cd35cc048422033c03fc33",
+					digest: "a70f1c53415828ac38d89e325ab976d474e5e6d6c172cb3c812174558261a176",
 				}),
 			],
 		]),

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "c612838e760ba65d0f305829d55410cd9521456e802cd168b6f516a9459b5b65",
+					digest: "ab41317bcca444e80162cc6eeae59fca059587e0a1cd35cc048422033c03fc33",
 				}),
 			],
 		]),

--- a/packages/cli/src/runtime/manifest-mcp.ts
+++ b/packages/cli/src/runtime/manifest-mcp.ts
@@ -130,7 +130,7 @@ function buildHostedMcpReconciliationPlan(
 		for (const [serverName, desired] of Object.entries(desiredServers).sort(([a], [b]) =>
 			a.localeCompare(b),
 		)) {
-			const server = hostedMcpNativeServerConfig(serverName, desired);
+			const server = hostedMcpNativeServerConfig(name, serverName, desired);
 			if (!canonicalJsonEqual(native.servers[serverName], server)) {
 				mutations.push({ kind: "set", serverName, server });
 			}
@@ -195,10 +195,14 @@ function readHostedMcpNativeState(
 	return { servers };
 }
 function hostedMcpNativeServerConfig(
+	runtime: HostedMcpTarget,
 	serverName: string,
 	desired: HostedMcpServerDesiredState,
-): { url: string; transport: "streamable-http" | "sse"; headers: Record<string, string> } {
+) {
 	return {
+		// OpenClaw shares the explicit request budget with catalog discovery;
+		// without it, tools/list has a separate 1.5-second default.
+		...(runtime === "openclaw" ? { requestTimeoutMs: 420_000 } : {}),
 		url: desired.url,
 		transport: desired.transport,
 		headers: Object.fromEntries(

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -833,6 +833,7 @@ describe("hosted runtime bundle v2", () => {
 			mcp: { servers: Record<string, unknown> };
 		};
 		expect(nativeMcpConfig.mcp.servers.clawdi).toEqual({
+			requestTimeoutMs: 420_000,
 			url: "https://cloud-api.test/v1/mcp/clawdi",
 			transport: "streamable-http",
 			headers: {

--- a/packages/cli/src/runtime/vault-files.test.ts
+++ b/packages/cli/src/runtime/vault-files.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
 	chmodSync,
 	linkSync,
@@ -52,6 +52,7 @@ function fixture(connected: boolean) {
 				name: "Vault",
 				slug: "vault",
 				revision: "1",
+				content_version: 1,
 				project_ids: [randomUUID()],
 				fields: [
 					{
@@ -102,6 +103,94 @@ for (const connected of [true, false]) {
 	describe.skipIf(!connected && process.platform !== "linux")(
 		connected ? "connected native filesystem" : "Hosted Linux filesystem",
 		() => {
+			test("incomplete owned metadata refreshes without rewriting secrets; delivery requires current material", async () => {
+				const { config, home, data } = fixture(connected);
+				let invalidCounter: "missing" | "null" | undefined;
+				let materialStatus = 200;
+				const server = Bun.serve({
+					hostname: "127.0.0.1",
+					port: 0,
+					async fetch(request) {
+						const vault = data.vaults[0];
+						const material = request.method === "POST";
+						if (material && materialStatus !== 200)
+							return new Response(null, { status: materialStatus });
+						if (!invalidCounter && request.headers.get("if-none-match") === vault.revision)
+							return new Response(null, { status: 304 });
+						const body = material ? await request.json() : undefined;
+						return Response.json(
+							{
+								...data,
+								vaults: [
+									{
+										...vault,
+										content_version:
+											invalidCounter === "missing"
+												? undefined
+												: invalidCounter === "null"
+													? null
+													: vault.content_version,
+										fields:
+											material && body?.revisions[vault.id] !== vault.revision
+												? vault.fields
+												: null,
+									},
+								],
+							},
+							{ headers: { etag: vault.revision } },
+						);
+					},
+				});
+				config.apiUrl = server.url.origin;
+				const dir = join(home, ".clawdi/vaults");
+				const index = () => JSON.parse(readFileSync(join(dir, "index.json"), "utf8")).vaults[0];
+				try {
+					await syncRuntimeVaultFiles(config);
+					const cached = JSON.parse(readFileSync(config.receiptPath, "utf8"));
+					const cachedIndex = JSON.parse(readFileSync(join(dir, "index.json"), "utf8"));
+					delete cached.inventory[0].content_version;
+					delete cachedIndex.vaults[0].content_version;
+					const cachedBytes = JSON.stringify(cachedIndex);
+					writeFileSync(join(dir, "index.json"), cachedBytes);
+					cached.digests["index.json"] = createHash("sha256").update(cachedBytes).digest("hex");
+					writeFileSync(config.receiptPath, JSON.stringify(cached));
+					const names = index().sections.map((section: { file: string }) => section.file);
+					const mtimes = names.map(
+						(file: string) => lstatSync(join(dir, file), { bigint: true }).mtimeNs,
+					);
+					// Refresh owned cache metadata using fields=null; secret section files stay intact.
+					expect(await syncRuntimeVaultFiles(config)).toBe("synced");
+					expect(index().content_version).toBe(1);
+					expect(
+						names.map((file: string) => lstatSync(join(dir, file), { bigint: true }).mtimeNs),
+					).toEqual(mtimes);
+					expect(await syncRuntimeVaultFiles(config)).toBe("unchanged");
+					const requestedContentVersion = 2;
+					data.vaults[0].content_version = requestedContentVersion;
+					data.vaults[0].revision = "2";
+					data.vaults[0].fields[0].value = "replacement";
+					materialStatus = 503;
+					await expect(syncRuntimeVaultFiles(config)).rejects.toThrow("Runtime Vault files");
+					// Matching names already exist, but metadata alone cannot publish delivery.
+					expect(index().sections[0].fields[0].name).toBe("TOKEN");
+					expect(index().content_version).toBeLessThan(requestedContentVersion);
+					materialStatus = 200;
+					await syncRuntimeVaultFiles(config);
+					expect(index().content_version).toBe(requestedContentVersion);
+					expect(
+						JSON.parse(readFileSync(config.receiptPath, "utf8")).inventory[0].content_version,
+					).toBe(requestedContentVersion);
+					for (const malformed of ["missing", "null"] as const) {
+						invalidCounter = malformed;
+						await expect(syncRuntimeVaultFiles(config)).rejects.toThrow("Runtime Vault files");
+						expect(index().content_version).toBe(requestedContentVersion);
+						expect(names.every((file: string) => lstatSync(join(dir, file)).isFile())).toBe(true);
+					}
+				} finally {
+					server.stop(true);
+				}
+			});
+
 			test("HTTP snapshots: stable sections, 304 no IO rewrite, rotation, additions/removal, offline and revocation", async () => {
 				const { config, home, data } = fixture(connected);
 				let revision = "1",

--- a/packages/cli/src/runtime/vault-files.ts
+++ b/packages/cli/src/runtime/vault-files.ts
@@ -41,6 +41,7 @@ const snapshotSchema = z.object({
 				slug: z.string(),
 				project_ids: z.array(z.uuid()).min(1),
 				revision: z.string(),
+				content_version: z.number().int().nonnegative(),
 				fields: z
 					.array(
 						z.object({
@@ -66,6 +67,7 @@ const indexVaultSchema = z.object({
 	slug: z.string(),
 	project_ids: z.array(z.uuid()),
 	revision: z.string(),
+	content_version: z.number().int().nonnegative(),
 	sections: z.array(
 		z.object({
 			id: z.string(),
@@ -96,7 +98,8 @@ const receiptSchema = z
 		device: z.number(),
 		inode: z.number(),
 		files: z.array(generatedName),
-		inventory: z.array(indexVaultSchema),
+		// Incomplete owned cache metadata is refreshed from the current API.
+		inventory: z.array(indexVaultSchema.partial({ content_version: true })),
 		etag: z.string().nullable(),
 	})
 	.strict();
@@ -519,7 +522,7 @@ function render(snapshot: Snapshot, previous: Receipt | null) {
 				(entry) => entry.id === vault.id && entry.revision === vault.revision,
 			);
 			if (!old) fail();
-			return old;
+			return { ...old, content_version: vault.content_version };
 		}
 		const sections = new Map<string, NonNullable<typeof vault.fields>>();
 		for (const field of vault.fields) {
@@ -533,6 +536,7 @@ function render(snapshot: Snapshot, previous: Receipt | null) {
 			slug: vault.slug,
 			project_ids: vault.project_ids,
 			revision: vault.revision,
+			content_version: vault.content_version,
 			sections: [...sections].map(([name, fields]) => {
 				const id = createHash("sha256").update(name).digest("hex");
 				const file = `${vault.id}-${id}.json`;
@@ -734,7 +738,11 @@ async function syncVaultSnapshot(
 			withDirectory(config, receipt, (fd) =>
 				receipt?.files.every((name) => fileDigest(fd, name) === receipt?.digests[name]),
 			);
-		const etag = intact ? receipt?.etag : null;
+		// Refresh incomplete cached metadata while reusing intact, owned values.
+		const etag =
+			intact && receipt?.inventory.every((vault) => vault.content_version !== undefined)
+				? receipt.etag
+				: null;
 		const response = await request(`${config.apiUrl}/v1/runtime/vaults${query}`, {
 			headers: {
 				...(config.connected ? {} : { Authorization: `Bearer ${config.apiKey}` }),

--- a/packages/cli/src/serve/vault-sync.test.ts
+++ b/packages/cli/src/serve/vault-sync.test.ts
@@ -88,6 +88,7 @@ test("connected delivery fences identity, retains offline files, coalesces chang
 							slug: "test",
 							project_ids: [projectId],
 							revision: String(version),
+							content_version: version,
 							fields: material
 								? [
 										{
@@ -269,6 +270,7 @@ test("cold account switch clears only matching old provenance, never a replaceme
 				slug: "fixture",
 				project_ids: [randomUUID()],
 				revision: "one",
+				content_version: 1,
 				fields: [
 					{
 						id: randomUUID(),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -11001,9 +11001,10 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 
 		expect(installed.installErrors).toEqual([]);
 		expect(readFileSync(installerLog, "utf-8")).toBe("installed\n");
-		expect(readOpenClawMcpServers(home).clawdi).toEqual(
-			nativeManagedRemoteMcpServer("clawdi", "v1"),
-		);
+		expect(readOpenClawMcpServers(home).clawdi).toEqual({
+			...nativeManagedRemoteMcpServer("clawdi", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 
 		rmSync(commandPath);
 		const unavailable = convergeAndCommitTestRuntimeManifest(
@@ -11014,9 +11015,10 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(unavailable.installErrors.join("\n")).toContain(
 			"could not mutate managed OpenClaw MCP servers: runtime is unavailable",
 		);
-		expect(readOpenClawMcpServers(home).clawdi).toEqual(
-			nativeManagedRemoteMcpServer("clawdi", "v1"),
-		);
+		expect(readOpenClawMcpServers(home).clawdi).toEqual({
+			...nativeManagedRemoteMcpServer("clawdi", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 	});
 
 	it("reconciles generic MCP maps and cleans the previously managed runtime on switch", () => {
@@ -11162,12 +11164,14 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			getRuntimePaths(),
 		);
 		expect(initial.installErrors).toEqual([]);
-		expect(readOpenClawMcpServers(home).clawdi).toEqual(
-			nativeManagedRemoteMcpServer("clawdi", "v1"),
-		);
-		expect(readOpenClawMcpServers(home)["search.proxy"]).toEqual(
-			nativeManagedRemoteMcpServer("search.proxy", "v1"),
-		);
+		expect(readOpenClawMcpServers(home).clawdi).toEqual({
+			...nativeManagedRemoteMcpServer("clawdi", "v1"),
+			requestTimeoutMs: 420_000,
+		});
+		expect(readOpenClawMcpServers(home)["search.proxy"]).toEqual({
+			...nativeManagedRemoteMcpServer("search.proxy", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 		expect(readOpenClawMcpServers(home)["user-entry"]).toEqual({
 			command: "user-owned",
 			args: ["keep"],
@@ -11187,18 +11191,20 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		);
 		expect(restarted.installErrors).toEqual([]);
 		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).toBe(installedSkill);
-		expect(readOpenClawMcpServers(home).clawdi).toEqual(
-			nativeManagedRemoteMcpServer("clawdi", "v1"),
-		);
+		expect(readOpenClawMcpServers(home).clawdi).toEqual({
+			...nativeManagedRemoteMcpServer("clawdi", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 
 		const updated = convergeAndCommitTestRuntimeManifest(
 			load(2, "openclaw", updatedServers),
 			getRuntimePaths(),
 		);
 		expect(updated.installErrors).toEqual([]);
-		expect(readOpenClawMcpServers(home)["search.proxy"]).toEqual(
-			nativeManagedRemoteMcpServer("search.proxy", "v2"),
-		);
+		expect(readOpenClawMcpServers(home)["search.proxy"]).toEqual({
+			...nativeManagedRemoteMcpServer("search.proxy", "v2"),
+			requestTimeoutMs: 420_000,
+		});
 		const updatedConfig = readFileSync(openclawConfigPath, "utf-8");
 		const callsBeforeIdempotent = readFileSync(openclawCalls, "utf-8");
 		const idempotent = convergeAndCommitTestRuntimeManifest(
@@ -11307,7 +11313,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const desiredServer = managedRemoteMcpServer("clawdi", "v2");
 		writeFileSync(
 			openclawConfigPath,
-			`${JSON.stringify({ mcp: { servers: { clawdi: nativeManagedRemoteMcpServer("clawdi", "v1") } } }, null, 2)}\n`,
+			`${JSON.stringify({ mcp: { servers: { clawdi: nativeManagedRemoteMcpServer("clawdi", "v2") } } }, null, 2)}\n`,
 		);
 		ensureRuntimeStateDirs(paths);
 		writeRuntimeAppliedState(
@@ -11344,6 +11350,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(upgraded.installErrors).toEqual([]);
 		expect(readOpenClawMcpServers(home).clawdi).toMatchObject({
 			url: desiredServer.url,
+			requestTimeoutMs: 420_000,
 		});
 
 		writeFileSync(
@@ -11431,16 +11438,18 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			getRuntimePaths(),
 		);
 		expect(managed.installErrors).toEqual([]);
-		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual(
-			nativeManagedRemoteMcpServer("owned-server", "v1"),
-		);
+		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual({
+			...nativeManagedRemoteMcpServer("owned-server", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 
 		writeFileSync(failUnset, "fail\n");
 		const failedRemoval = convergeRuntimeManifest(load(5, {}), getRuntimePaths());
 		expect(failedRemoval.installErrors.join("\n")).toContain("runtime MCP projection failed");
-		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual(
-			nativeManagedRemoteMcpServer("owned-server", "v1"),
-		);
+		expect(readOpenClawMcpServers(home)["owned-server"]).toEqual({
+			...nativeManagedRemoteMcpServer("owned-server", "v1"),
+			requestTimeoutMs: 420_000,
+		});
 
 		rmSync(failUnset);
 		const retriedRemoval = convergeRuntimeManifest(load(6, {}), getRuntimePaths());

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -8578,6 +8578,8 @@ export interface components {
             project_ids: string[];
             /** Revision */
             revision: string;
+            /** Content Version */
+            content_version: number;
             /** Fields */
             fields?: components["schemas"]["RuntimeVaultField"][] | null;
         };
@@ -10279,6 +10281,10 @@ export interface components {
             section: string;
             /** Fields */
             fields: string[];
+            /** Update Fields */
+            update_fields: string[];
+            /** Content Version */
+            content_version: number;
             /**
              * Status
              * @enum {string}
@@ -10295,8 +10301,6 @@ export interface components {
             references: {
                 [key: string]: string;
             };
-            /** Local Command */
-            local_command: string;
             /** Url */
             url: string;
         };
@@ -10327,6 +10331,10 @@ export interface components {
             section: string;
             /** Fields */
             fields: string[];
+            /** Update Fields */
+            update_fields: string[];
+            /** Content Version */
+            content_version: number;
             /**
              * Status
              * @enum {string}
@@ -10343,8 +10351,6 @@ export interface components {
             references: {
                 [key: string]: string;
             };
-            /** Local Command */
-            local_command: string;
         };
         /** VaultSecretRequestSupply */
         VaultSecretRequestSupply: {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -2744,6 +2744,8 @@ export interface components {
              * @constant
              */
             browser_mode: "embedded_and_top_level";
+            /** Browser Session Url */
+            browser_session_url?: string | null;
         };
         /** V2PlanResponse */
         V2PlanResponse: {

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -54,7 +54,11 @@ export function isRuntimeUiEndpointInfo(value: unknown): value is RuntimeUiEndpo
 		(value.runtime === "openclaw"
 			? value.auth_mode === "openclaw_token"
 			: value.auth_mode === "password") &&
-		isCleanRuntimeUiUrl(value.url)
+		isCleanRuntimeUiUrl(value.url) &&
+		(value.runtime !== "openclaw" ||
+			value.browser_session_url == null ||
+			value.browser_session_url ===
+				new URL("/.well-known/openclaw/browser-session", value.url).href)
 	);
 }
 

--- a/scripts/test-openclaw-native.sh
+++ b/scripts/test-openclaw-native.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 test_name="clawdi-openclaw-native-$$"
+paired_args=()
+if [[ -n "${CLAWDI_OPENCLAW_HOSTED_SOURCE:-}" ]]; then
+  test -f "$CLAWDI_OPENCLAW_HOSTED_SOURCE/backend/tests/support/openclaw_browser_native.py"
+  paired_args=(-v "$CLAWDI_OPENCLAW_HOSTED_SOURCE:/hosted:ro" -e OPENCLAW_PAIRED=1)
+fi
 cleanup() {
   docker rm -f "$test_name" >/dev/null 2>&1 || true
   docker image rm "$test_name" >/dev/null 2>&1 || true
@@ -10,11 +15,14 @@ cleanup() {
 trap cleanup EXIT
 docker build -t "$test_name" - <<'DOCKERFILE'
 FROM oven/bun:1.4.0 AS bun
+FROM ghcr.io/astral-sh/uv:0.12.5 AS uv
 FROM mcr.microsoft.com/playwright:v1.62.1-noble
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=uv /uv /usr/local/bin/uv
 DOCKERFILE
 docker run --rm --name "$test_name" --cpus 4 --memory 4g --memory-swap 4g \
   --pids-limit 512 -v "$repo_root:/repo:ro" -e HOME=/tmp/openclaw-home \
+  "${paired_args[@]}" \
   -e CI=true "$test_name" timeout 900 bash -euo pipefail -c '
 mkdir -p /work/clawdi "$HOME"
 tar -C /repo --exclude=.git --exclude=node_modules --exclude=.env --exclude=".env.*" \
@@ -35,5 +43,46 @@ for attempt in $(seq 1 60); do
   sleep 1
 done
 curl -kfsS https://127.0.0.1:19443/readyz >/dev/null || { cat /work/gateway-fixture.log; exit 1; }
+if [[ "${OPENCLAW_PAIRED:-}" = 1 ]]; then
+  mkdir -p /work/hosted
+  tar -C /hosted --exclude=.git --exclude=node_modules --exclude=.env --exclude=".env.*" --exclude=.venv -cf - backend infra config | tar -C /work/hosted -xf -
+  uv sync --project /work/hosted/backend --frozen --python python3
+  # A real non-loopback client address is required by official proxy attribution.
+  fixture_ip="$(hostname -i)"
+  printf "%s cloud.clawdi.test api.clawdi.test cloud-api.clawdi.test agent-42-18789.prod.clawdi.test\n" "$fixture_ip" >> /etc/hosts
+  cd /work
+  curl -fsSLO https://github.com/traefik/traefik/releases/download/v3.7.12/traefik_v3.7.12_linux_amd64.tar.gz
+  curl -fsSLO https://github.com/traefik/traefik/releases/download/v3.7.12/traefik_v3.7.12_checksums.txt
+  sha256sum --ignore-missing -c traefik_v3.7.12_checksums.txt
+  tar -xzf traefik_v3.7.12_linux_amd64.tar.gz traefik
+  cd /work/hosted/backend
+  uv run --frozen python -c "from app.core.test_env import apply_backend_test_environment; apply_backend_test_environment(); import uvicorn; uvicorn.run(\"tests.support.openclaw_browser_native:app\", host=\"127.0.0.1\", port=19445)" > /work/browser-issuer.log 2>&1 &
+  issuer_pid=$!
+  trap '\''kill "$fixture_pid" "$issuer_pid" "${proxy_pid:-}" 2>/dev/null || true'\'' EXIT
+  for attempt in $(seq 1 30); do
+    if curl -fsS http://127.0.0.1:19445/fixture >/dev/null 2>&1; then break; fi
+    if ! kill -0 "$issuer_pid" 2>/dev/null; then cat /work/browser-issuer.log; exit 1; fi
+    sleep 1
+  done
+  curl -fsS http://127.0.0.1:19445/fixture >/dev/null || { cat /work/browser-issuer.log; exit 1; }
+  /work/traefik --configFile=/work/traefik.yaml > /work/traefik.log 2>&1 &
+  proxy_pid=$!
+  for attempt in $(seq 1 15); do
+    if curl -kfsS https://agent-42-18789.prod.clawdi.test:19444/readyz >/dev/null 2>&1; then break; fi
+    if ! kill -0 "$proxy_pid" 2>/dev/null; then cat /work/traefik.log; exit 1; fi
+    sleep 1
+  done
+  curl -kfsS https://agent-42-18789.prod.clawdi.test:19444/readyz >/dev/null || { cat /work/traefik.log; exit 1; }
+  cd /work/clawdi
+  export E2E_HOSTED_BASE_URL=https://cloud.clawdi.test:19444
+  export E2E_HOSTED_DEPLOY_API_URL=https://api.clawdi.test:19444
+  export E2E_HOSTED_CLOUD_API_URL=https://cloud-api.clawdi.test:19444
+  bun run --cwd apps/web e2e --config=playwright.openclaw.config.ts --grep "protected runtime owner" || { cat /work/browser-issuer.log /work/traefik.log; exit 1; }
+  VITE_CLAWDI_HOSTED=true E2E_HOSTED_DEPLOY_API_URL=http://127.0.0.1:50021 E2E_HOSTED_CLOUD_API_URL=http://127.0.0.1:8000 bun run --cwd apps/web e2e --config=playwright.auth.config.ts --grep "OpenClaw (grant|retires late)"
+  bun run --cwd apps/web e2e --config=playwright.openclaw.config.ts --grep-invert "protected runtime owner"
+  uv run --project /work/hosted/backend --frozen python /work/hosted/backend/scripts/check_python_types.py
+else
 bun run --cwd apps/web e2e --config=playwright.openclaw.config.ts
+fi
+bun run --cwd apps/web typecheck
 '


### PR DESCRIPTION
When Hosted advertises an applied browser_session_url, establish the dedicated runtime-origin owner cookie with POST and verify its delivery with HEAD before mounting the official Control UI. A stale reuse hint with a missing native device token can then recover through OpenClaw's same-origin issuer without replacing the document. First launch retains the official bootstrap fragment; native authentication remains owned by OpenClaw, with no parent auth acknowledgement or parallel WebSocket.

Paired backend: https://github.com/Clawdi-AI/clawdi-hosted/pull/2201. Do not probe unadvertised runtime endpoints with a Clerk bearer. Preserve the existing first-launch/legacy/Reconnect path when the optional URL is absent, and retain the persistent iframe and three muted recent-session slots.

Validation in isolated Docker: real Chrome HTTPS same-site traffic through Traefik and the Hosted grant/JWT handler to official OpenClaw recovered operator.admin hello-ok after deleting only the native device token. The document remained unchanged; the recovered connection survived Console reveal and the next reload reused deviceToken. Exactly one initial POST and HEAD; all four auth/cancellation lifecycle cases passed, plus the original native success/expired/consumed/revoked matrix. Same-resource-version grant failure recovered via manual Retry. Web typecheck, Biome and generated API checks passed. Clerk and DB seams were synthetic; this is not a production user-session trace.

Backend and applied auxiliary routes must precede frontend activation. The live generated-contract CI gate remains dependent on backend publication. No installed-runtime recovery capability is inferred. Expired/consumed first-fragment credentials and revoked current-page device credentials remain explicit Reconnect cases where upstream does not call recovery. Latest main was merged without conflicts; no production deployment has been performed.


Release evidence (2026-09-12): Released frontend186fe5212 to production after the live deploy-contract check passed against the published backend schema. Public site bundle verified. One existing OpenClaw canary has acknowledged auxiliary routes; other existing deployments are not claimed activated. Hermes is unchanged.
