### PR TITLE
feat(cli): teach agents session sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- CLI 0.14.75 teaches Connected and Hosted agents to create, list, and revoke
+  Session shares through MCP. Connected agents retain the CLI fallback; Hosted
+  agents use MCP only.
 - CLI 0.14.74 recognizes credential tasks in the Clawdi skill and reuses ready,
   authorized integrations, including connected Composio services, without
   requiring duplicate credentials or account migration.

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.74",
+      "version": "0.14.75",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.74",
+	"version": "0.14.75",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -44,12 +44,23 @@ It preserves metadata; find the exact ID before changing it.
 - Use `session_list` to browse recent sessions or filter by time, Agent, or Project.
 - Use `session_search` to find past agent conversations by keyword and obtain session UUIDs.
 - Use `session_get` to read a session by UUID or Clawdi share URL.
+- Use `session_share_create` to publish an immutable snapshot only when the user explicitly asks
+  to share a Session, part of it, or one Assistant response.
+- Use `session_share_list` to inspect active links and obtain their exact IDs and kinds.
+- Use `session_share_revoke` to stop sharing one exact link only when the user asks.
 
 Call `session_get` when the user provides a Clawdi share URL or session UUID and wants its
 contents. For a request to open a specific unnamed past conversation, use `session_search`
 to find the UUID and then read the selected match.
 
 Do NOT call WebFetch on `cloud.clawdi.ai/s/...` URLs — `session_get` is the right tool and avoids the WebFetch permission prompt.
+
+For `session_share_create`, omit `position` for the full `session` scope. For `through` or
+`response`, use the stable message `position` returned by `session_get` or `session_search`,
+never a filtered array index; `response` must target an Assistant message. Public snapshots
+include only the existing safe user/Assistant projection, never reasoning, system/developer
+messages, hidden events, or tool activity. Before revoking, use `session_share_list` unless the
+user already supplied the exact `share_id` and `kind`; never infer a link ID or kind.
 
 CLI fallback: `clawdi session search "query" --json`, then `clawdi session read <cloud-session-id> --json`.
 `session list` is local; `session export <cloud-session-id>` exports owner Markdown without

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -11,7 +11,8 @@ Use Clawdi Cloud tools through the `clawdi` MCP server. Treat the live tool sche
 
 Third-party tool routing below applies unchanged in Hosted. Do not inspect, run, or suggest
 Clawdi host-management commands such as `clawdi setup`, `clawdi wallet`, `clawdi vault`, or
-`clawdi ai-provider`.
+`clawdi ai-provider`. Do not use any `clawdi` CLI command as a Cloud capability fallback;
+use the Clawdi MCP tools exposed to the Hosted runtime.
 
 ## Context Routing
 
@@ -46,10 +47,22 @@ already supplied the exact memory ID; never infer which stored item to mutate.
 - Use `session_list` to browse recent sessions or filter by time, Agent, or Project.
 - Use `session_search` to find past agent conversations by keyword and obtain session UUIDs.
 - Use `session_get` to read a session by UUID or Clawdi share URL.
+- Use `session_share_create` to publish an immutable snapshot only when the user explicitly asks
+  to share a Session, part of it, or one Assistant response.
+- Use `session_share_list` to inspect active links and obtain their exact IDs and kinds.
+- Use `session_share_revoke` to stop sharing one exact link only when the user asks.
 
 Call `session_get` when the user provides a Clawdi share URL or session UUID and wants its
 contents. Use `session_search` to locate a requested unnamed conversation. Do not use a
 generic web fetcher for Clawdi share URLs.
+
+For `session_share_create`, omit `position` for the full `session` scope. For `through` or
+`response`, use the stable message `position` returned by `session_get` or `session_search`,
+never a filtered array index; `response` must target an Assistant message. Public snapshots
+include only the existing safe user/Assistant projection, never reasoning, system/developer
+messages, hidden events, or tool activity. Before revoking, use `session_share_list` unless the
+user already supplied the exact `share_id` and `kind`; never infer a link ID or kind. Hosted
+Session sharing uses these MCP tools only, not CLI commands.
 
 ## Projects
 

--- a/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
+++ b/packages/cli/src/runtime/bundled-clawdi-skill.test.ts
@@ -27,6 +27,28 @@ describe("bundled Clawdi skill context routing", () => {
 			expect(skill.split("---")[1]).toContain("Gmail");
 		}
 	});
+
+	it("documents Session sharing without leaking Connected CLI fallbacks into Hosted", () => {
+		for (const skill of [genericSkill, hostedSkill]) {
+			const sessions = section(skill, "Sessions");
+			for (const tool of [
+				"`session_share_create`",
+				"`session_share_list`",
+				"`session_share_revoke`",
+			]) {
+				expect(sessions).toContain(tool);
+			}
+			expect(sessions).toContain("stable message `position`");
+			expect(sessions).toContain("safe user/Assistant projection");
+			expect(sessions).toContain("exact `share_id` and `kind`");
+		}
+
+		expect(section(genericSkill, "Sessions")).toContain("CLI fallback");
+		expect(section(hostedSkill, "Sessions")).not.toMatch(/`clawdi\s/);
+		expect(section(hostedSkill, "Hosted Boundary")).toContain(
+			"Do not use any `clawdi` CLI command as a Cloud capability fallback",
+		);
+	});
 });
 
 function section(content: string, heading: string): string {

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "c612838e760ba65d0f305829d55410cd9521456e802cd168b6f516a9459b5b65",
+					digest: "ab41317bcca444e80162cc6eeae59fca059587e0a1cd35cc048422033c03fc33",
 				}),
 			],
 		]),


### PR DESCRIPTION
## Summary

- document session_share_create, session_share_list, and session_share_revoke in both bundled Clawdi skills
- keep Connected CLI fallbacks while requiring Hosted Session sharing to use MCP only
- publish the updated skill bundle as clawdi 0.14.75 with an updated Hosted digest

## Safety and behavior

- sharing requires explicit user intent
- through/response scopes use canonical message positions
- public shares retain the existing safe user/Assistant projection
- revoke uses an exact share ID and kind from inventory

## Verification

- isolated Docker CLI typecheck and full CLI suite: 154 test files, 0 failures
- bundled skill contract tests: 12 passed
- Biome 2.5.11 check
- publish manifest check
- git diff --check

## Release impact

Changes packages/cli/package.json from 0.14.74 to 0.14.75, so the immutable CLI publish workflow will run. Hosted rollout remains a separate exact-version selection after the package is published.