### PR TITLE
Isolate sync queue failures and bound systemd recovery commands

### DIFF
--- a/.github/workflows/cli-systemd-e2e.yml
+++ b/.github/workflows/cli-systemd-e2e.yml
@@ -8,6 +8,8 @@ on:
       - "packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts"
       - "packages/cli/tests/fixtures/runtime-official-installer-systemd/**"
       - "scripts/test-runtime-official-installer-systemd.sh"
+      - "scripts/test-systemd-command.sh"
+      - "scripts/test.sh"
       - ".github/workflows/cli-systemd-e2e.yml"
 
 permissions:
@@ -23,5 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+      - name: Test systemd command failure boundaries
+        run: bash scripts/test.sh runtime-systemd
       - name: Test CLI against systemd as PID 1
         run: scripts/test-runtime-official-installer-systemd.sh

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -226,6 +226,7 @@ import {
 	deploymentRuntimeUiIsReady,
 	deploymentStatusFromResource,
 	deploymentStatusLabel,
+	deploymentTerminalIsAvailable,
 	isRunningStatus,
 } from "@/hosted/deployment-status";
 import { DeploymentStatusUnavailableState } from "@/hosted/deployment-status-unavailable";
@@ -2238,7 +2239,7 @@ function TerminalTab({
 	standalone: boolean;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
-	const isRunning = isRunningStatus(status);
+	const terminalAvailable = deploymentTerminalIsAvailable(deployment);
 	const isStarting = isStartingStatus(status);
 	const label = agentName;
 	const client = useBillingClient();
@@ -2284,7 +2285,7 @@ function TerminalTab({
 		return <StoppedAgentState deployment={deployment} />;
 	}
 
-	if (!isRunning) {
+	if (!terminalAvailable) {
 		return (
 			<EmptyState
 				icon={TerminalSquare}

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -18,6 +18,7 @@ import {
 	deploymentStatusFromResource,
 	deploymentStatusLabel,
 	deploymentStatusTone,
+	deploymentTerminalIsAvailable,
 	isRunningStatus,
 	isTerminalStatus,
 	isTransitionalStatus,
@@ -53,6 +54,63 @@ function acceptedOperation(verb: DeploymentOperationVerb): DeploymentOperation {
 }
 
 describe("DeploymentStatus", () => {
+	test("offers repair after post-ready health loss without admitting unproven or retired runtimes", () => {
+		const deployment = hostedDeploymentFixture({
+			status: "failed",
+			failure: {
+				type: "https://api.clawdi.ai/problems/runtime_unreachable",
+				title: "Runtime unreachable",
+				detail: "Fresh runtime health was not restored during the grace period.",
+				status: 503,
+				code: "runtime_unreachable",
+				phase: "reconcile",
+				retryable: true,
+				conditionReason: "RuntimeUnreachable",
+				conditionMessage: "Runtime unreachable",
+				observedGeneration: 1,
+			},
+		});
+		expect(deploymentTerminalIsAvailable(deployment)).toBe(true);
+		const status = deployment.resource.status;
+		if (!status?.failure) throw new Error("expected deployment failure");
+		for (const changed of [
+			{ driver_applied_generation: 0 },
+			{ observedGeneration: 0 },
+			{ failure: { ...status.failure, code: "runtime_readiness_timeout" } },
+			{ failure: { ...status.failure, observedGeneration: 0 } },
+			{ deleted_at: "2026-09-11T00:00:00Z" },
+		]) {
+			expect(
+				deploymentTerminalIsAvailable({
+					...deployment,
+					resource: {
+						...deployment.resource,
+						status: { ...status, ...changed },
+					},
+				}),
+			).toBe(false);
+		}
+		expect(
+			deploymentTerminalIsAvailable({
+				...deployment,
+				resource: {
+					...deployment.resource,
+					spec: { ...deployment.resource.spec, desired_lifecycle: "stopped" },
+				},
+			}),
+		).toBe(false);
+		expect(
+			deploymentTerminalIsAvailable({
+				...deployment,
+				compute_slot_occupancy: {
+					occupies_slot: false,
+					backing_infra: "absent",
+					reason: "authoritative_absence",
+				},
+			}),
+		).toBe(false);
+	});
+
 	test("normalizes known hosted backend statuses", () => {
 		for (const raw of KNOWN_DEPLOYMENT_STATUSES) {
 			const status = parseDeploymentStatus(raw.toUpperCase());

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -186,6 +186,26 @@ export function hasCurrentRuntimeHealthDegradation(status: HostedDeploymentStatu
 }
 
 /** Public readiness evidence authorizes a launch attempt, not an authenticated browser session. */
+export function deploymentTerminalIsAvailable(deployment: HostedDeployment): boolean {
+	const { metadata, spec, status } = deployment.resource;
+	if (spec.desired_lifecycle !== "running" || !status || status.deleted_at) return false;
+	if (status.summary_state === "running") return true;
+	const generation = metadata.generation;
+	return Boolean(
+		status.summary_state === "failed" &&
+			generation >= 1 &&
+			status.observedGeneration === generation &&
+			status.driver_acknowledged_generation === generation &&
+			status.driver_applied_generation === generation &&
+			status.observed_at &&
+			deployment.compute_slot_occupancy?.backing_infra === "present" &&
+			status.failure?.code === "runtime_unreachable" &&
+			status.failure.phase === "reconcile" &&
+			status.failure.observedGeneration === generation,
+	);
+}
+
+/** Aggregate readiness is required for Runtime UI credentials, including during repair. */
 export function deploymentRuntimeUiIsReady(deployment: HostedDeployment): boolean {
 	const { metadata, spec, status } = deployment.resource;
 	const generation = metadata.generation;

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -352,6 +352,18 @@ only for those test files, their containing runtime group, name-filtered runs,
 or the full suite; it never uses or changes a user's Hermes install. The
 fixture source and venv are removed when the runner exits.
 
+On a Linux Docker host, verify native systemd command deadlines and crash-loop
+readiness through the official suite:
+
+```bash
+bash scripts/test.sh runtime-systemd
+```
+
+This uses a disposable systemd container and filtered checkout inputs. It is
+also run by the privileged systemd CI workflow before the official installer
+suite. Done: the command exits 0 and reports the native no-job auto-restart
+regression passing; no operator configuration or live runtime is used.
+
 For daemon end-to-end and manual browser verification, see
 [`clawdi-daemon-test-guide.md`](clawdi-daemon-test-guide.md).
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1286,6 +1286,17 @@ CLI self-upgrade verifies a new exact package before atomically switching the
 active link inside the root-only managed directory. There is no shared
 `/var/lib/clawdi/bin` compatibility path and no migration or dual-path read.
 
+An apply-stage exception, including a failed systemd preflight, rolls back a
+pending CLI upgrade through the existing verified previous-target mechanism.
+The original error and any rollback diagnostics remain visible. Successful
+rollback signals `selfReexec`: `runtime init` preserves error status and exits
+75 with `handoff=cli_reexec`, while a running `runtime watch` exits its current
+loop so supervision restarts the managed target. A one-shot watch still exits
+nonzero for the failed apply. With no pending upgrade, the ordinary error/retry
+path is unchanged. A pending systemd Job or uncertain command outcome remains
+deferred and never authorizes CLI rollback; manifest fetch/auth failures retain
+their existing loader recovery policy.
+
 The `clawdi.cliNpmBootstrapStatus.v1` reader supports the exact initial
 bootstrap field set written by released images (without `verification`,
 `previous`, or `bad`) as well as the complete CLI-authored receipt. It never

--- a/docs/plans/sync-module-lifecycle.md
+++ b/docs/plans/sync-module-lifecycle.md
@@ -1,0 +1,149 @@
+# Recoverable sync module lifecycle
+
+Draft for owner review, 2026-09-12. This specifies the remaining within-Agent
+sync isolation change; it is not an implemented guarantee. No Cloud/Hosted wire
+schema, Files credential proof, model, or native service policy changes are needed.
+
+## Why a local catch is insufficient
+
+[`runSyncEngine`](../../packages/cli/src/serve/sync-engine.ts) prepares sessions
+then Skills before starting either worker, heartbeat, or drain. A preparation
+failure exits the engine. `runDaemonWorkers` then aborts its observation worker.
+Preparation currently has no independently owned cancellation scope.
+
+The data adapter contract in
+[`base.ts`](../../packages/cli/src/adapters/base.ts) exposes Promise-returning
+`contentProtocol`, `collect`, `scan`, `resolve`, and `listKeys` without an abort
+context. [`watcher.ts`](../../packages/cli/src/serve/watcher.ts) and
+[`sessions-watcher.ts`](../../packages/cli/src/serve/sessions-watcher.ts) close
+their watchers on abort, but their callbacks return void. The callbacks launch
+scans/enqueues without an awaitable close boundary. Merely retrying preparation
+does not address already-started work or the drain's mutable hash maps.
+
+## Proposed internal API changes
+
+Add `serve/sync-module.ts` with these internal contracts. `Binding` is the
+existing queue module plus its `lastPushedHash` map, published as one object:
+
+```ts
+type ModuleState =
+  | "unsupported"
+  | "preparing"
+  | "ready"
+  | "draining"
+  | "retry_wait"
+  | "stopped";
+
+interface ModuleLease<Binding> {
+  binding: Binding;
+  signal: AbortSignal;
+  release(): void;
+}
+
+interface PreparedModule<Binding> {
+  binding: Binding;
+  run(): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface ModuleSlot<Binding> {
+  readonly state: ModuleState;
+  acquire(): ModuleLease<Binding> | null;
+  run(): Promise<void>;
+  close(): Promise<void>;
+}
+```
+
+`ModuleSlot` owns one attempt controller and at most one prepared instance. Its
+factory takes `{ signal, track }`; `track(promise)` registers every scan,
+watcher callback and project reconciliation before returning control to its
+caller. Factory failure closes this scope even if no PreparedModule was returned.
+`close()` is idempotent: reject new leases, abort the attempt, close watchers,
+then join tracked tasks and drain/SSE leases. Only then discard the binding and
+construct another attempt. A swallowed rejection is not a completed module.
+
+Session binding retains `{ module, protocol, lastPushedHash }`; Skill binding
+retains `{ module, getProjectId, lastPushedHash, onEvent }`. Do not move the
+project getter or maps into unrelated mutable globals. A lease captures one
+binding through an entire queue upload and its version-fenced acknowledgement.
+
+Change `watchSkills.onSkillChanged` and `watchSessions.onPathStable` to accept
+`void | Promise<void>`. Watcher shutdown must wait for callback promises, and
+the sync preparation functions must return their enqueue/scan promises instead
+of discarding them. Keep callback coalescing; do not serialize independent
+filesystem events behind a stalled network request.
+
+For bounded cancellation, extend adapter read operations with an optional
+`SyncReadContext = { signal: AbortSignal }` argument: SessionModule
+`contentProtocol(context?)`, `collect(request, context?)`,
+`scan(request, knownRevisions, context?)`, `resolve(id, context?)`, and SkillModule
+`collect(context?)`, `listKeys(context?)`. Thread it through `scanSessionModule`
+and the six adapter implementations. Existing foreground callers remain valid.
+Iterators check abort between batches and close DB/file handles in finally;
+network/subprocess reads use the signal. No cancellation may infer local absence
+or mark a scan complete. This is a local TypeScript contract, not a generated
+HTTP API change. Writes/removals keep their existing ownership checks.
+
+## Engine and queue integration
+
+1. Keep initial Agent/registration identity validation as a shared startup
+   prerequisite. After it succeeds, start slots, heartbeat, SSE, and drain
+   together. Preserve one shared queue and one heartbeat per Agent.
+2. Use `unsupported` only when the adapter does not implement the module.
+   `preparing`, `draining`, and `retry_wait` are unavailable but retain all
+   queued work. Existing unsupported-module drop behavior remains explicit.
+3. Extend `RetryQueue.peek` with an eligibility predicate and add
+   `waitForChange(signal, timeoutMs)`, which waits for a new queue/slot event even
+   when the queue is nonempty. Drain selects an eligible item, acquires its
+   module lease synchronously, then awaits upload. If none is eligible, wait;
+   do not call the current `waitForItem` and spin on retained blocked work.
+   Slot publication wakes drain. Skip unready items without incrementing attempts
+   or drop counts. Preserve same-key version guards, identity fences and normal
+   upload retry budgets.
+4. Run queue HTTP calls under the lease signal combined with Agent shutdown.
+   Update queue/hash/claims only under that lease and current version. Closing
+   a module waits for this work before reloading its hash maps. A lease cancelled
+   by module shutdown retains the queue item and does not exhaust its retries.
+5. SSE acquires a Skill lease before onEvent; otherwise ignore the wakeup and
+   rely on the next complete startup scan. Vault-only auth handling remains
+   separate. Decide global SSE auth failure from adapter capability, not whether
+   the Skill slot happens to be ready.
+6. On recoverable preparation/run failure: `ready -> draining -> retry_wait ->
+   preparing`. Backoff starts at 1 second, doubles to 60 seconds with jitter,
+   and resets after one healthy minute, not after merely constructing a worker.
+   Publish module health errors through existing SyncHealth; healthy module
+   success must not clear another module's error.
+7. Identity revocation/disconnect and authoritative auth failure still invoke
+   the existing global abort/exit-code-2 path. These never enter local retry.
+   Engine finally closes slots, joins heartbeat/SSE/drain, flushes the queue,
+   and calls Vault finish even when startup preparation failed.
+
+If an old adapter cannot cancel an in-flight read, its slot stays `draining`
+until it actually completes; expose that state and never overlap a replacement
+worker. Other slots and runtime observation continue. Do not implement a
+Promise.race deadline that abandons a writer while claiming cleanup succeeded.
+The adapter context work is required to make shutdown itself bounded rather
+than merely make peer progress independent.
+
+## Reviewable acceptance scenarios
+
+Use `scripts/test.sh cli` only, with a fake HOME, real persisted queue, local
+fixture adapters, and controlled HTTP responses. Three integration scenarios
+cover the meaningful boundaries without one test per state:
+
+- Fail session protocol preparation, keep a queued session, and successfully
+  upload a Skill and heartbeat. Restore the session adapter; the retained session
+  uploads after backoff without duplicated watchers or a daemon restart.
+- Fail a Skill worker while its scan and one drain request are active. Verify
+  both leases drain/cancel before replacement, no stale hash/claim acknowledgement
+  removes a newer queued version, and healthy session uploads continue. Abort
+  during retry/cleanup and assert every owned handle and queue write finishes.
+- Return an authoritative 401/disconnect during local retry and during SSE.
+  Both slots and observation stop via the existing global authority boundary;
+  queued work is retained and exit code stays 2. A partial/aborted inventory never
+  authorizes deletion.
+
+Done: these scenarios and existing sync, queue, watcher, session protocol and
+Vault isolation tests pass through the hermetic CLI entrypoint, with no live
+services or left-over task resources. This design requires review of the
+adapter cancellation and lease boundaries before implementation is called done.

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -79,6 +79,7 @@ import {
 import {
 	applySystemdRuntimeUpdate,
 	assertRuntimeUserCanRead,
+	assertSystemdRuntimeIdle,
 	RUNTIME_SIDECAR_SYSTEM_UNIT,
 	readSystemdUnitSnapshot,
 	SystemdReobservationRequiredError,
@@ -1344,6 +1345,7 @@ async function applyRuntimeDesiredState(
 				opts.authorityCommit?.(committedConvergence, authority);
 			},
 			systemdApply: {
+				assertIdle: () => assertSystemdRuntimeIdle(paths, previousSystemdUnits),
 				activateEgressPrerequisite: () => {
 					const candidateSystemdUnits = readSystemdUnitSnapshot(paths);
 					try {
@@ -1420,6 +1422,10 @@ async function applyRuntimeDesiredState(
 			},
 		});
 		if (convergence.deferredReason) {
+			// Native plugin mutations/receipts may already exist. Keep their
+			// archives available for the next observation and reconciliation.
+			preservePreparedAgentPluginArchives =
+				convergence.deferredReason === "systemd_reobservation_required";
 			return {
 				kind: "deferred",
 				reason: convergence.deferredReason,
@@ -1441,6 +1447,10 @@ async function applyRuntimeDesiredState(
 				delete replayOptions.preparedHostedAgentPlugins;
 				delete replayOptions.preparedHostedSourcedSkills;
 				const replay = await applyRuntimeDesiredState(committed, paths, replayOptions);
+				if (replay.kind === "deferred") {
+					preservePreparedAgentPluginArchives = replay.reason === "systemd_reobservation_required";
+					return replay;
+				}
 				if (replay.kind !== "converged") {
 					convergence.installErrors.push(
 						`last-good replay failed: runtime ${replay.kind.replaceAll("_", " ")}`,

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -81,6 +81,7 @@ import {
 	assertRuntimeUserCanRead,
 	RUNTIME_SIDECAR_SYSTEM_UNIT,
 	readSystemdUnitSnapshot,
+	SystemdReobservationRequiredError,
 	withoutStaleSystemdUnits,
 } from "../runtime/systemd-transaction";
 import { syncRuntimeVaultFiles } from "../runtime/vault-files";
@@ -825,7 +826,10 @@ async function runtimeInitLocked(
 		return;
 	}
 	if (outcome.kind === "deferred") {
-		const message = "Hermes config changed during runtime convergence; retry on the next poll";
+		const message =
+			outcome.reason === "systemd_reobservation_required"
+				? "Systemd job outcome is unknown; retry with fresh observation on the next poll"
+				: "Hermes config changed during runtime convergence; retry on the next poll";
 		const applied = runtimeAppliedStatus(paths);
 		emitRuntimeInitRepair({
 			opts,
@@ -1093,7 +1097,11 @@ function runtimeWatchEventForOutcome(
 	paths: RuntimePaths,
 ): RuntimeWatchEvent | null {
 	if (outcome.kind === "idle") return null;
-	if (outcome.kind === "deferred") return null;
+	if (outcome.kind === "deferred") {
+		return outcome.reason === "systemd_reobservation_required"
+			? runtimeWatchError("final", outcome.convergence.installErrors, { etag: outcome.load.etag })
+			: null;
+	}
 	if (outcome.kind === "reconciliation_error") {
 		return runtimeWatchError("cli-update", [outcome.error], { selfReexec: false });
 	}
@@ -1359,6 +1367,7 @@ async function applyRuntimeDesiredState(
 						egressPrerequisiteApply = prerequisite;
 						return prerequisite;
 					} catch (error) {
+						if (error instanceof SystemdReobservationRequiredError) throw error;
 						throw new Error(
 							`transparent-egress prerequisite activation failed: ${toErrorMessage(error)}`,
 						);
@@ -1404,6 +1413,7 @@ async function applyRuntimeDesiredState(
 						};
 						return { ...systemdApply, activated: activation.activated };
 					} catch (error) {
+						if (error instanceof SystemdReobservationRequiredError) throw error;
 						throw new Error(`systemd apply failed: ${toErrorMessage(error)}`);
 					}
 				},

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -58,7 +58,7 @@ import {
 	type RuntimeResourcePreparationFailures,
 	runtimeRecoverableSecretValues,
 } from "../runtime/manifest";
-import { runtimeWorkspaceRoot } from "../runtime/manifest-planning";
+import { runtimeConvergenceWithoutApply, runtimeWorkspaceRoot } from "../runtime/manifest-planning";
 import {
 	hostedRuntimeBundleV2Schema,
 	loadCommittedRuntimeManifest,
@@ -218,7 +218,15 @@ type ConvergeOutcome =
 			ConvergeLoadResult,
 			{ kind: "not_modified" }
 	  >)
-	| { kind: "apply_error"; error: string; load?: RuntimeManifestLoad; etag?: string }
+	| {
+			kind: "apply_error";
+			error: string;
+			errors?: string[];
+			load?: RuntimeManifestLoad;
+			etag?: string;
+			cliRollback?: RuntimeCliRollbackResult;
+			selfReexec?: boolean;
+	  }
 	| { kind: "cli_update_failed"; load: RuntimeManifestLoad; cliUpdate: RuntimeCliUpdateResult }
 	| {
 			kind: "deferred";
@@ -598,10 +606,20 @@ function emitRuntimeInitRepair(
 		active?: ReturnType<typeof runtimeAppliedStatus>;
 		rejectedGeneration?: number | null;
 		manifestLoad?: RuntimeManifestLoad;
+		jsonExtras?: Record<string, unknown>;
 	},
 ): void {
-	const { opts, paths, persist, render, active, rejectedGeneration, manifestLoad, ...repair } =
-		input;
+	const {
+		opts,
+		paths,
+		persist,
+		render,
+		active,
+		rejectedGeneration,
+		manifestLoad,
+		jsonExtras,
+		...repair
+	} = input;
 	emitRuntimeInitStatus({
 		opts,
 		paths,
@@ -628,6 +646,7 @@ function emitRuntimeInitRepair(
 		},
 		persist,
 		render,
+		jsonExtras,
 	});
 }
 
@@ -858,6 +877,7 @@ async function runtimeInitLocked(
 				? outcome.error
 				: (outcome.cliUpdate.error ?? "CLI update failed");
 		const load = outcome.load;
+		const selfReexec = outcome.kind === "apply_error" && outcome.selfReexec === true;
 		const applied = runtimeAppliedStatus(paths);
 		emitRuntimeInitRepair({
 			opts,
@@ -865,11 +885,17 @@ async function runtimeInitLocked(
 			stage: outcome.kind === "cli_update_failed" ? "config" : "final",
 			bootId,
 			runtimeMode: mode,
-			errors: [message],
-			exitCode: 23,
+			errors: outcome.kind === "apply_error" ? (outcome.errors ?? [message]) : [message],
+			exitCode: selfReexec ? RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE : 23,
 			active: applied,
 			rejectedGeneration: load?.manifest.generation ?? null,
 			...(outcome.kind === "apply_error" && load ? { manifestLoad: load } : {}),
+			jsonExtras: {
+				...(outcome.kind === "apply_error" && outcome.cliRollback
+					? { cliRollback: outcome.cliRollback }
+					: {}),
+				...(selfReexec ? { selfReexec: true, handoff: "cli_reexec" } : {}),
+			},
 			render: renderRuntimeInit(paths, `repair: ${message}`, chalk.red),
 		});
 		return;
@@ -896,7 +922,7 @@ async function runtimeInitLocked(
 				...(outcome.resourceProjectionErrors.length > 0
 					? { resourceProjectionErrors: outcome.resourceProjectionErrors }
 					: {}),
-				exitCode: runtimeReady ? 0 : 23,
+				exitCode: outcome.selfReexec ? RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE : runtimeReady ? 0 : 23,
 				datasource: "RuntimeSource",
 				hostPolicy: hostPolicySummary(hostPolicy),
 				manifestSource: {
@@ -905,6 +931,10 @@ async function runtimeInitLocked(
 					offline: outcome.convergence.offline,
 				},
 				convergence: outcome.convergence.outputs,
+			},
+			jsonExtras: {
+				...(outcome.cliRollback ? { cliRollback: outcome.cliRollback } : {}),
+				...(outcome.selfReexec ? { selfReexec: true, handoff: "cli_reexec" } : {}),
 			},
 			render: renderRuntimeInit(
 				paths,
@@ -971,11 +1001,38 @@ async function convergeOnce(
 		}
 		applyResult = await applyRuntimeManifestLoad(convergenceLoad, paths, apply);
 	} catch (error) {
+		const message = toErrorMessage(error);
+		if (error instanceof SystemdReobservationRequiredError) {
+			return {
+				kind: "deferred",
+				load: convergenceLoad,
+				reason: "systemd_reobservation_required",
+				convergence: runtimeConvergenceWithoutApply({
+					load: convergenceLoad,
+					paths,
+					workspaceRoot: runtimeWorkspaceRoot(convergenceLoad.manifest, paths),
+					enabledRuntimes: Object.entries(convergenceLoad.manifest.runtimes)
+						.filter(([, runtime]) => runtime.enabled)
+						.map(([name]) => name),
+					installErrors: [message],
+					projectedProviderIds: {},
+				}),
+			};
+		}
+		const errors = [message];
+		const cliRollback = maybeRollbackFailedCliUpgrade(paths, errors);
 		return {
 			kind: "apply_error",
-			error: toErrorMessage(error),
+			error: message,
+			errors,
 			load: convergenceLoad,
 			...(convergenceLoad.etag ? { etag: convergenceLoad.etag } : {}),
+			...(cliRollback.status !== "not_pending"
+				? {
+						cliRollback,
+						selfReexec: cliRollback.status === "rolled_back",
+					}
+				: {}),
 		};
 	}
 	if (applyResult.kind === "cli_handoff") {
@@ -1159,8 +1216,17 @@ export function runtimeWatchEventForOutcome(
 		});
 	}
 	if (outcome.kind === "apply_error") {
-		return runtimeWatchError("final", [outcome.error], {
+		return runtimeWatchError("final", outcome.errors ?? [outcome.error], {
 			...(outcome.etag ? { etag: outcome.etag } : {}),
+			...(outcome.load
+				? {
+						...runtimeAppliedStatus(paths),
+						rejectedGeneration: outcome.load.manifest.generation,
+					}
+				: {}),
+			...(outcome.cliRollback
+				? { cliRollback: outcome.cliRollback, selfReexec: outcome.selfReexec }
+				: {}),
 		});
 	}
 	if (outcome.kind === "cli_update_failed") {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -832,18 +832,23 @@ async function runtimeInitLocked(
 				? "Systemd job outcome is unknown; retry with fresh observation on the next poll"
 				: "Hermes config changed during runtime convergence; retry on the next poll";
 		const applied = runtimeAppliedStatus(paths);
+		const errors = [
+			...outcome.convergence.installErrors,
+			...outcome.convergence.resourceProjectionErrors,
+			message,
+		];
 		emitRuntimeInitRepair({
 			opts,
 			paths,
 			stage: "final",
 			bootId,
 			runtimeMode: mode,
-			errors: [message],
+			errors,
 			exitCode: 23,
 			active: applied,
 			rejectedGeneration: outcome.load.manifest.generation,
 			manifestLoad: outcome.load,
-			render: renderRuntimeInit(paths, `repair: ${message}`, chalk.red),
+			render: renderRuntimeInit(paths, `repair: ${errors[0]}`, chalk.red),
 		});
 		return;
 	}
@@ -1093,14 +1098,18 @@ async function loadRuntimeManifestForWatch(
 	}
 }
 
-function runtimeWatchEventForOutcome(
+export function runtimeWatchEventForOutcome(
 	outcome: ConvergeOutcome,
 	paths: RuntimePaths,
 ): RuntimeWatchEvent | null {
 	if (outcome.kind === "idle") return null;
 	if (outcome.kind === "deferred") {
-		return outcome.reason === "systemd_reobservation_required"
-			? runtimeWatchError("final", outcome.convergence.installErrors, { etag: outcome.load.etag })
+		const errors = [
+			...outcome.convergence.installErrors,
+			...outcome.convergence.resourceProjectionErrors,
+		];
+		return errors.length > 0
+			? runtimeWatchError("final", errors, { etag: outcome.load.etag })
 			: null;
 	}
 	if (outcome.kind === "reconciliation_error") {
@@ -1448,8 +1457,19 @@ async function applyRuntimeDesiredState(
 				delete replayOptions.preparedHostedSourcedSkills;
 				const replay = await applyRuntimeDesiredState(committed, paths, replayOptions);
 				if (replay.kind === "deferred") {
-					preservePreparedAgentPluginArchives = replay.reason === "systemd_reobservation_required";
-					return replay;
+					preservePreparedAgentPluginArchives = true;
+					return {
+						...replay,
+						convergence: {
+							...convergence,
+							deferredReason: replay.reason,
+							installErrors: [...convergence.installErrors, ...replay.convergence.installErrors],
+							resourceProjectionErrors: [
+								...convergence.resourceProjectionErrors,
+								...replay.convergence.resourceProjectionErrors,
+							],
+						},
+					};
 				}
 				if (replay.kind !== "converged") {
 					convergence.installErrors.push(

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1332,6 +1332,13 @@ export function convergeRuntimeManifest(
 	opts: RuntimeConvergenceOptions = {},
 ): RuntimeConvergenceResult {
 	const { context, state } = initializeRuntimeConvergence(load, paths, opts);
+	try {
+		// Check existing jobs before changing native installs/config/plugins, not
+		// only after publishing the candidate units at activation time.
+		opts.systemdApply?.assertIdle?.();
+	} catch (error) {
+		return runtimeApplyFailure(context, state, error);
+	}
 	const installResult = prepareRuntimeInstallStage(context, state);
 	if (installResult) return installResult.result;
 	context.hermesConfig = beginRuntimeHermesConfig(context, state);

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1337,6 +1337,9 @@ export function convergeRuntimeManifest(
 		// only after publishing the candidate units at activation time.
 		opts.systemdApply?.assertIdle?.();
 	} catch (error) {
+		// No native mutations have started. Preserve setup/inspection failures
+		// as errors, without attempting a compensating apply or CLI rollback.
+		if (!(error instanceof SystemdReobservationRequiredError)) throw error;
 		return runtimeApplyFailure(context, state, error);
 	}
 	const installResult = prepareRuntimeInstallStage(context, state);

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -129,6 +129,7 @@ import {
 } from "./runtime-systemd-reconciliation";
 import { executableExists, withRuntimeUserFileAccess } from "./runtime-user-command";
 import { ensureRuntimePlatformDirectory } from "./state";
+import { SystemdReobservationRequiredError } from "./systemd-transaction";
 
 type RuntimeManifest = RuntimeManifestLoad["manifest"];
 type RuntimeEntry = [string, RuntimeManifest["runtimes"][string]];
@@ -1307,6 +1308,13 @@ function runtimeApplyFailure(
 	state: RuntimeConvergenceState,
 	error: unknown,
 ): RuntimeConvergenceResult {
+	if (error instanceof SystemdReobservationRequiredError) {
+		state.installErrors.push(error.message);
+		return {
+			...runtimeConvergenceFailure(context, state),
+			deferredReason: "systemd_reobservation_required",
+		};
+	}
 	if (state.agentPluginMutationAttempted) {
 		for (const name of state.agentPluginTransaction?.mutationNames ?? []) {
 			state.agentPluginFailedNames.add(name);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -38,6 +38,7 @@ import {
 } from "./runtime-systemd-reconciliation";
 import { ensureRuntimeStateDirs } from "./state";
 import { RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
+import { SystemdReobservationRequiredError } from "./systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const originalEnv = { ...process.env };
@@ -346,6 +347,48 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_AUTH_TOKEN = "test-token";
 	return getRuntimePaths({ mode: "hosted" });
 }
+
+test("defers unknown systemd jobs without committing authority and accepts a later completed observation", () => {
+	const paths = tempRuntimePaths();
+	const load: RuntimeManifestLoad = {
+		manifest: {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "hdep_systemd_pending",
+			environmentId: "env_systemd_pending",
+			instanceId: "hri_systemd_pending",
+			generation: 1,
+			issuedAt: "2026-09-11T00:00:00Z",
+			workspaceRoot: paths.userHome,
+			controlPlane: { apiUrl: "https://cloud.example.test" },
+			runtimes: {},
+			recovery: {},
+		},
+		source: "remote-datasource",
+		sourcePath: "inline-systemd-pending",
+		offline: false,
+	};
+	let pending = true;
+	let commits = 0;
+	const converge = () =>
+		convergeRuntimeManifest(load, paths, {
+			commitAuthority: () => commits++,
+			systemdApply: {
+				activateEgressPrerequisite: () => {
+					throw new Error("unexpected egress prerequisite");
+				},
+				activate: () => {
+					if (pending) throw new SystemdReobservationRequiredError();
+					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+				},
+			},
+		});
+	const deferred = converge();
+	expect(deferred.deferredReason).toBe("systemd_reobservation_required");
+	expect(commits).toBe(0);
+	pending = false;
+	expect(converge().installErrors).toEqual([]);
+	expect(commits).toBe(1);
+});
 
 function runSettings(command: string, args: string[]): RuntimeRunSettings {
 	return { command, args, env: {}, prependPath: [] };

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -367,7 +367,7 @@ test("defers unknown systemd jobs without committing authority and accepts a lat
 		sourcePath: "inline-systemd-pending",
 		offline: false,
 	};
-	let pending: "preflight" | "activation" | null = "preflight";
+	let pending: "preflight" | "activation" | "invalid-preflight" | null = "preflight";
 	let commits = 0;
 	let activations = 0;
 	const converge = () =>
@@ -375,6 +375,7 @@ test("defers unknown systemd jobs without committing authority and accepts a lat
 			commitAuthority: () => commits++,
 			systemdApply: {
 				assertIdle: () => {
+					if (pending === "invalid-preflight") throw new Error("systemctl is missing");
 					if (pending === "preflight") throw new SystemdReobservationRequiredError();
 				},
 				activateEgressPrerequisite: () => {
@@ -391,6 +392,10 @@ test("defers unknown systemd jobs without committing authority and accepts a lat
 	expect(deferred.deferredReason).toBe("systemd_reobservation_required");
 	expect(commits).toBe(0);
 	expect(activations).toBe(0);
+	pending = "invalid-preflight";
+	expect(converge).toThrow("systemctl is missing");
+	expect(activations).toBe(0);
+	expect(commits).toBe(0);
 	pending = "activation";
 	expect(converge().deferredReason).toBe("systemd_reobservation_required");
 	expect(commits).toBe(0);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -367,17 +367,22 @@ test("defers unknown systemd jobs without committing authority and accepts a lat
 		sourcePath: "inline-systemd-pending",
 		offline: false,
 	};
-	let pending = true;
+	let pending: "preflight" | "activation" | null = "preflight";
 	let commits = 0;
+	let activations = 0;
 	const converge = () =>
 		convergeRuntimeManifest(load, paths, {
 			commitAuthority: () => commits++,
 			systemdApply: {
+				assertIdle: () => {
+					if (pending === "preflight") throw new SystemdReobservationRequiredError();
+				},
 				activateEgressPrerequisite: () => {
 					throw new Error("unexpected egress prerequisite");
 				},
 				activate: () => {
-					if (pending) throw new SystemdReobservationRequiredError();
+					activations++;
+					if (pending === "activation") throw new SystemdReobservationRequiredError();
 					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
 				},
 			},
@@ -385,7 +390,11 @@ test("defers unknown systemd jobs without committing authority and accepts a lat
 	const deferred = converge();
 	expect(deferred.deferredReason).toBe("systemd_reobservation_required");
 	expect(commits).toBe(0);
-	pending = false;
+	expect(activations).toBe(0);
+	pending = "activation";
+	expect(converge().deferredReason).toBe("systemd_reobservation_required");
+	expect(commits).toBe(0);
+	pending = null;
 	expect(converge().installErrors).toEqual([]);
 	expect(commits).toBe(1);
 });

--- a/packages/cli/src/runtime/manifest-shared.ts
+++ b/packages/cli/src/runtime/manifest-shared.ts
@@ -52,6 +52,7 @@ interface RuntimeSystemdApplySignal {
 	invalidatedUserUnits: string[];
 }
 export interface RuntimeSystemdApplyHooks {
+	assertIdle?: () => void;
 	activateEgressPrerequisite: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 	activate: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 }

--- a/packages/cli/src/runtime/manifest-shared.ts
+++ b/packages/cli/src/runtime/manifest-shared.ts
@@ -19,7 +19,7 @@ export interface RuntimeConvergenceResult {
 	resourceProjectionErrors: string[];
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames: string[];
-	deferredReason?: "hermes_config_conflict";
+	deferredReason?: "hermes_config_conflict" | "systemd_reobservation_required";
 	outputs: {
 		processManager: "systemd";
 		workspaceRoot: string;

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -112,6 +112,8 @@ export function createPrivilegeDropResolver(
 const privilegeDropResolver = createPrivilegeDropResolver();
 
 interface BuildRuntimeUserCommandOptions {
+	/** Keep noninteractive command descendants in the caller's supervised group. */
+	preserveSession?: boolean;
 	currentUid?: number;
 	runtimeUid?: number;
 	runtimeGid?: number;
@@ -180,7 +182,7 @@ export function buildRuntimeUserCommand(
 			"--preserve-environment",
 			"--shell",
 			"/bin/sh",
-			"--command",
+			options.preserveSession ? "--session-command" : "--command",
 			'exec "$0" "$@"',
 			runtimeUser,
 			childCommand,

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -52,7 +52,7 @@ export function commandResolvable(command: string): boolean {
 	return isAbsolute(command) ? executableExists(command) : commandExists(command);
 }
 
-const PRIVILEGE_DROP_STRATEGIES = [
+export const PRIVILEGE_DROP_STRATEGIES = [
 	{ mechanism: "setpriv", supportsNumericIdentity: true },
 	{ mechanism: "runuser", supportsNumericIdentity: false },
 	{ mechanism: "su", supportsNumericIdentity: false },

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -37,6 +37,15 @@ interface CommandResult {
 export const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
 export const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
 const NON_TRANSACTIONAL_SYSTEM_UNITS = new Set([RUNTIME_WATCH_SYSTEM_UNIT]);
+const SYSTEMD_COMMAND_TIMEOUT_MS = 120_000;
+
+export class SystemdReobservationRequiredError extends Error {
+	constructor(
+		message = "systemd command timed out; job outcome is unknown and requires fresh observation",
+	) {
+		super(message);
+	}
+}
 
 export function shouldRecoverFailedSystemdUnit(input: {
 	activeState: string;
@@ -418,10 +427,12 @@ function readSystemdRuntimeUnits(
 	if (uniqueUnits.length === 0) return states;
 	const showArgs = [
 		"show",
+		"--all",
 		...uniqueUnits,
 		"--property=LoadState",
 		"--property=ActiveState",
 		"--property=NeedDaemonReload",
+		"--property=Job",
 	];
 	const show = systemdCommandResult(paths, scope, showArgs);
 	assertCommandSucceeded(systemdCommandName(scope), showArgs, show);
@@ -469,8 +480,17 @@ function parseSystemdUnitManagerState(
 	const loadState = properties.LoadState;
 	const activeState = properties.ActiveState;
 	const needDaemonReload = properties.NeedDaemonReload;
-	if (!loadState || !activeState || !needDaemonReload) {
+	const job = properties.Job;
+	if (!loadState || !activeState || !needDaemonReload || job === undefined) {
 		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
+	}
+	if (
+		job !== "" ||
+		["activating", "deactivating", "reloading", "refreshing"].includes(activeState)
+	) {
+		throw new SystemdReobservationRequiredError(
+			`systemd ${scope} unit ${unit} has unfinished work; fresh observation is required`,
+		);
 	}
 	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
 		throw new Error(
@@ -607,15 +627,23 @@ function runCommand(command: string, args: string[], env?: Record<string, string
 	return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
 }
 
-function runCommandResult(
+export function runCommandResult(
 	command: string,
 	args: string[],
 	env?: Record<string, string>,
+	timeoutMs = SYSTEMD_COMMAND_TIMEOUT_MS,
 ): CommandResult {
 	const result = spawnSync(command, args, {
 		encoding: "utf8",
+		timeout: timeoutMs,
+		// Terminate the client even if it ignores TERM. This does not cancel the
+		// manager's job; the caller must defer authority/rollback and re-observe.
+		killSignal: "SIGKILL",
 		...(env ? { env: { ...process.env, ...env } } : {}),
 	});
+	if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
+		throw new SystemdReobservationRequiredError();
+	}
 	return {
 		status: result.status,
 		stdout: result.stdout ?? "",

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -68,6 +68,22 @@ export function readSystemdUnitSnapshot(
 	};
 }
 
+export function assertSystemdRuntimeIdle(
+	paths: ReturnType<typeof getRuntimePaths>,
+	snapshot: SystemdUnitSnapshot,
+): void {
+	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
+	try {
+		readSystemdRuntimeUnits(paths, "system", [...snapshot.system.keys()]);
+		readSystemdRuntimeUnits(paths, "user", [...snapshot.user.keys()]);
+	} catch (error) {
+		if (error instanceof SystemdReobservationRequiredError) throw error;
+		throw new SystemdReobservationRequiredError(
+			"systemd preflight state is unavailable; fresh observation is required",
+		);
+	}
+}
+
 function systemdUnitFingerprint(
 	paths: ReturnType<typeof getRuntimePaths>,
 	unit: string,
@@ -608,7 +624,7 @@ function runtimeUserSystemctlResult(
 			paths.userHome,
 			systemctlPath(),
 			["--user", ...args],
-			{ environment: runtimeUserSystemdEnvironment(uid) },
+			{ environment: runtimeUserSystemdEnvironment(uid), preserveSession: true },
 		);
 		return runCommandResult(child.command, child.args, child.env);
 	}
@@ -617,7 +633,9 @@ function runtimeUserSystemctlResult(
 
 export function assertRuntimeUserCanRead(path: string, home: string): void {
 	const runtimeUser = runtimeUserName();
-	const proof = buildRuntimeUserCommand(runtimeUser, home, "test", ["-r", path]);
+	const proof = buildRuntimeUserCommand(runtimeUser, home, "test", ["-r", path], {
+		preserveSession: true,
+	});
 	runCommand(proof.command, proof.args, proof.env);
 }
 
@@ -633,15 +651,22 @@ export function runCommandResult(
 	env?: Record<string, string>,
 	timeoutMs = SYSTEMD_COMMAND_TIMEOUT_MS,
 ): CommandResult {
-	const result = spawnSync(command, args, {
-		encoding: "utf8",
-		timeout: timeoutMs,
-		// Terminate the client even if it ignores TERM. This does not cancel the
-		// manager's job; the caller must defer authority/rollback and re-observe.
-		killSignal: "SIGKILL",
-		...(env ? { env: { ...process.env, ...env } } : {}),
-	});
-	if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
+	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+		throw new Error("systemd command timeout must be a positive integer");
+	}
+	// GNU timeout supervises its own process group. A spawnSync timeout kills
+	// only the direct child, leaving descendants holding stdout/stderr open.
+	const result = spawnSync(
+		"/usr/bin/timeout",
+		["--signal=KILL", `${timeoutMs / 1000}s`, command, ...args],
+		{
+			encoding: "utf8",
+			...(env ? { env: { ...process.env, ...env } } : {}),
+		},
+	);
+	// SIGKILL also terminates timeout itself. A killed/OOM client is likewise
+	// an unknown manager outcome; neither result proves that a job was cancelled.
+	if (result.signal === "SIGKILL" || result.status === 124 || result.status === 137) {
 		throw new SystemdReobservationRequiredError();
 	}
 	return {

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -73,15 +73,13 @@ export function assertSystemdRuntimeIdle(
 	snapshot: SystemdUnitSnapshot,
 ): void {
 	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
-	try {
-		readSystemdRuntimeUnits(paths, "system", [...snapshot.system.keys()]);
-		readSystemdRuntimeUnits(paths, "user", [...snapshot.user.keys()]);
-	} catch (error) {
-		if (error instanceof SystemdReobservationRequiredError) throw error;
-		throw new SystemdReobservationRequiredError(
-			"systemd preflight state is unavailable; fresh observation is required",
-		);
+	// First install has no unit inventory yet, but still requires the tools
+	// and manager connection before native mutations start.
+	if (snapshot.system.size === 0 && snapshot.user.size === 0) {
+		systemctl(["show", "--property=Version"]);
 	}
+	readSystemdRuntimeUnits(paths, "system", [...snapshot.system.keys()]);
+	readSystemdRuntimeUnits(paths, "user", [...snapshot.user.keys()]);
 }
 
 function systemdUnitFingerprint(
@@ -500,17 +498,19 @@ function parseSystemdUnitManagerState(
 	if (!loadState || !activeState || !needDaemonReload || job === undefined) {
 		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
 	}
-	if (
-		job !== "" ||
-		["activating", "deactivating", "reloading", "refreshing"].includes(activeState)
-	) {
-		throw new SystemdReobservationRequiredError(
-			`systemd ${scope} unit ${unit} has unfinished work; fresh observation is required`,
-		);
-	}
 	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
 		throw new Error(
 			`systemd ${scope} unit ${unit} returned invalid NeedDaemonReload: ${needDaemonReload}`,
+		);
+	}
+	if (job !== "" && !/^[1-9][0-9]*$/.test(job)) {
+		throw new Error(`systemd ${scope} unit ${unit} returned invalid Job: ${job}`);
+	}
+	// Restart=always can be activating/auto-restart without a Job. Admit its
+	// repair and let final readiness determine whether it recovered.
+	if (job !== "") {
+		throw new SystemdReobservationRequiredError(
+			`systemd ${scope} unit ${unit} has unfinished work; fresh observation is required`,
 		);
 	}
 	const managerState = {
@@ -667,6 +667,11 @@ export function runCommandResult(
 			...(env ? { env: { ...process.env, ...env } } : {}),
 		},
 	);
+	if (result.error && "code" in result.error && result.error.code === "ENOENT") {
+		throw new Error(
+			"systemd runtime commands require GNU timeout at /usr/bin/timeout; install GNU coreutils",
+		);
+	}
 	// SIGKILL also terminates timeout itself. A killed/OOM client is likewise
 	// an unknown manager outcome; neither result proves that a job was cancelled.
 	if (result.signal === "SIGKILL" || result.status === 124 || result.status === 137) {

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -651,6 +651,9 @@ export function runCommandResult(
 	env?: Record<string, string>,
 	timeoutMs = SYSTEMD_COMMAND_TIMEOUT_MS,
 ): CommandResult {
+	if (process.platform !== "linux") {
+		throw new Error("systemd runtime commands require Linux");
+	}
 	if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
 		throw new Error("systemd command timeout must be a positive integer");
 	}

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getRuntimePaths } from "./paths";
+import { buildRuntimeUserCommand } from "./runtime-user-command";
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
 import {
 	applySystemdRuntimeUpdate,
@@ -103,7 +104,12 @@ esac
 	test("bounds an unresponsive client without treating the manager job as cancelled", () => {
 		const start = Date.now();
 		expect(() =>
-			runCommandResult("/bin/sh", ["-c", "trap '' TERM; while :; do :; done"], undefined, 50),
+			runCommandResult(
+				"/bin/sh",
+				["-c", "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & wait"],
+				undefined,
+				50,
+			),
 		).toThrow(SystemdReobservationRequiredError);
 		expect(Date.now() - start).toBeLessThan(5_000);
 		expect(runCommandResult("/bin/sh", ["-c", "printf active"], undefined, 1_000)).toMatchObject({
@@ -111,6 +117,59 @@ esac
 			stdout: "active",
 		});
 	});
+	test.skipIf(process.env.CLAWDI_TEST_SYSTEMD_COMMAND !== "1")(
+		"verifies native Job rendering and privilege-wrapper descendant deadlines",
+		() => {
+			const unit = `clawdi-command-proof-${crypto.randomUUID()}.service`;
+			const path = `/run/systemd/system/${unit}`;
+			writeFileSync(path, "[Service]\nType=oneshot\nExecStart=/bin/sleep 30\n");
+			try {
+				expect(runCommandResult("systemctl", ["daemon-reload"]).status).toBe(0);
+				const idle = runCommandResult("systemctl", ["show", "--all", "--property=Job", unit]);
+				expect(idle.stdout.trim()).toBe("Job=");
+				expect(runCommandResult("systemctl", ["start", "--no-block", unit]).status).toBe(0);
+				const busy = runCommandResult("systemctl", ["show", "--all", "--property=Job", unit]);
+				expect(busy.stdout.trim()).toMatch(/^Job=[1-9][0-9]*$/);
+				expect(() => runCommandResult("systemctl", ["start", unit], undefined, 100)).toThrow(
+					SystemdReobservationRequiredError,
+				);
+				expect(
+					runCommandResult("systemctl", ["show", "--all", "--property=Job", unit]).stdout.trim(),
+				).toMatch(/^Job=[1-9][0-9]*$/);
+				for (const mechanism of ["setpriv", "runuser", "su"] as const) {
+					const child = buildRuntimeUserCommand(
+						"clawdi",
+						"/home/clawdi",
+						"/bin/sh",
+						["-c", "trap '' TERM; sh -c 'trap \"\" TERM; while :; do :; done' & wait"],
+						{
+							runtimeUid: 10001,
+							runtimeGid: 10001,
+							preserveSession: true,
+							resolver: { resolve: () => mechanism },
+						},
+					);
+					const started = Date.now();
+					expect(() => runCommandResult(child.command, child.args, child.env, 100)).toThrow(
+						SystemdReobservationRequiredError,
+					);
+					expect(Date.now() - started).toBeLessThan(3_000);
+				}
+				expect(runCommandResult("systemctl", ["stop", unit]).status).toBe(0);
+				expect(
+					runCommandResult("systemctl", ["show", "--all", "--property=Job", unit]).stdout.trim(),
+				).toBe("Job=");
+				const version = runCommandResult("systemctl", ["--version"]).stdout.split("\n")[0];
+				console.log(
+					`native ${version} proof: ${idle.stdout.trim()}, ${busy.stdout.trim()}; all wrapper deadlines passed`,
+				);
+			} finally {
+				runCommandResult("systemctl", ["stop", unit]);
+				rmSync(path);
+				runCommandResult("systemctl", ["daemon-reload"]);
+			}
+		},
+	);
 	test("recovers a failed unit when the current activation changed it", () => {
 		expect(
 			shouldRecoverFailedSystemdUnit({

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { getRuntimePaths } from "./paths";
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
-import { shouldRecoverFailedSystemdUnit } from "./systemd-transaction";
+import {
+	applySystemdRuntimeUpdate,
+	runCommandResult,
+	SystemdReobservationRequiredError,
+	shouldRecoverFailedSystemdUnit,
+} from "./systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const roots: string[] = [];
@@ -48,6 +54,63 @@ describe("managed runtime systemd unit classification", () => {
 });
 
 describe("failed runtime systemd unit recovery", () => {
+	test("reobserves an existing job before issuing mutations", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-systemd-pending-"));
+		roots.push(root);
+		const command = join(root, "systemctl");
+		const log = join(root, "commands");
+		const previous = {
+			apply: process.env.CLAWDI_SYSTEMD_APPLY,
+			command: process.env.CLAWDI_SYSTEMCTL_PATH,
+		};
+		try {
+			process.env.CLAWDI_SYSTEMD_APPLY = "1";
+			process.env.CLAWDI_SYSTEMCTL_PATH = command;
+			const paths = {
+				...getRuntimePaths({ mode: "local" }),
+				appliedState: join(root, "absent.json"),
+			};
+			const snapshot = {
+				system: new Map([["clawdi-fixture.service", "revision"]]),
+				user: new Map<string, string>(),
+			};
+			const writeManager = (job: string) =>
+				writeFileSync(
+					command,
+					`#!/bin/sh
+echo "$*" >> '${log}'
+case "$1" in
+show) printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\nJob=${job}\\n' ;;
+is-enabled) printf 'enabled\\n' ;;
+esac
+`,
+					{ mode: 0o755 },
+				);
+			writeManager("42");
+			expect(() => applySystemdRuntimeUpdate(paths, snapshot, snapshot, {})).toThrow(
+				SystemdReobservationRequiredError,
+			);
+			expect(readFileSync(log, "utf8")).not.toMatch(/restart|start|stop|daemon-reload/);
+			writeManager("");
+			expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(true);
+		} finally {
+			if (previous.apply === undefined) delete process.env.CLAWDI_SYSTEMD_APPLY;
+			else process.env.CLAWDI_SYSTEMD_APPLY = previous.apply;
+			if (previous.command === undefined) delete process.env.CLAWDI_SYSTEMCTL_PATH;
+			else process.env.CLAWDI_SYSTEMCTL_PATH = previous.command;
+		}
+	});
+	test("bounds an unresponsive client without treating the manager job as cancelled", () => {
+		const start = Date.now();
+		expect(() =>
+			runCommandResult("/bin/sh", ["-c", "trap '' TERM; while :; do :; done"], undefined, 50),
+		).toThrow(SystemdReobservationRequiredError);
+		expect(Date.now() - start).toBeLessThan(5_000);
+		expect(runCommandResult("/bin/sh", ["-c", "printf active"], undefined, 1_000)).toMatchObject({
+			status: 0,
+			stdout: "active",
+		});
+	});
 	test("recovers a failed unit when the current activation changed it", () => {
 		expect(
 			shouldRecoverFailedSystemdUnit({

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -7,6 +7,7 @@ import { buildRuntimeUserCommand, PRIVILEGE_DROP_STRATEGIES } from "./runtime-us
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
 import {
 	applySystemdRuntimeUpdate,
+	assertSystemdRuntimeIdle,
 	runCommandResult,
 	SystemdReobservationRequiredError,
 	shouldRecoverFailedSystemdUnit,
@@ -75,13 +76,13 @@ describe("failed runtime systemd unit recovery", () => {
 				system: new Map([["clawdi-fixture.service", "revision"]]),
 				user: new Map<string, string>(),
 			};
-			const writeManager = (job: string) =>
+			const writeManager = (job: string, activeState = "active") =>
 				writeFileSync(
 					command,
 					`#!/bin/sh
 echo "$*" >> '${log}'
 case "$1" in
-show) printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\nJob=${job}\\n' ;;
+show) printf 'LoadState=loaded\\nActiveState=${activeState}\\nSubState=${activeState === "activating" ? "auto-restart" : "running"}\\nNeedDaemonReload=no\\nJob=${job}\\n' ;;
 is-enabled) printf 'enabled\\n' ;;
 esac
 `,
@@ -92,8 +93,18 @@ esac
 				SystemdReobservationRequiredError,
 			);
 			expect(readFileSync(log, "utf8")).not.toMatch(/restart|start|stop|daemon-reload/);
+			writeManager("", "activating");
+			expect(() => assertSystemdRuntimeIdle(paths, snapshot)).not.toThrow();
+			expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(false);
 			writeManager("");
 			expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(true);
+			writeManager("invalid");
+			expect(() => assertSystemdRuntimeIdle(paths, snapshot)).toThrow("invalid Job");
+			writeFileSync(command, "#!/bin/sh\nprintf 'bus unavailable' >&2\nexit 1\n");
+			expect(() => assertSystemdRuntimeIdle(paths, snapshot)).toThrow("bus unavailable");
+			expect(() => assertSystemdRuntimeIdle(paths, { system: new Map(), user: new Map() })).toThrow(
+				"bus unavailable",
+			);
 		} finally {
 			if (previous.apply === undefined) delete process.env.CLAWDI_SYSTEMD_APPLY;
 			else process.env.CLAWDI_SYSTEMD_APPLY = previous.apply;
@@ -162,6 +173,56 @@ esac
 				const version = runCommandResult("systemctl", ["--version"]).stdout.split("\n")[0];
 				console.log(
 					`native ${version} proof: ${idle.stdout.trim()}, ${busy.stdout.trim()}; all wrapper deadlines passed`,
+				);
+			} finally {
+				runCommandResult("systemctl", ["stop", unit]);
+				rmSync(path);
+				runCommandResult("systemctl", ["daemon-reload"]);
+			}
+		},
+	);
+	test.skipIf(process.env.CLAWDI_TEST_SYSTEMD_COMMAND !== "1")(
+		"allows no-job auto-restart to reach final proof without claiming it is healthy",
+		async () => {
+			const unit = `clawdi-restart-proof-${crypto.randomUUID()}.service`;
+			const path = `/run/systemd/system/${unit}`;
+			const definition = (command: string) =>
+				`[Service]\nExecStart=${command}\nRestart=always\nRestartSec=60\n[Install]\nWantedBy=multi-user.target\n`;
+			const paths = {
+				...getRuntimePaths({ mode: "local" }),
+				systemdSystemRoot: "/run/systemd/system",
+				appliedState: join(tmpdir(), `${unit}.absent.json`),
+			};
+			const snapshot = { system: new Map([[unit, "fixture"]]), user: new Map<string, string>() };
+			writeFileSync(path, definition("/bin/false"));
+			try {
+				runCommandResult("systemctl", ["daemon-reload"]);
+				runCommandResult("systemctl", ["start", unit]);
+				let observed = "";
+				const deadline = Date.now() + 5_000;
+				do {
+					observed = runCommandResult("systemctl", [
+						"show",
+						"--all",
+						"--property=ActiveState",
+						"--property=SubState",
+						"--property=Job",
+						unit,
+					]).stdout;
+					if (observed.includes("SubState=auto-restart")) break;
+					await Bun.sleep(25);
+				} while (Date.now() < deadline);
+				expect(observed).toContain("ActiveState=activating");
+				expect(observed).toContain("SubState=auto-restart");
+				expect(observed).toMatch(/^Job=$/m);
+				expect(() => assertSystemdRuntimeIdle(paths, snapshot)).not.toThrow();
+				expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(false);
+				writeFileSync(path, definition("/bin/sleep 30"));
+				runCommandResult("systemctl", ["daemon-reload"]);
+				expect(runCommandResult("systemctl", ["restart", unit]).status).toBe(0);
+				expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(true);
+				console.log(
+					`native crash-loop proof: ${observed.trim().replaceAll("\n", ", ")}; readiness required after repair`,
 				);
 			} finally {
 				runCommandResult("systemctl", ["stop", unit]);

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getRuntimePaths } from "./paths";
-import { buildRuntimeUserCommand } from "./runtime-user-command";
+import { buildRuntimeUserCommand, PRIVILEGE_DROP_STRATEGIES } from "./runtime-user-command";
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
 import {
 	applySystemdRuntimeUpdate,
@@ -136,7 +136,7 @@ esac
 				expect(
 					runCommandResult("systemctl", ["show", "--all", "--property=Job", unit]).stdout.trim(),
 				).toMatch(/^Job=[1-9][0-9]*$/);
-				for (const mechanism of ["setpriv", "runuser", "su"] as const) {
+				for (const { mechanism } of PRIVILEGE_DROP_STRATEGIES) {
 					const child = buildRuntimeUserCommand(
 						"clawdi",
 						"/home/clawdi",

--- a/packages/cli/src/serve/queue.test.ts
+++ b/packages/cli/src/serve/queue.test.ts
@@ -348,6 +348,60 @@ describe("RetryQueue", () => {
 		await q.flushPersist();
 	});
 
+	it("a failed Skill yields to a healthy session across a daemon restart", async () => {
+		const q = new RetryQueue({ agentType: "claude_code" });
+		q.enqueue({
+			kind: "skill_delete",
+			agent_id: "test-agent",
+			project_id: "test-project",
+			skill_key: "broken",
+			enqueued_at: "2026-01-01T00:00:00Z",
+			attempts: 0,
+		});
+		const failed = q.peek();
+		if (!failed) throw new Error("expected failing Skill");
+		q.enqueue({
+			kind: "session_push",
+			...sessionFence("healthy"),
+			local_session_id: "healthy",
+			content_hash: "h1",
+			enqueued_at: "2026-01-01T00:00:01Z",
+			attempts: 0,
+		});
+		q.bumpAttempts(failed);
+		await q.flushPersist();
+		const reloaded = new RetryQueue({ agentType: "claude_code" });
+		reloaded.load();
+		const healthy = reloaded.peek();
+		if (healthy?.kind !== "session_push") throw new Error("healthy session was starved");
+		expect(reloaded.markDoneIfVersion(healthy)).toBe(true);
+		expect(reloaded.peek()).toEqual({ ...failed, attempts: 1 });
+		await reloaded.flushPersist();
+	});
+
+	it("a stale retry cannot move or increment a replacement operation", async () => {
+		const q = new RetryQueue({ agentType: "claude_code" });
+		const input = {
+			kind: "skill_push" as const,
+			agent_id: "test-agent",
+			project_id: "test-project",
+			skill_key: "alpha",
+			new_hash: "h1",
+			enqueued_at: "2026-01-01T00:00:00Z",
+			attempts: 0,
+		};
+		q.enqueue(input);
+		const stale = q.peek();
+		if (!stale) throw new Error("expected original operation");
+		q.enqueue({ ...input, skill_key: "beta" });
+		q.enqueue({ ...input, new_hash: "h2" });
+		const before = [...q.all()];
+		q.bumpAttempts(stale);
+		expect(q.all()).toEqual(before);
+		expect(q.markDoneIfVersion(stale)).toBe(false);
+		await q.flushPersist();
+	});
+
 	it("bumpAttempts increments the counter and persists", async () => {
 		const q = new RetryQueue({ agentType: "claude_code" });
 		q.enqueue({

--- a/packages/cli/src/serve/queue.test.ts
+++ b/packages/cli/src/serve/queue.test.ts
@@ -396,6 +396,7 @@ describe("RetryQueue", () => {
 		q.enqueue({ ...input, skill_key: "beta" });
 		q.enqueue({ ...input, new_hash: "h2" });
 		const before = [...q.all()];
+		expect(q.peek()).toMatchObject({ skill_key: "beta", attempts: 0 });
 		q.bumpAttempts(stale);
 		expect(q.all()).toEqual(before);
 		expect(q.markDoneIfVersion(stale)).toBe(false);

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -383,11 +383,10 @@ export class RetryQueue {
 		// delete therefore both converge to the latest local state.
 		// Sessions remain keyed by local_session_id.
 		const idx = this.items.findIndex((existing) => sameKey(existing, stamped));
-		if (idx >= 0) {
-			this.items[idx] = stamped;
-		} else {
-			this.items.push(stamped);
-		}
+		// A frequently edited resource must not retain the head while every
+		// in-flight attempt becomes stale. Its latest state joins pending peers.
+		if (idx >= 0) this.items.splice(idx, 1);
+		this.items.push(stamped);
 		this.evictIfFull();
 		this.highWater = Math.max(this.highWater, this.items.length);
 		this.persist();

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -9,7 +9,7 @@
  * middle (PID 1 OOM-killed in a container, laptop sleep, etc.)
  * doesn't drop work either.
  *
- * Bounded — when the queue hits `maxItems`, the oldest entry is
+ * Bounded — when the queue hits `maxItems`, the first eligible entry is
  * evicted to make room for the new one and a `dropped_count`
  * counter ticks up. The dashboard surfaces that counter so a
  * stuck daemon ("queue keeps growing, nothing landing") is
@@ -465,7 +465,7 @@ export class RetryQueue {
 	}
 
 	private evictIfFull(): void {
-		// Eviction priority: drop oldest skill operation first, only fall
+		// Eviction priority: drop the first queued skill operation, only fall
 		// back to dropping sessions when no skills remain to evict.
 		// Skills are content-deduped by skill_key — the periodic local
 		// inventory scan re-derives the latest push/delete state after
@@ -532,7 +532,8 @@ export class RetryQueue {
 		return true;
 	}
 
-	/** Bump the attempts counter on the version-matching item.
+	/** Bump the attempts counter and move the matching item behind pending peers.
+	 * A broken resource must not consume every retry before healthy work runs.
 	 * If a newer version has replaced it (rare retry race) we
 	 * leave the new item alone — its attempts counter restarts
 	 * at 0 by design, which is what the caller wants. */
@@ -540,7 +541,9 @@ export class RetryQueue {
 		const idx = this.items.findIndex((existing) => sameKey(existing, item));
 		if (idx < 0) return;
 		if (this.items[idx].version !== item.version) return;
-		this.items[idx] = { ...this.items[idx], attempts: this.items[idx].attempts + 1 };
+		const current = this.items[idx];
+		this.items.splice(idx, 1);
+		this.items.push({ ...current, attempts: current.attempts + 1 });
 		this.persist();
 	}
 

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -38,7 +38,7 @@ describe("clean runner suite contract", () => {
 		expect(runner).toContain(`if [[ "\${1:-}" == "--in-container" ]]`);
 		expect(runner).toContain('test-runner bash /repo/scripts/test.sh --in-container "$suite" "$@"');
 		expect(runner).toContain(
-			"all|backend|ci|js|cli|desktop|shared|sidecar|web|runtime-vaults|provider-recovery-fixture)",
+			"all|backend|ci|js|cli|desktop|shared|sidecar|web|runtime-vaults|runtime-systemd|provider-recovery-fixture)",
 		);
 		expect(runnerDockerfile).not.toContain("docker/test-runner.sh");
 		expect(runnerDockerfile).not.toContain("ENTRYPOINT");

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -2222,6 +2222,16 @@ test("0.14.18 keeps tenant-owned Hermes state writable without chowning tenant h
 	const runtimeGid = 10_001;
 	const root = mkdtempSync(join(tmpdir(), "clawdi-live-hermes-ownership-"));
 	chmodSync(root, 0o755);
+	// The checkout can be private to another UID (for example a worktree).
+	// Give the tenant only a bundled fixture, not access to the source tree.
+	const hermesConfigMock = join(root, "hermes-config-cli-mock.js");
+	const buildMock = spawnSync(
+		process.execPath,
+		["build", HERMES_CONFIG_CLI_MOCK, "--target", "bun", "--outfile", hermesConfigMock],
+		{ encoding: "utf8", timeout: 30_000 },
+	);
+	expect(buildMock.status, buildMock.stderr).toBe(0);
+	chmodSync(hermesConfigMock, 0o644);
 	const hermesCommand = join(runtimeHome, ".local", "bin", "hermes");
 	const installLog = join(root, "hermes-installer.log");
 	const rootOwnedSentinel = join(runtimeHome, "root-owned-sentinel");
@@ -2258,7 +2268,7 @@ case "$*" in
     printf '%s\\n' 'Hermes Agent v0.19.1'
     ;;
   "config path"|"config get "*|"config set "*|"config unset "*)
-	exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
+	exec '${process.execPath}' '${hermesConfigMock}' "$@"
     ;;
   "gateway install --force --no-start-now")
     printf '%s\\n' install >> ${JSON.stringify(installLog)}

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -4,7 +4,7 @@ ARG UV_VERSION=0.12.5
 
 FROM oven/bun:${BUN_VERSION} AS bun
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
-FROM node:${NODE_VERSION}-trixie
+FROM node:${NODE_VERSION}-trixie AS systemd
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
@@ -25,6 +25,12 @@ RUN systemctl mask systemd-sysctl.service systemd-modules-load.service
 
 RUN groupadd --gid 10001 clawdi \
 	&& useradd --uid 10001 --gid 10001 --create-home --home-dir /home/clawdi --shell /bin/bash clawdi
+
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]
+
+FROM systemd AS runtimes
 
 # `openclaw --version` identifies this published package as official source
 # commit ea806575e6450e4d1efdfc72c19f04be982a1b9b. npm omits gitHead, so the

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -26,6 +26,7 @@ import {
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
 	runtimePublicContentRevision,
+	runtimeWatchEventForOutcome,
 	runtimeWatchPollDelayMs,
 	runtimeWatch as runtimeWatchWithContext,
 } from "../src/commands/runtime";
@@ -85,6 +86,7 @@ import {
 	officialInstallArgs,
 	validateUnmanagedProviderSecretValues,
 } from "../src/runtime/manifest-contract";
+import { runtimeConvergenceWithoutApply } from "../src/runtime/manifest-planning";
 import { recordValue } from "../src/runtime/manifest-shared";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
@@ -2553,6 +2555,33 @@ describe("runtime applied content identity", () => {
 });
 
 describe("runtime manifest datasource", () => {
+	it("keeps original failures visible when recovery is deferred by systemd or Hermes", () => {
+		const paths = getRuntimePaths({ mode: "local" });
+		const load: RuntimeManifestLoad = {
+			manifest: runtimeWatchLocaleManifest(join(root, "home"), 2),
+			source: "remote-datasource",
+			sourcePath: "inline-deferred",
+			offline: false,
+			etag: testBundleEtag("deferred-errors"),
+		};
+		const convergence = runtimeConvergenceWithoutApply({
+			load,
+			paths,
+			workspaceRoot: join(root, "home"),
+			enabledRuntimes: [],
+			installErrors: ["desired runtime install failed"],
+			projectedProviderIds: {},
+		});
+		for (const reason of ["systemd_reobservation_required", "hermes_config_conflict"] as const) {
+			expect(
+				runtimeWatchEventForOutcome({ kind: "deferred", reason, load, convergence }, paths),
+			).toMatchObject({
+				status: "error",
+				error: "desired runtime install failed",
+				errors: ["desired runtime install failed"],
+			});
+		}
+	});
 	it("rejects the legacy /api runtime manifest path", () => {
 		const parsed = runtimeManifestSourceSchema.safeParse({
 			type: "http",
@@ -7045,7 +7074,14 @@ exit 64
 			expect(readFileSync(tokenPath, "utf-8")).toBe(tokenBeforeRejection);
 			expect(statSync(tokenPath).mtimeMs).toBe(tokenMtimeBeforeRejection);
 			expect(readFileSync(paths.appliedState, "utf-8")).toBe(appliedStateBeforeRejection);
-			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+			// Rejected credentials may trigger read-only preflight inspection, but
+			// must not change units, secrets or committed authority.
+			expect(
+				readFileSync(systemctlLog, "utf-8")
+					.trim()
+					.split("\n")
+					.filter((call) => call && !/^(?:--user )?(?:show|is-enabled)(?: |$)/.test(call)),
+			).toEqual([]);
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2555,6 +2555,126 @@ describe("runtime applied content identity", () => {
 });
 
 describe("runtime manifest datasource", () => {
+	it.each([
+		["watch", "rollback"],
+		["init", "rollback"],
+		["init", "readiness"],
+		["watch", "ordinary"],
+		["watch", "unknown-job"],
+		["watch", "rollback-error"],
+	] as const)(
+		"handles preflight failure and CLI handoff: %s / %s",
+		async (entrypoint, scenario) => {
+			const home = join(root, "home", "clawdi");
+			const paths = seedRuntimeWatchLocaleBaseline(home, join(root, "state"), join(root, "run"));
+			reconcilePendingRuntimeCliUpgrade(paths, TEST_RUNNING_CLI_VERSION);
+			const candidateTarget = readlinkSync(paths.cliManagedBin);
+			const previous = createVersionedCliFixture(paths, "1.0.0-test");
+			const receipt = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf8"));
+			if (scenario !== "ordinary") {
+				receipt.previous = { activeTarget: previous.activeTarget, version: previous.version };
+				writeFileSync(paths.cliBootstrapStatus, JSON.stringify(receipt));
+			}
+			if (scenario === "rollback-error") rmSync(previous.activeTarget);
+			const appliedBefore = readFileSync(paths.appliedState, "utf8");
+			const manager = join(root, "manager");
+			const wrapper = join(root, "systemctl");
+			writeFakeSystemdManager({
+				path: manager,
+				logPath: join(root, "manager.log"),
+				stateRoot: join(root, "manager-state"),
+			});
+			const transform =
+				scenario === "unknown-job" ? "s/^Job=$/Job=7/" : "s/^ActiveState=.*/ActiveState=failed/";
+			writeFileSync(
+				wrapper,
+				scenario === "unknown-job" || scenario === "readiness"
+					? `#!/bin/sh
+'${manager}' "$@" | sed '${transform}'
+`
+					: "#!/bin/sh\nprintf 'fixture systemctl show failed' >&2\nexit 1\n",
+				{ mode: 0o755 },
+			);
+			process.env.CLAWDI_SYSTEMD_APPLY = "1";
+			process.env.CLAWDI_SYSTEMCTL_PATH = wrapper;
+			setRuntimeApplyGeneration(2, CANONICAL_TEST_CONTEXT);
+			const etag = testBundleEtag("preflight-cli-rollback");
+			const { restore, captured } = mockFetch([
+				{
+					method: "GET",
+					path: "/v1/runtime/manifest",
+					response: () =>
+						hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 2), { etag }),
+				},
+			]);
+			const logs: string[] = [];
+			const priorLog = console.log;
+			console.log = (value?: unknown) => logs.push(String(value));
+			const abort = new AbortController();
+			const deadline = setTimeout(() => abort.abort(), 5_000);
+			process.exitCode = undefined;
+			try {
+				if (entrypoint === "init") await runtimeInit({ json: true, nonInteractive: true });
+				else await runtimeWatch({ json: true, once: scenario !== "rollback", abort: abort.signal });
+				expect(abort.signal.aborted).toBe(false);
+				expect(captured.filter((request) => request.path === "/v1/runtime/manifest")).toHaveLength(
+					1,
+				);
+				const event = JSON.parse(logs.at(-1) ?? "{}");
+				expect(event.status).toBe("error");
+				expect(readFileSync(paths.appliedState, "utf8")).toBe(appliedBefore);
+				if (scenario === "unknown-job") {
+					expect(event.error).toContain("unfinished work");
+					expect(event.cliRollback).toBeUndefined();
+					expect(event.selfReexec ?? false).toBe(false);
+					expect(process.exitCode).toBe(1);
+					expect(readlinkSync(paths.cliManagedBin)).toBe(candidateTarget);
+					expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf8")).previous).toEqual(
+						receipt.previous,
+					);
+					return;
+				}
+				expect(event.error).toContain(
+					scenario === "readiness"
+						? "transparent-egress system prerequisites did not reach readiness"
+						: "fixture systemctl show failed",
+				);
+				expect(event.errors[0]).toBe(event.error);
+				expect(event.rejectedGeneration).toBe(2);
+				if (entrypoint === "watch") expect(event.etag).toBe(etag);
+				if (scenario === "rollback" || scenario === "readiness") {
+					expect(event.cliRollback.status).toBe("rolled_back");
+					expect(event.selfReexec).toBe(true);
+					expect(event.errors.join("\n")).toContain("rolled back clawdi CLI");
+					expect(readlinkSync(paths.cliManagedBin)).toBe(previous.activeTarget);
+					expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf8"))).toMatchObject({
+						version: previous.version,
+						previous: null,
+						bad: { version: TEST_RUNNING_CLI_VERSION },
+					});
+					if (entrypoint === "init") {
+						expect(process.exitCode).toBe(75);
+						expect(event.handoff).toBe("cli_reexec");
+					} else expect(process.exitCode ?? 0).toBe(0);
+				} else {
+					expect(process.exitCode).toBe(1);
+					expect(event.selfReexec ?? false).toBe(false);
+					expect(readlinkSync(paths.cliManagedBin)).toBe(candidateTarget);
+					if (scenario === "ordinary") expect(event.cliRollback).toBeUndefined();
+					else {
+						expect(event.cliRollback.status).toBe("error");
+						expect(event.errors.join("\n")).toContain("failed to roll back clawdi CLI");
+					}
+				}
+			} finally {
+				clearTimeout(deadline);
+				abort.abort();
+				restore();
+				console.log = priorLog;
+				process.exitCode = 0;
+			}
+		},
+	);
 	it("keeps original failures visible when recovery is deferred by systemd or Hermes", () => {
 		const paths = getRuntimePaths({ mode: "local" });
 		const load: RuntimeManifestLoad = {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -461,7 +461,7 @@ case "$command" in
   show)
     first=1
     for unit in "$@"; do
-      case "$unit" in --property=*) continue ;; esac
+      case "$unit" in --all|--property=*) continue ;; esac
       if [ "$first" = "0" ]; then printf '\\n'; fi
       first=0
       load_state=loaded
@@ -473,7 +473,7 @@ case "$command" in
       [ ! -f "$(state_path "$unit" reload)" ] || need_daemon_reload=yes
       main_pid=0
       [ ! -f "$(state_path "$unit" pid)" ] || main_pid="$(cat "$(state_path "$unit" pid)")"
-      printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
+      printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\nJob=\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
     done
     ;;
   is-enabled)

--- a/scripts/test-systemd-command.sh
+++ b/scripts/test-systemd-command.sh
@@ -6,25 +6,39 @@ fixture="$repo_root/packages/cli/tests/fixtures/runtime-official-installer-syste
 image="clawdi-systemd-command-test:local-$$"
 container="clawdi-systemd-command-test-$$"
 cleanup() {
-	docker rm --force "$container" >/dev/null 2>&1 || true
-	docker image rm "$image" >/dev/null 2>&1 || true
+	timeout --kill-after=5s 30s docker rm --force "$container" >/dev/null 2>&1 || true
+	timeout --kill-after=5s 30s docker image rm "$image" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Reuse only the systemd stage; no agent packages, models or runtime installs.
-docker build --quiet --target systemd --file "$fixture" --tag "$image" \
-	"$(dirname -- "$fixture")" >/dev/null
-docker run --detach --privileged --cgroupns=private \
+# This stage needs no checkout build context.
+timeout --kill-after=15s 900s docker build --quiet --target systemd --tag "$image" - < "$fixture" >/dev/null
+timeout --kill-after=15s 30s docker run --detach --privileged --cgroupns=private \
 	--cpus=2 --memory=2g --pids-limit=256 --name "$container" \
 	--tmpfs /run --tmpfs /run/lock --tmpfs /tmp:exec \
-	--volume "$repo_root:/repo:ro" --workdir /work "$image" >/dev/null
-docker exec "$container" timeout 20 bash -c '
+	--workdir /work "$image" >/dev/null
+timeout --kill-after=15s 30s docker exec "$container" timeout 20 bash -c '
 	until systemctl show --property=Version >/dev/null 2>&1; do sleep 0.1; done
 '
-docker exec "$container" bash -euo pipefail -c '
-	mkdir -p /work
-	tar -C /repo --exclude=.git --exclude=node_modules --exclude=.venv \
-		--exclude=.env --exclude=.env.local -cf - . | tar -C /work -xf -
+# Never mount the unfiltered checkout in the privileged fixture. Native command
+# checks need no environment examples, so exclude all .env variants as well.
+timeout --kill-after=15s 120s tar -C "$repo_root" \
+	--exclude=.git --exclude=.paseo --exclude=.kamal \
+	--exclude=.ssh --exclude=.aws --exclude=.kube --exclude=.gnupg \
+	--exclude=.npmrc --exclude=.netrc --exclude=.clawdi.env \
+	--exclude=.env --exclude='.env.*' --exclude='.envrc*' \
+	--exclude=node_modules --exclude=.venv --exclude=__pycache__ --exclude='*.pyc' \
+	--exclude=.pytest_cache --exclude=.ruff_cache --exclude=.turbo \
+	--exclude=.output --exclude=.nitro --exclude=.tanstack --exclude='.vite*' \
+	--exclude=test-results --exclude=playwright-report --exclude=coverage \
+	--exclude=dist --exclude=dist-native --exclude=dist-release \
+	--exclude='./backend/data' --exclude=tmp --exclude='*.log' --exclude='*.tsbuildinfo' \
+	--exclude='.component-tools.*' --exclude='.provider-recovery-baseline.*' \
+	-cf - . | timeout --kill-after=15s 120s docker exec --interactive "$container" tar -C /work -xf -
+timeout --kill-after=15s 930s docker exec "$container" timeout 900 bash -euo pipefail -c '
 	cd /work
 	bun install --frozen-lockfile --ignore-scripts
 	CLAWDI_TEST_SYSTEMD_COMMAND=1 timeout 60 bun test --isolate --max-concurrency=1 \

--- a/scripts/test-systemd-command.sh
+++ b/scripts/test-systemd-command.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$repo_root/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile"
+image="clawdi-systemd-command-test:local-$$"
+container="clawdi-systemd-command-test-$$"
+cleanup() {
+	docker rm --force "$container" >/dev/null 2>&1 || true
+	docker image rm "$image" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Reuse only the systemd stage; no agent packages, models or runtime installs.
+docker build --quiet --target systemd --file "$fixture" --tag "$image" \
+	"$(dirname -- "$fixture")" >/dev/null
+docker run --detach --privileged --cgroupns=private \
+	--cpus=2 --memory=2g --pids-limit=256 --name "$container" \
+	--tmpfs /run --tmpfs /run/lock --tmpfs /tmp:exec \
+	--volume "$repo_root:/repo:ro" --workdir /work "$image" >/dev/null
+docker exec "$container" timeout 20 bash -c '
+	until systemctl show --property=Version >/dev/null 2>&1; do sleep 0.1; done
+'
+docker exec "$container" bash -euo pipefail -c '
+	mkdir -p /work
+	tar -C /repo --exclude=.git --exclude=node_modules --exclude=.venv \
+		--exclude=.env --exclude=.env.local -cf - . | tar -C /work -xf -
+	cd /work
+	bun install --frozen-lockfile --ignore-scripts
+	CLAWDI_TEST_SYSTEMD_COMMAND=1 timeout 60 bun test --isolate --max-concurrency=1 \
+		--timeout=15000 packages/cli/src/runtime/systemd.test.ts
+'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,7 @@ if [[ -z "${TEST_RUNNER_IMAGE:-}" ]]; then
 fi
 
 usage() {
-	echo "Usage: scripts/test.sh [all|ci|js|cli|desktop|shared|sidecar|web|backend|runtime-vaults|provider-recovery-fixture] [suite args...]"
+	echo "Usage: scripts/test.sh [all|ci|js|cli|desktop|shared|sidecar|web|backend|runtime-vaults|runtime-systemd|provider-recovery-fixture] [suite args...]"
 }
 
 compose() {
@@ -22,7 +22,7 @@ compose() {
 
 validate_suite() {
 	case "$1" in
-		all|backend|ci|js|cli|desktop|shared|sidecar|web|runtime-vaults|provider-recovery-fixture)
+		all|backend|ci|js|cli|desktop|shared|sidecar|web|runtime-vaults|runtime-systemd|provider-recovery-fixture)
 			;;
 		*)
 			echo "Unknown test suite: $1" >&2
@@ -50,6 +50,14 @@ run_on_host() {
 	fi
 	validate_suite "$suite"
 	python3 "$repo_root/scripts/check_postgres_image_parity.py"
+	if [[ "$suite" == runtime-systemd ]]; then
+		if [[ $# -gt 0 ]]; then
+			echo "Suite 'runtime-systemd' does not accept extra arguments" >&2
+			return 2
+		fi
+		bash "$script_dir/test-systemd-command.sh"
+		return
+	fi
 	local provider_output=""
 	if [[ "$suite" == provider-recovery-fixture ]]; then
 		provider_output="$(realpath "${1:?Provide an existing output directory inside this checkout}")"
@@ -279,6 +287,10 @@ run_in_container() {
 	copy_repo
 
 	case "$suite" in
+		runtime-systemd)
+			echo "Run runtime-systemd from the host entrypoint to create its isolated systemd container" >&2
+			exit 2
+			;;
 		all)
 			run_js
 			run_backend "$@"


### PR DESCRIPTION
Failed or repeatedly replaced sync resources could block healthy queued work, and unbounded systemctl clients could stall reconciliation. Rotate matching failed/replaced items behind peers, and bound Linux systemd command groups. Only a real pending systemd Job defers mutation: an auto-restart crash loop with no job remains eligible for corrective configuration. Timeouts defer commit/rollback until fresh observation, preserving prepared archives and original failure diagnostics through last-good replay.

Expose repair-terminal access for a current-generation post-ready health failure, paired with Hosted PR2202. Keep other Runtime UI authorization and aggregate health unchanged. No CLI version/default change.

Independent Fable review approved exact head 19b81905bdd46e6d9c4af3937b2aa075c753dab4 after fixes to crash-loop admission, privilege-drop ownership, diagnostics and CLI upgrade rollback/handoff. Fable independently reproduced seven focused scenarios with type checking. New-head remote CI is still running; merge remains gated on its completion without failures.

Local validation: all 154 CLI test files passed; ownership contract 2 passed and typecheck passed; official runtime-systemd suite 8 passed/37 assertions; complete installer/systemd E2E 9 passed/412 assertions. Native checks run through scripts/test.sh and the systemd CI lane. No production fault injection.

Independent sync-module startup/retry lifecycle and component-specific Files/UI proof remain unimplemented audit/design findings; this PR does not claim complete component isolation.
