### PR TITLE
fix(web): prevent Control UI height jumps during route loading

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -5230,6 +5230,12 @@ for (const viewport of [
 		await expect(iframe).toHaveAttribute("src", nativeHandoff);
 		await expect.poll(runtime.documentLoads).toBe(1);
 		await expect(iframe).toBeHidden();
+		const consoleHeading = page.getByRole("heading", {
+			level: 1,
+			name: "OpenClaw Control UI",
+			exact: true,
+		});
+		await expect(consoleHeading).toHaveCount(0);
 		expect(await iframe.evaluate((element) => Boolean(element.closest("[inert]")))).toBe(true);
 		const original = await iframe.elementHandle();
 		if (!original) throw new Error("Background iframe must already exist.");
@@ -5264,6 +5270,8 @@ for (const viewport of [
 			expect(runtime.documentLoads()).toBe(1);
 			expect(runtime.credentialRequests).toHaveLength(1);
 			if (section === "/console") {
+				await expect(consoleHeading).toHaveCount(1);
+				await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
 				await expect(iframe).toBeVisible();
 				await expect(page.getByRole("button", { name: "Reconnect", exact: true })).toHaveCount(1);
 				const box = await iframe.boundingBox();
@@ -5273,7 +5281,10 @@ for (const viewport of [
 				expect(box.x).toBeGreaterThanOrEqual(0);
 				expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1);
 				expect(box.y + box.height).toBeLessThanOrEqual(viewport.height + 1);
-			} else await expect(iframe).toBeHidden();
+			} else {
+				await expect(iframe).toBeHidden();
+				await expect(consoleHeading).toHaveCount(0);
+			}
 		}
 		await page.screenshot({ path: `test-results/persistent-control-ui-${viewport.width}.png` });
 		await page.getByRole("button", { name: "Reconnect", exact: true }).click();
@@ -5452,6 +5463,13 @@ for (const viewport of [
 					if (viewport.width < 768) await expect(sidebar).toBeHidden();
 				}
 				const surface = page.getByTestId("hosted-agent-live-surface");
+				await expect(
+					page.getByRole("heading", {
+						level: 1,
+						name: "OpenClaw Control UI",
+						exact: true,
+					}),
+				).toHaveCount(1);
 				await expect(
 					surface.getByText("Opening OpenClaw Control UI…", { exact: true }),
 				).toBeVisible();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -17,6 +17,7 @@ import {
 	mutationDeploymentReadFixture,
 	readDeploymentFixture,
 } from "./hosted-stub-api";
+import { expectRecordedLiveToolGeometry, recordLiveToolGeometry } from "./live-tool-geometry";
 import { measureNavigation } from "./navigation-measurement";
 
 type PlanChangeProgress = DeployComponents["schemas"]["ComputePlanChangeProgress"];
@@ -5218,7 +5219,8 @@ for (const viewport of [
 	test(`OpenClaw retains the same background document across sections at ${viewport.width}px`, async ({
 		page,
 		context,
-	}) => {
+	}, testInfo) => {
+		await recordLiveToolGeometry(page);
 		const errors = collectBrowserErrors(page);
 		await page.setViewportSize(viewport);
 		const nativeHandoff = `${openClawRuntimeEndpoint}#bootstrapToken=one-time-token&bootstrapProfile=owner`;
@@ -5284,6 +5286,7 @@ for (const viewport of [
 		await page.getByRole("link", { name: "Console", exact: true }).click();
 		await expect(iframe).toHaveCount(0);
 		expect(await replacement?.evaluate((element) => element.isConnected)).toBe(false);
+		await expectRecordedLiveToolGeometry(page, testInfo);
 		await original.dispose();
 		await document.dispose();
 		await replacement?.dispose();
@@ -5400,3 +5403,88 @@ test("OpenClaw retries a new resource version after a pending 412 without replac
 		release();
 	}
 });
+
+for (const viewport of [
+	{ width: 1440, height: 900 },
+	{ width: 390, height: 844 },
+	{ width: 320, height: 568 },
+]) {
+	for (const direct of [true, false]) {
+		test(`OpenClaw fills the viewport with AgentHome pending (${direct ? "direct" : "overview"}, ${viewport.width}px)`, async ({
+			page,
+			context,
+		}, testInfo) => {
+			await page.setViewportSize(viewport);
+			await recordLiveToolGeometry(page);
+			const runtime = await stubOpenClawRuntime(
+				page,
+				context,
+				`${openClawRuntimeEndpoint}#bootstrapToken=one-time-token&bootstrapProfile=owner`,
+			);
+			let releaseHome = () => {};
+			const homeGate = new Promise<void>((resolve) => {
+				releaseHome = resolve;
+			});
+			let homeRequested = false;
+			await page.route("**/src/hosted/agents/agent-home.tsx*", async (route) => {
+				homeRequested = true;
+				await homeGate;
+				await route.continue();
+			});
+			let releaseCredentials = () => {};
+			const credentialsGate = new Promise<void>((resolve) => {
+				releaseCredentials = resolve;
+			});
+			await page.route("**/runtime-ui/credentials", async (route) => {
+				await credentialsGate;
+				await route.fallback();
+			});
+			try {
+				await page.goto(`/agents/${runtime.agentId}${direct ? "/console" : ""}`);
+				await expect.poll(() => homeRequested).toBe(true);
+				if (!direct) {
+					if (viewport.width < 768)
+						await page.getByRole("button", { name: "Toggle Sidebar" }).click();
+					const sidebar =
+						viewport.width < 768 ? page.getByRole("dialog") : page.getByTestId("app-sidebar");
+					await sidebar.locator(`a[href="/agents/${runtime.agentId}/console"]`).click();
+					await expect(page).toHaveURL(`/agents/${runtime.agentId}/console`);
+					if (viewport.width < 768) await expect(sidebar).toBeHidden();
+				}
+				const surface = page.getByTestId("hosted-agent-live-surface");
+				await expect(
+					surface.getByText("Opening OpenClaw Control UI…", { exact: true }),
+				).toBeVisible();
+				await testInfo.attach("credentials-pending", {
+					body: await page.screenshot(),
+					contentType: "image/png",
+				});
+				releaseCredentials();
+				const iframe = page.locator('iframe[title="OpenClaw Control UI"]');
+				await expect(iframe).toBeVisible();
+				await expect.poll(runtime.documentLoads).toBe(1);
+				// The real lazy route remains suspended while its sibling iframe is visible.
+				await expect(page.getByTestId("agent-live-tool-loading-shell")).toHaveCount(1);
+				await testInfo.attach("agent-home-pending", {
+					body: await page.screenshot(),
+					contentType: "image/png",
+				});
+				releaseHome();
+				await expect(page.getByTestId("agent-live-tool-loading-shell")).toHaveCount(0);
+				await expectLiveToolFillsDashboard(page, surface);
+				await testInfo.attach("agent-home-ready", {
+					body: await page.screenshot(),
+					contentType: "image/png",
+				});
+				await page.setViewportSize({ width: viewport.height, height: viewport.width });
+				await expectLiveToolFillsDashboard(page, surface);
+				await page.setViewportSize(viewport);
+				await expectLiveToolFillsDashboard(page, surface);
+				await expectRecordedLiveToolGeometry(page, testInfo);
+			} finally {
+				releaseHome();
+				releaseCredentials();
+			}
+		});
+	}
+}

--- a/apps/web/e2e/live-tool-geometry.ts
+++ b/apps/web/e2e/live-tool-geometry.ts
@@ -1,0 +1,60 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+
+type Sample = {
+	time: number;
+	height: number;
+	frameHeight: number | null;
+	topGap: number;
+	bottomGap: number;
+	frameBottomGap: number | null;
+};
+
+declare global {
+	interface Window {
+		__liveToolGeometry: Sample[];
+	}
+}
+
+// Observe actual painted geometry, including Suspense and credential transitions.
+export async function recordLiveToolGeometry(page: Page) {
+	await page.addInitScript(() => {
+		window.__liveToolGeometry = [];
+		function sample() {
+			const dashboard = document.querySelector("#dashboard-scroll-container");
+			const header = dashboard?.querySelector(":scope > header");
+			const surface = document.querySelector('[data-testid="hosted-agent-live-surface"]');
+			const box = surface?.getBoundingClientRect();
+			if (dashboard && header && box && box.width > 0 && box.height > 0) {
+				const frame = surface?.querySelector("iframe")?.getBoundingClientRect();
+				window.__liveToolGeometry.push({
+					time: performance.now(),
+					height: box.height,
+					frameHeight: frame?.height ?? null,
+					topGap: box.top - header.getBoundingClientRect().bottom,
+					bottomGap: dashboard.getBoundingClientRect().bottom - box.bottom,
+					frameBottomGap: frame ? box.bottom - frame.bottom : null,
+				});
+			}
+			requestAnimationFrame(sample);
+		}
+		requestAnimationFrame(sample);
+	});
+}
+
+export async function expectRecordedLiveToolGeometry(page: Page, testInfo: TestInfo) {
+	const samples = await page.evaluate(() => window.__liveToolGeometry);
+	await testInfo.attach("live-tool-geometry", {
+		body: JSON.stringify(samples, null, 2),
+		contentType: "application/json",
+	});
+	expect(samples.length).toBeGreaterThan(0);
+	expect(
+		samples.filter(
+			(sample) =>
+				Math.abs(sample.topGap) > 1 ||
+				Math.abs(sample.bottomGap) > 1 ||
+				(sample.frameBottomGap !== null && Math.abs(sample.frameBottomGap) > 1),
+		),
+		"Every visible console frame must fill the dashboard below its header",
+	).toEqual([]);
+}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -621,10 +621,10 @@ export function HostedAgentDetail({
 		shouldShowInitialDeploymentProgress(deploymentStatus, deploymentFailure);
 	const isLiveToolTab =
 		activeTab === "console" || activeTab === "files" || activeTab === "terminal";
-	// The persistent agent layout owns the ready OpenClaw surface. Keep this
+	// The persistent agent layout owns the ready OpenClaw surface and heading. Keep this
 	// route mounted for its breadcrumb and canonical Outlet lifecycle.
 	if (activeTab === "console" && runtime === "openclaw" && deploymentRuntimeUiIsReady(deployment))
-		return <h1 className="sr-only">{availableAgentTitle}</h1>;
+		return null;
 	return (
 		<div
 			data-hosted="true"

--- a/apps/web/src/hosted/agents/hosted-agent-event-stream-layout.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-event-stream-layout.tsx
@@ -10,6 +10,7 @@ import { useDeploymentEventStream } from "@/hosted/use-deployment-event-stream";
 import { agentSectionHref, parseAgentPathname } from "@/lib/agent-routes";
 import { useSessionIdentity } from "@/lib/auth-client";
 import { DeploymentEventStreamActiveProvider } from "@/lib/deployment-event-stream-context";
+import { runtimeBrowserUiLabel } from "@/lib/navigation-model";
 
 const route = getRouteApi("/_protected/_dashboard/agents/$id");
 
@@ -62,6 +63,7 @@ export function HostedAgentEventStreamLayout() {
 							consoleActive ? "flex min-h-0 w-full flex-1 flex-col overflow-hidden" : "hidden"
 						}
 					>
+						<h1 className="sr-only">{runtimeBrowserUiLabel("openclaw")}</h1>
 						<ConsoleTab
 							deployment={persistentConsole}
 							runtime="openclaw"

--- a/apps/web/src/hosted/agents/hosted-agent-event-stream-layout.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-event-stream-layout.tsx
@@ -32,6 +32,7 @@ export function HostedAgentEventStreamLayout() {
 		deploymentRuntimeUiIsReady(deployment)
 			? deployment
 			: null;
+	const outletHidden = Boolean(persistentConsole && consoleActive);
 	const deploymentEvents = useDeploymentEventStream({
 		deploymentId: deployment?.resource.id ?? null,
 		agentId,
@@ -72,7 +73,15 @@ export function HostedAgentEventStreamLayout() {
 						/>
 					</div>
 				) : null}
-				<Outlet />
+				{/* Keep route effects mounted without letting retained content or Suspense
+				    fallbacks share the persistent console's available height. */}
+				<div
+					hidden={outletHidden}
+					inert={outletHidden}
+					className={outletHidden ? "hidden" : "contents"}
+				>
+					<Outlet />
+				</div>
 			</div>
 		</DeploymentEventStreamActiveProvider>
 	);


### PR DESCRIPTION
The persistent OpenClaw console and the AgentHome Suspense fallback both requested flex-1 as siblings. While the route module loaded, each received half the available height; the iframe jumped to full height when the fallback disappeared.

Keep Outlet mounted for route effects, but remove its content and fallbacks from layout while the persistent console is visible. The console then naturally fills the existing flex container. Move the single accessible h1 into that visible surface. No fixed-height calculation, timer, observer-driven sizing, portal or iframe remount is introduced; authentication behavior is unchanged.

Validation in isolated Docker: typecheck, Biome, 27 focused tests and OSS build passed. Browser measurements reproduced the bug at 1440x900, 390x844 and 320x568, for direct entry and navigation with delayed AgentHome and credentials. Final eight geometry/accessibility/lifecycle cases passed; all 521 sampled frames filled the available height. Existing iframe/document identity, credential request count and explicit reconnect assertions passed. An earlier mobile sidebar timeout passed three consecutive reruns without source changes; its exact cause remains unconfirmed. Browser APIs/runtime were fixtures; this layout change did not re-test live gateway authentication.


Additional real-UI verification: official OpenClaw 2026.9.4 chat and gateway reproduced the pre-fix 370px iframe while the route was pending; reviewed head remains full-height at 788px desktop and748px mobile. Native owner authentication and same document/socket through section changes passed. A standalone official page reproduced its separate 300ms entrance animation and45px cold composer reflow; this PR does not modify those upstream behaviors. No further product changes. The user reviewed the real before/after screenshots and authorized release.


Released as bcd4e75e17dc242fd88722b2fa7fe295f03732ff. Vercel production deployment succeeded; cloud.clawdi.ai now references hosted-agent-event-stream-layout-CZflN1xZ.js, verified to contain the hidden/inert Outlet wrapper and persistent accessible heading. Authentication behavior is unchanged. [Deployment](https://vercel.com/phala/clawdi/FrmmEiCdR8EvzSRBz1eAsrKN7Kmj).
