### PR TITLE
Isolate sync module recovery and report component activation proof

### DIFF
--- a/apps/web/src/hosted/agents/runtime-readiness.test.ts
+++ b/apps/web/src/hosted/agents/runtime-readiness.test.ts
@@ -68,3 +68,23 @@ test("running without UI publication retains bounded fast polling until ready", 
 		DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
 	);
 });
+
+test("versioned component admission permits one healthy UI while aggregate Ready remains false", () => {
+	const deployment = readyDeployment();
+	const status = deployment.resource.status;
+	const endpoint = deployment.runtime_ui_endpoint;
+	if (!status || !endpoint) throw new Error("Expected fixture evidence");
+	status.summary_state = "failed";
+	status.conditions = status.conditions.map((condition) =>
+		condition.type === "Ready" ? { ...condition, status: "False" } : condition,
+	);
+	expect(deploymentRuntimeUiIsReady(deployment)).toBe(false);
+	deployment.runtime_ui_endpoint = { ...endpoint, component_readiness: 1 };
+	expect(deploymentRuntimeUiIsReady(deployment)).toBe(true);
+	expect(status.conditions.find((condition) => condition.type === "Ready")?.status).toBe("False");
+	status.observedGeneration = 0;
+	expect(deploymentRuntimeUiIsReady(deployment)).toBe(false);
+	status.observedGeneration = deployment.resource.metadata.generation;
+	deployment.resource.spec.desired_lifecycle = "stopped";
+	expect(deploymentRuntimeUiIsReady(deployment)).toBe(false);
+});

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -205,23 +205,26 @@ export function deploymentTerminalIsAvailable(deployment: HostedDeployment): boo
 	);
 }
 
-/** Aggregate readiness is required for Runtime UI credentials, including during repair. */
+/** Versioned component admission or aggregate readiness permits a credential attempt. */
 export function deploymentRuntimeUiIsReady(deployment: HostedDeployment): boolean {
 	const { metadata, spec, status } = deployment.resource;
 	const generation = metadata.generation;
 	const ready = status?.conditions.find((condition) => condition.type === "Ready");
+	const componentReady = deployment.runtime_ui_endpoint?.component_readiness === 1;
 	return Boolean(
 		generation >= 1 &&
 			spec.desired_lifecycle === "running" &&
-			status?.summary_state === "running" &&
+			(status?.summary_state === "running" ||
+				(componentReady && status?.summary_state === "failed")) &&
 			!status.deleted_at &&
 			status.observed_at &&
 			status.observedGeneration === generation &&
 			status.driver_acknowledged_generation === generation &&
 			status.driver_applied_generation === generation &&
-			ready?.status === "True" &&
-			ready.observedGeneration === generation &&
-			!hasCurrentRuntimeHealthDegradation(status) &&
+			(componentReady ||
+				(ready?.status === "True" &&
+					ready.observedGeneration === generation &&
+					!hasCurrentRuntimeHealthDegradation(status))) &&
 			deployment.runtime_ui_endpoint?.runtime === spec.runtime &&
 			deployment.runtime_ui_endpoint.role === "control_ui" &&
 			deployment.runtime_ui_endpoint.url,

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -11,6 +11,7 @@ from app.schemas.runtime_observed import (
     HostedRuntimeObservedAppliedV2,
     HostedRuntimeObservedBootV1,
     HostedRuntimeObservedCliV1,
+    HostedRuntimeObservedComponentsV1,
     HostedRuntimeObservedProviderPayload,
     HostedRuntimeObservedSupervisorV1,
     HostedRuntimeObservedSystemdV1,
@@ -281,6 +282,7 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     applied: HostedRuntimeObservedAppliedV2
     boot: HostedRuntimeObservedBootV1 | None
     cli: HostedRuntimeObservedCliV1 | None
+    components: HostedRuntimeObservedComponentsV1 | None = None
     systemd: HostedRuntimeObservedSystemdV1 | None = None
     supervisor: HostedRuntimeObservedSupervisorV1 | None = None
     providers: dict[str, HostedRuntimeObservedProviderPayload] | None = None
@@ -321,6 +323,16 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     sequence: int = Field(ge=1, le=9_007_199_254_740_991)
     event_id: str = Field(alias="eventId", min_length=1, max_length=128)
     captured_at: datetime = Field(alias="capturedAt")
+
+    @model_validator(mode="after")
+    def validate_component_health(self) -> RuntimeObservationEventV2:
+        if (
+            self.components
+            and self.status == "ok"
+            and any(entry.status != "ok" for entry in self.components.entries)
+        ):
+            raise ValueError("unready components cannot certify aggregate health")
+        return self
 
     @field_validator("reported_at", "captured_at", mode="before")
     @classmethod

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -11,7 +11,6 @@ from app.schemas.runtime_observed import (
     HostedRuntimeObservedAppliedV2,
     HostedRuntimeObservedBootV1,
     HostedRuntimeObservedCliV1,
-    HostedRuntimeObservedComponentsV1,
     HostedRuntimeObservedProviderPayload,
     HostedRuntimeObservedSupervisorV1,
     HostedRuntimeObservedSystemdV1,
@@ -30,6 +29,30 @@ RuntimeObservationIngestOutcome = Literal[
 
 class RuntimeObservationRequestModel(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class HostedRuntimeObservedComponentV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    component: Literal["files", "hermes-ui", "openclaw-ui"]
+    status: Literal["ok", "unknown"]
+    config_revision: str = Field(alias="configRevision", pattern=r"^[0-9a-f]{64}$")
+    access_revision: str = Field(alias="accessRevision", pattern=r"^[0-9a-f]{64}$")
+    invocation_id: str = Field(alias="invocationId", pattern=r"^[0-9a-f]{32}$")
+
+
+class HostedRuntimeObservedComponentsV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: Literal[1] = Field(alias="schemaVersion")
+    entries: list[HostedRuntimeObservedComponentV1] = Field(max_length=3)
+
+    @model_validator(mode="after")
+    def validate_unique_components(self) -> HostedRuntimeObservedComponentsV1:
+        names = [entry.component for entry in self.entries]
+        if len(set(names)) != len(names):
+            raise ValueError("component proofs must have unique names")
+        return self
 
 
 AgentPluginObservedStatus = Literal["installed", "failed", "unknown"]

--- a/backend/app/schemas/runtime_observed.py
+++ b/backend/app/schemas/runtime_observed.py
@@ -95,6 +95,26 @@ class HostedRuntimeObservedProviderPayload(RootModel[dict[str, JsonValue]]):
         return self
 
 
+class HostedRuntimeObservedComponentV1(_StrictObservedWireModel):
+    component: Literal["files", "hermes-ui", "openclaw-ui"]
+    status: Literal["ok", "unknown"]
+    config_revision: str = Field(alias="configRevision", pattern=r"^[0-9a-f]{64}$")
+    access_revision: str = Field(alias="accessRevision", pattern=r"^[0-9a-f]{64}$")
+    invocation_id: str = Field(alias="invocationId", pattern=r"^[0-9a-f]{32}$")
+
+
+class HostedRuntimeObservedComponentsV1(_StrictObservedWireModel):
+    schema_version: Literal[1] = Field(alias="schemaVersion")
+    entries: list[HostedRuntimeObservedComponentV1] = Field(max_length=3)
+
+    @model_validator(mode="after")
+    def validate_unique_components(self) -> HostedRuntimeObservedComponentsV1:
+        names = [entry.component for entry in self.entries]
+        if len(set(names)) != len(names):
+            raise ValueError("component proofs must have unique names")
+        return self
+
+
 class HostedRuntimeObservedAppliedV2(_StrictObservedWireModel):
     etag: str = Field(min_length=1, max_length=1024)
     source_revision: str = Field(alias="sourceRevision", pattern=r"^[0-9a-f]{64}$")
@@ -123,6 +143,7 @@ class HostedRuntimeObservedV2(_StrictObservedWireModel):
     applied: HostedRuntimeObservedAppliedV2 | None
     boot: HostedRuntimeObservedBootV1 | None
     cli: HostedRuntimeObservedCliV1 | None
+    components: HostedRuntimeObservedComponentsV1 | None = None
     systemd: HostedRuntimeObservedSystemdV1 | None = None
     supervisor: HostedRuntimeObservedSupervisorV1 | None = None
     providers: dict[str, HostedRuntimeObservedProviderPayload] | None = None

--- a/backend/app/schemas/runtime_observed.py
+++ b/backend/app/schemas/runtime_observed.py
@@ -95,26 +95,6 @@ class HostedRuntimeObservedProviderPayload(RootModel[dict[str, JsonValue]]):
         return self
 
 
-class HostedRuntimeObservedComponentV1(_StrictObservedWireModel):
-    component: Literal["files", "hermes-ui", "openclaw-ui"]
-    status: Literal["ok", "unknown"]
-    config_revision: str = Field(alias="configRevision", pattern=r"^[0-9a-f]{64}$")
-    access_revision: str = Field(alias="accessRevision", pattern=r"^[0-9a-f]{64}$")
-    invocation_id: str = Field(alias="invocationId", pattern=r"^[0-9a-f]{32}$")
-
-
-class HostedRuntimeObservedComponentsV1(_StrictObservedWireModel):
-    schema_version: Literal[1] = Field(alias="schemaVersion")
-    entries: list[HostedRuntimeObservedComponentV1] = Field(max_length=3)
-
-    @model_validator(mode="after")
-    def validate_unique_components(self) -> HostedRuntimeObservedComponentsV1:
-        names = [entry.component for entry in self.entries]
-        if len(set(names)) != len(names):
-            raise ValueError("component proofs must have unique names")
-        return self
-
-
 class HostedRuntimeObservedAppliedV2(_StrictObservedWireModel):
     etag: str = Field(min_length=1, max_length=1024)
     source_revision: str = Field(alias="sourceRevision", pattern=r"^[0-9a-f]{64}$")
@@ -143,7 +123,6 @@ class HostedRuntimeObservedV2(_StrictObservedWireModel):
     applied: HostedRuntimeObservedAppliedV2 | None
     boot: HostedRuntimeObservedBootV1 | None
     cli: HostedRuntimeObservedCliV1 | None
-    components: HostedRuntimeObservedComponentsV1 | None = None
     systemd: HostedRuntimeObservedSystemdV1 | None = None
     supervisor: HostedRuntimeObservedSupervisorV1 | None = None
     providers: dict[str, HostedRuntimeObservedProviderPayload] | None = None

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -167,6 +167,26 @@ def test_runtime_observation_semantic_hash_ignores_only_transport_fields() -> No
         assert runtime_observation_service._observation_semantic_hash(changed) != baseline
 
 
+def test_component_proof_is_versioned_unique_and_cannot_certify_partial_health() -> None:
+    payload = _payload().model_dump(mode="json", by_alias=True)
+    entry = {
+        "component": "files",
+        "status": "ok",
+        "configRevision": "a" * 64,
+        "accessRevision": "b" * 64,
+        "invocationId": "c" * 32,
+    }
+    payload["components"] = {"schemaVersion": 1, "entries": [entry]}
+    assert RuntimeObservationEventV2.model_validate(payload).components is not None
+    for proof in [
+        {"schemaVersion": 2, "entries": [entry]},
+        {"schemaVersion": 1, "entries": [entry, entry]},
+        {"schemaVersion": 1, "entries": [{**entry, "status": "unknown"}]},
+    ]:
+        with pytest.raises(ValueError):
+            RuntimeObservationEventV2.model_validate({**payload, "components": proof})
+
+
 def test_runtime_observation_identity_envelope_is_additive_and_consistent() -> None:
     payload = _payload().model_dump(mode="json", by_alias=True)
     assert payload["generation"] == payload["applied"]["generation"]

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -3021,6 +3021,7 @@ def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:
         "agentPlugins",
         "skills",
         "userActivity",
+        "components",
     ):
         payload.pop(field)
     return payload
@@ -3093,9 +3094,19 @@ async def test_v1_heartbeat_is_byte_frozen_and_has_no_companion_side_effects(
                     "runtime_observed": _payload().model_dump(mode="json", by_alias=True),
                 },
             )
+            components_on_legacy = await client.post(
+                f"/v1/agents/{environment.id}/sync-heartbeat",
+                json={
+                    "runtime_observed": {
+                        **_legacy_runtime_observed(_payload()),
+                        "components": {"schemaVersion": 1, "entries": []},
+                    }
+                },
+            )
     finally:
         app.dependency_overrides.clear()
 
+    assert components_on_legacy.status_code == 422
     assert legacy.status_code == 204
     assert legacy.content == b""
     assert strict_v2_on_v1.status_code == 422

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -178,6 +178,13 @@ def test_component_proof_is_versioned_unique_and_cannot_certify_partial_health()
     }
     payload["components"] = {"schemaVersion": 1, "entries": [entry]}
     assert RuntimeObservationEventV2.model_validate(payload).components is not None
+    unknown_proof = {"schemaVersion": 1, "entries": [{**entry, "status": "unknown"}]}
+    for status in ("unknown", "error"):
+        observed = RuntimeObservationEventV2.model_validate(
+            {**payload, "status": status, "components": unknown_proof}
+        )
+        assert observed.status == status
+
     for proof in [
         {"schemaVersion": 2, "entries": [entry]},
         {"schemaVersion": 1, "entries": [entry, entry]},

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1930,6 +1930,11 @@ comparing the selected product version to a semver floor.
 
 ## Runtime UI And Terminal
 
+Versioned [component activation proof](plans/component-activation-proof.md) lets
+readers admit a healthy Files or Runtime UI component while aggregate Ready is
+false. It retains the exact apply/boot/configuration and credential authority;
+legacy or unavailable proof retains the complete-runtime admission gate.
+
 Hosted deployment pages expose two live surfaces:
 
 - **Control UI** opens runtime-native authentication in a top-level window. The

--- a/docs/plans/component-activation-proof.md
+++ b/docs/plans/component-activation-proof.md
@@ -96,13 +96,14 @@ release qualification or Fable's independent final review.
 
 ```bash
 bash scripts/test.sh cli src/runtime/hermes-dashboard-auth.test.ts src/runtime/observed-v2.test.ts src/runtime/heartbeat-observation.test.ts
+bash scripts/test.sh runtime-systemd
 ```
 
 The native auth fixture downloads the exact checksum/commit already pinned in
 `tests/fixtures/runtime-official-installer-systemd/Dockerfile` and imports its
-real `gated_auth_middleware` and `BasicAuthProvider`. Status, HTML and systemd
-handlers are fixtures; this does not build or run the complete native SPA or
-gateway. It proves anonymous root 302, public login 200, healthy aggregate ok,
+real `gated_auth_middleware`, `BasicAuthProvider` and dashboard auth router,
+including its actual server-rendered `login_page`. Gateway status and systemd
+remain fixtures; this does not build or run the complete native SPA or gateway. It proves anonymous root 302, public login 200, healthy aggregate ok,
 and usable component UI with gateway state stopped. Ordinary HTTP regressions
 also cover timestamp-only watch rewrites surviving probes, meaningful parent
 health/receipt changes rejecting snapshots, and unknown proof preserving a
@@ -122,3 +123,14 @@ prepares. The Cloud component contract passed through `scripts/test.sh backend`
 (1 selected test), accepting unknown/error with unknown proof while rejecting
 contradictory aggregate ok. Wire fields are unchanged, so no client regeneration
 is required for this correction. Biome, Ruff and shell syntax checks passed.
+
+The existing privileged systemd CI workflow calls `runtime-systemd`, which now
+prepares the pinned dashboard fixture and executes the native auth test alongside
+systemd tests. Missing fixture setup in that suite fails instead of silently
+skipping. The native check verifies root 302, actual login 200/no-store/password
+form, native provider metadata and the unchanged CLI probe. It does not require
+an added workflow or a CLI release artifact.
+
+CI wiring follow-up: `bash scripts/test.sh runtime-systemd` passed 9 tests / 53
+assertions with the actual native login router and provider. No new workflow was
+created; the existing privileged systemd workflow now covers this scenario.

--- a/docs/plans/component-activation-proof.md
+++ b/docs/plans/component-activation-proof.md
@@ -19,6 +19,12 @@ the probe. Automatic service restart can qualify a new invocation under the
 unchanged committed configuration. Missing configuration, unknown invocation,
 probe failure or mutation during observation produces unavailable proof.
 
+The complete observation rechecks the applied receipt and boot/watch health
+after asynchronous probes. Any parent change invalidates the entire snapshot,
+including its aggregate health; it cannot fall back to a stale healthy result.
+Buffered event retries retain their original capture timestamp, from which
+Cloud computes freshness.
+
 The additive `components` v1 observation envelope inherits the existing exact
 apply receipt, boot nonce/session, runtime identity and source revision from its
 parent event. Its point-in-time freshness is bounded by the existing observation

--- a/docs/plans/component-activation-proof.md
+++ b/docs/plans/component-activation-proof.md
@@ -1,0 +1,78 @@
+# Component activation proof
+
+Implementation draft for owner review, 2026-09-12. This is source behavior, not a
+released CLI or deployed-service guarantee.
+
+The CLI writes a separate `component-activations.json` version-1 record after
+successful apply, bound to the digest of the complete existing apply receipt.
+The legacy receipt schema stays unchanged so an older CLI can still replay it. Each entry binds an enabled Files, Hermes UI or OpenClaw UI component
+to its committed systemd fingerprint, effective native unit/drop-ins from
+`systemctl cat`, configuration bytes, access
+revision and observed service invocation. Capture follows the existing complete
+activation/authority commit; it never certifies a partially successful apply.
+
+[`component-observation.ts`](../../packages/cli/src/runtime/component-observation.ts)
+reads only the component's unit/configuration. Independent observation requires
+that configuration to match the committed receipt, a successful component HTTP
+probe, and the same live systemd invocation and configuration before and after
+the probe. Automatic service restart can qualify a new invocation under the
+unchanged committed configuration. Missing configuration, unknown invocation,
+probe failure or mutation during observation produces unavailable proof.
+
+The additive `components` v1 observation envelope inherits the existing exact
+apply receipt, boot nonce/session, runtime identity and source revision from its
+parent event. Its point-in-time freshness is bounded by the existing observation
+deadline. A required component's unavailable proof cannot certify aggregate
+healthy status. Aggregate Ready remains independent of component admission.
+
+Access revisions use SHA-256 over compact UTF-8 JSON arrays:
+
+- Files: `["files", auth.accessRevision, auth.secret]`.
+- Hermes UI: `["hermes-ui", username, password, sessionSecret]`.
+- OpenClaw UI: `["openclaw-ui", gatewayToken]`.
+
+These reuse the existing credential derivation and access-reset generation; they
+do not add another secret or revision authority. No secret bytes are reported.
+Component identities fix the serving ports to 9120, 9119 and 18789 respectively.
+Hermes UI checks its own basic-auth status and served SPA independently of
+gateway health; the aggregate readiness check still requires the gateway.
+The pinned native Hermes SPA is a FastAPI GET route, so this component probe
+uses GET rather than assuming HEAD support. Systemd v257 documents a new
+InvocationID per unit runtime cycle and formats it as 32 hexadecimal characters.
+
+Readers must deploy before the producing CLI. Absent, malformed, truncated,
+unknown-version or legacy proof never authorizes partial-runtime admission; the
+existing complete-runtime gate remains the fallback. Native OpenClaw `$include`
+configurations have no component proof until their resolved dependency set can
+be attested. The OSS UI consumes an optional version-1 admission marker on the
+published endpoint; credential/route authorization still occurs server-side.
+
+Independent services do not isolate shared RAM, disk, kernel, container or node
+failure. This protocol does not promise instantaneous failure detection.
+
+## Verification
+
+```bash
+bash scripts/test.sh cli src/runtime/manifest-reconciliation.test.ts --test-name-pattern 'component proof requires'
+bash scripts/test.sh runtime-systemd
+bash scripts/test.sh web src/hosted/agents/runtime-readiness.test.ts
+```
+
+Done: focused tests/typechecks pass, the native fixture verifies invocation
+rotation, and the UI keeps aggregate Ready false while admitting a proved healthy
+component. Cloud/Hosted schema and authorization verification belongs to the
+paired reader changes. Root must qualify the next released CLI with a successful
+owner deployment and fresh component observations before enabling this behavior
+for that deployment; no fleet or tenant upgrade is implied.
+
+Local implementation verification (2026-09-12): component persistence and
+configuration/native-override drift scenario passed (1 test, 8 assertions);
+`runtime-systemd` passed (8 tests, 42 assertions), including real invocation
+rotation and unchanged effective configuration across restart. Observation and
+producer regressions passed (33 tests, 141 assertions), including actual local
+HTTP responses for a healthy Hermes UI with its gateway stopped. The frontend
+component admission test passed (3 tests, 19 assertions), with typecheck,
+production build and 9 SSR checks. CLI typecheck and Biome passed. The paired
+Hosted reader/admission milestone is `1c5ede6da`; its 134 boundary tests and 13
+PostgreSQL route tests passed. These results do not replace owner runtime/CLI
+release qualification or Fable's independent final review.

--- a/docs/plans/component-activation-proof.md
+++ b/docs/plans/component-activation-proof.md
@@ -20,7 +20,9 @@ unchanged committed configuration. Missing configuration, unknown invocation,
 probe failure or mutation during observation produces unavailable proof.
 
 The complete observation rechecks the applied receipt and boot/watch health
-after asynchronous probes. Any parent change invalidates the entire snapshot,
+after asynchronous probes. Only the watch wrapper's top-level `timestamp` is
+excluded from its canonical comparison; event, schema, health and identity
+changes still invalidate the entire snapshot,
 including its aggregate health; it cannot fall back to a stale healthy result.
 Buffered event retries retain their original capture timestamp, from which
 Cloud computes freshness.
@@ -28,8 +30,13 @@ Cloud computes freshness.
 The additive `components` v1 observation envelope inherits the existing exact
 apply receipt, boot nonce/session, runtime identity and source revision from its
 parent event. Its point-in-time freshness is bounded by the existing observation
-deadline. A required component's unavailable proof cannot certify aggregate
-healthy status. Aggregate Ready remains independent of component admission.
+deadline. Component entries report `ok` or `unknown`: an unavailable proof is
+not proof of a definite service failure. An unknown component downgrades an
+otherwise `ok` aggregate to `unknown`; existing `error` and `unknown` remain.
+Cloud accepts unknown/error aggregates with unknown proof and continues to reject
+contradictory `ok` plus unknown proof. Hosted partial admission still requires
+that component's positive proof and unchanged exact identity/freshness gates.
+Absent legacy proof retains the existing aggregate fallback.
 
 Access revisions use SHA-256 over compact UTF-8 JSON arrays:
 
@@ -40,10 +47,11 @@ Access revisions use SHA-256 over compact UTF-8 JSON arrays:
 These reuse the existing credential derivation and access-reset generation; they
 do not add another secret or revision authority. No secret bytes are reported.
 Component identities fix the serving ports to 9120, 9119 and 18789 respectively.
-Hermes UI checks its own basic-auth status and served SPA independently of
-gateway health; the aggregate readiness check still requires the gateway.
-The pinned native Hermes SPA is a FastAPI GET route, so this component probe
-uses GET rather than assuming HEAD support. Systemd v257 documents a new
+Hermes UI checks `/api/status` for enabled basic form authentication, then GETs
+public `/login` HTML independently of gateway health. The aggregate readiness
+check still requires the gateway. In the pinned native auth middleware,
+`_GATE_PUBLIC_PREFIXES` includes `/login`; anonymous `/` redirects there with 302.
+The probe neither assumes HTTP Basic headers nor follows redirects. Systemd v257 documents a new
 InvocationID per unit runtime cycle and formats it as 32 hexadecimal characters.
 
 Readers must deploy before the producing CLI. Absent, malformed, truncated,
@@ -71,7 +79,7 @@ paired reader changes. Root must qualify the next released CLI with a successful
 owner deployment and fresh component observations before enabling this behavior
 for that deployment; no fleet or tenant upgrade is implied.
 
-Local implementation verification (2026-09-12): component persistence and
+Earlier verification (before the Fable probe correction): component persistence and
 configuration/native-override drift scenario passed (1 test, 8 assertions);
 `runtime-systemd` passed (8 tests, 42 assertions), including real invocation
 rotation and unchanged effective configuration across restart. Observation and
@@ -82,3 +90,35 @@ production build and 9 SSR checks. CLI typecheck and Biome passed. The paired
 Hosted reader/admission milestone is `1c5ede6da`; its 134 boundary tests and 13
 PostgreSQL route tests passed. These results do not replace owner runtime/CLI
 release qualification or Fable's independent final review.
+
+
+## Fable correction evidence
+
+```bash
+bash scripts/test.sh cli src/runtime/hermes-dashboard-auth.test.ts src/runtime/observed-v2.test.ts src/runtime/heartbeat-observation.test.ts
+```
+
+The native auth fixture downloads the exact checksum/commit already pinned in
+`tests/fixtures/runtime-official-installer-systemd/Dockerfile` and imports its
+real `gated_auth_middleware` and `BasicAuthProvider`. Status, HTML and systemd
+handlers are fixtures; this does not build or run the complete native SPA or
+gateway. It proves anonymous root 302, public login 200, healthy aggregate ok,
+and usable component UI with gateway state stopped. Ordinary HTTP regressions
+also cover timestamp-only watch rewrites surviving probes, meaningful parent
+health/receipt changes rejecting snapshots, and unknown proof preserving a
+previous definite error. No CLI package/release artifact is produced.
+
+`persistComponentActivations` runs only from `commitRuntimeAppliedState`; the
+same-receipt 304 `not_modified` path returns without that commit. Existing
+receipts therefore need a successful actual apply to gain proof. No automatic
+apply or receipt migration is added. Owner qualification must check proof
+presence; this source fact is not evidence of live rollout state.
+
+Fable correction verification (2026-09-12): the command above passed 27 tests
+with CLI typecheck, including the native middleware/provider scenario.
+`bash scripts/test.sh cli src/serve/sync-engine.test.ts src/serve/sync-module.test.ts`
+passed 71 tests, including a null initial `last_sync_error` while normal startup
+prepares. The Cloud component contract passed through `scripts/test.sh backend`
+(1 selected test), accepting unknown/error with unknown proof while rejecting
+contradictory aggregate ok. Wire fields are unchanged, so no client regeneration
+is required for this correction. Biome, Ruff and shell syntax checks passed.

--- a/docs/plans/sync-module-lifecycle.md
+++ b/docs/plans/sync-module-lifecycle.md
@@ -1,149 +1,49 @@
 # Recoverable sync module lifecycle
 
-Draft for owner review, 2026-09-12. This specifies the remaining within-Agent
-sync isolation change; it is not an implemented guarantee. No Cloud/Hosted wire
-schema, Files credential proof, model, or native service policy changes are needed.
+Implementation draft for owner review, 2026-09-12. The CLI implementation is in
+[`sync-module.ts`](../../packages/cli/src/serve/sync-module.ts) and
+[`sync-engine.ts`](../../packages/cli/src/serve/sync-engine.ts). This local
+lifecycle does not change Cloud/Hosted wire contracts or Files/UI admission.
 
-## Why a local catch is insufficient
+After shared Agent identity validation, Session and Skill slots prepare and run
+independently alongside heartbeat, SSE and the durable queue. A missing adapter
+capability is `unsupported`; `preparing`, `draining` and `retry_wait` retain queued
+work without consuming its upload retry budget. Eligibility-aware queue waiting
+avoids spinning on blocked items. Publication wakes the drain immediately.
 
-[`runSyncEngine`](../../packages/cli/src/serve/sync-engine.ts) prepares sessions
-then Skills before starting either worker, heartbeat, or drain. A preparation
-failure exits the engine. `runDaemonWorkers` then aborts its observation worker.
-Preparation currently has no independently owned cancellation scope.
+Each attempt owns its cancellation scope. Queue uploads and Skill SSE callbacks
+capture the prepared module, Project getter and hash map under a lease. Closing
+an attempt prevents acquisition, aborts its HTTP reads, and joins scans, watcher
+callbacks, reconciliation and leases before replacement. Project reassignment
+also retires the binding before loading another Project's claims. Same-key queue
+version and Agent/Project identity fences remain in place.
 
-The data adapter contract in
-[`base.ts`](../../packages/cli/src/adapters/base.ts) exposes Promise-returning
-`contentProtocol`, `collect`, `scan`, `resolve`, and `listKeys` without an abort
-context. [`watcher.ts`](../../packages/cli/src/serve/watcher.ts) and
-[`sessions-watcher.ts`](../../packages/cli/src/serve/sessions-watcher.ts) close
-their watchers on abort, but their callbacks return void. The callbacks launch
-scans/enqueues without an awaitable close boundary. Merely retrying preparation
-does not address already-started work or the drain's mutable hash maps.
+Preparation and worker failures retry from one second with exponential backoff
+and jitter, capped at a 60-second base delay. One healthy minute resets backoff.
+Module state/errors have independent SyncHealth keys. Global authentication
+revocation and authoritative Agent disconnect still abort the daemon with exit
+code 2, including during local retry. All workers settle before final queue
+persistence and Vault cleanup; startup failure also runs that cleanup.
 
-## Proposed internal API changes
+Adapter reads accept an optional `SyncReadContext`. Session iteration checks
+cancellation between batches/files, database readers close in `finally`, and
+OpenClaw command reads cancel and join their subprocess before releasing the
+command slot. Foreground callers need not supply a context. Native SDK calls
+without cancellation support and synchronous filesystem reads must actually
+finish; a slot remains draining until they do. There is no abandoned-promise
+replacement or guarantee against kernel-level uninterruptible I/O, shared disk
+failure, or event-loop blocking inside a third-party reader.
 
-Add `serve/sync-module.ts` with these internal contracts. `Binding` is the
-existing queue module plus its `lastPushedHash` map, published as one object:
+## Verification
 
-```ts
-type ModuleState =
-  | "unsupported"
-  | "preparing"
-  | "ready"
-  | "draining"
-  | "retry_wait"
-  | "stopped";
-
-interface ModuleLease<Binding> {
-  binding: Binding;
-  signal: AbortSignal;
-  release(): void;
-}
-
-interface PreparedModule<Binding> {
-  binding: Binding;
-  run(): Promise<void>;
-  close(): Promise<void>;
-}
-
-interface ModuleSlot<Binding> {
-  readonly state: ModuleState;
-  acquire(): ModuleLease<Binding> | null;
-  run(): Promise<void>;
-  close(): Promise<void>;
-}
+```bash
+bash scripts/test.sh cli tests/adapters src/adapters/openclaw-workspace.test.ts src/serve/sync-module.test.ts src/serve/sync-engine.test.ts src/serve/queue.test.ts src/serve/sessions-watcher.test.ts src/serve/watcher.test.ts
 ```
 
-`ModuleSlot` owns one attempt controller and at most one prepared instance. Its
-factory takes `{ signal, track }`; `track(promise)` registers every scan,
-watcher callback and project reconciliation before returning control to its
-caller. Factory failure closes this scope even if no PreparedModule was returned.
-`close()` is idempotent: reject new leases, abort the attempt, close watchers,
-then join tracked tasks and drain/SSE leases. Only then discard the binding and
-construct another attempt. A swallowed rejection is not a completed module.
-
-Session binding retains `{ module, protocol, lastPushedHash }`; Skill binding
-retains `{ module, getProjectId, lastPushedHash, onEvent }`. Do not move the
-project getter or maps into unrelated mutable globals. A lease captures one
-binding through an entire queue upload and its version-fenced acknowledgement.
-
-Change `watchSkills.onSkillChanged` and `watchSessions.onPathStable` to accept
-`void | Promise<void>`. Watcher shutdown must wait for callback promises, and
-the sync preparation functions must return their enqueue/scan promises instead
-of discarding them. Keep callback coalescing; do not serialize independent
-filesystem events behind a stalled network request.
-
-For bounded cancellation, extend adapter read operations with an optional
-`SyncReadContext = { signal: AbortSignal }` argument: SessionModule
-`contentProtocol(context?)`, `collect(request, context?)`,
-`scan(request, knownRevisions, context?)`, `resolve(id, context?)`, and SkillModule
-`collect(context?)`, `listKeys(context?)`. Thread it through `scanSessionModule`
-and the six adapter implementations. Existing foreground callers remain valid.
-Iterators check abort between batches and close DB/file handles in finally;
-network/subprocess reads use the signal. No cancellation may infer local absence
-or mark a scan complete. This is a local TypeScript contract, not a generated
-HTTP API change. Writes/removals keep their existing ownership checks.
-
-## Engine and queue integration
-
-1. Keep initial Agent/registration identity validation as a shared startup
-   prerequisite. After it succeeds, start slots, heartbeat, SSE, and drain
-   together. Preserve one shared queue and one heartbeat per Agent.
-2. Use `unsupported` only when the adapter does not implement the module.
-   `preparing`, `draining`, and `retry_wait` are unavailable but retain all
-   queued work. Existing unsupported-module drop behavior remains explicit.
-3. Extend `RetryQueue.peek` with an eligibility predicate and add
-   `waitForChange(signal, timeoutMs)`, which waits for a new queue/slot event even
-   when the queue is nonempty. Drain selects an eligible item, acquires its
-   module lease synchronously, then awaits upload. If none is eligible, wait;
-   do not call the current `waitForItem` and spin on retained blocked work.
-   Slot publication wakes drain. Skip unready items without incrementing attempts
-   or drop counts. Preserve same-key version guards, identity fences and normal
-   upload retry budgets.
-4. Run queue HTTP calls under the lease signal combined with Agent shutdown.
-   Update queue/hash/claims only under that lease and current version. Closing
-   a module waits for this work before reloading its hash maps. A lease cancelled
-   by module shutdown retains the queue item and does not exhaust its retries.
-5. SSE acquires a Skill lease before onEvent; otherwise ignore the wakeup and
-   rely on the next complete startup scan. Vault-only auth handling remains
-   separate. Decide global SSE auth failure from adapter capability, not whether
-   the Skill slot happens to be ready.
-6. On recoverable preparation/run failure: `ready -> draining -> retry_wait ->
-   preparing`. Backoff starts at 1 second, doubles to 60 seconds with jitter,
-   and resets after one healthy minute, not after merely constructing a worker.
-   Publish module health errors through existing SyncHealth; healthy module
-   success must not clear another module's error.
-7. Identity revocation/disconnect and authoritative auth failure still invoke
-   the existing global abort/exit-code-2 path. These never enter local retry.
-   Engine finally closes slots, joins heartbeat/SSE/drain, flushes the queue,
-   and calls Vault finish even when startup preparation failed.
-
-If an old adapter cannot cancel an in-flight read, its slot stays `draining`
-until it actually completes; expose that state and never overlap a replacement
-worker. Other slots and runtime observation continue. Do not implement a
-Promise.race deadline that abandons a writer while claiming cleanup succeeded.
-The adapter context work is required to make shutdown itself bounded rather
-than merely make peer progress independent.
-
-## Reviewable acceptance scenarios
-
-Use `scripts/test.sh cli` only, with a fake HOME, real persisted queue, local
-fixture adapters, and controlled HTTP responses. Three integration scenarios
-cover the meaningful boundaries without one test per state:
-
-- Fail session protocol preparation, keep a queued session, and successfully
-  upload a Skill and heartbeat. Restore the session adapter; the retained session
-  uploads after backoff without duplicated watchers or a daemon restart.
-- Fail a Skill worker while its scan and one drain request are active. Verify
-  both leases drain/cancel before replacement, no stale hash/claim acknowledgement
-  removes a newer queued version, and healthy session uploads continue. Abort
-  during retry/cleanup and assert every owned handle and queue write finishes.
-- Return an authoritative 401/disconnect during local retry and during SSE.
-  Both slots and observation stop via the existing global authority boundary;
-  queued work is retained and exit code stays 2. A partial/aborted inventory never
-  authorizes deletion.
-
-Done: these scenarios and existing sync, queue, watcher, session protocol and
-Vault isolation tests pass through the hermetic CLI entrypoint, with no live
-services or left-over task resources. This design requires review of the
-adapter cancellation and lease boundaries before implementation is called done.
+Done: CLI typecheck and the selected tests pass in the hermetic runner. Scenarios
+cover retained Session work while Skills and heartbeat progress through a failed
+protocol preparation and recovery, cancellation while both an upload lease and
+worker cleanup are held, auth revocation during retry, and joining an
+unresponsive native command before its successor. Existing queue version,
+watcher, adapter and global auth regressions run in the same suite. These are
+local fault-injection results, not a released-CLI or live deployment guarantee.

--- a/docs/plans/sync-module-lifecycle.md
+++ b/docs/plans/sync-module-lifecycle.md
@@ -20,7 +20,8 @@ version and Agent/Project identity fences remain in place.
 
 Preparation and worker failures retry from one second with exponential backoff
 and jitter, capped at a 60-second base delay. One healthy minute resets backoff.
-Module state/errors have independent SyncHealth keys. Cancelled uploads cannot
+Module state/errors have independent SyncHealth keys. Normal initial preparation
+is not a sync error; a prior retry failure remains reported until ready. Cancelled uploads cannot
 advance confirmed hashes or claims, and a received authoritative auth failure
 still triggers global revocation when module cancellation races it. Global authentication
 revocation and authoritative Agent disconnect still abort the daemon with exit

--- a/docs/plans/sync-module-lifecycle.md
+++ b/docs/plans/sync-module-lifecycle.md
@@ -20,7 +20,9 @@ version and Agent/Project identity fences remain in place.
 
 Preparation and worker failures retry from one second with exponential backoff
 and jitter, capped at a 60-second base delay. One healthy minute resets backoff.
-Module state/errors have independent SyncHealth keys. Global authentication
+Module state/errors have independent SyncHealth keys. Cancelled uploads cannot
+advance confirmed hashes or claims, and a received authoritative auth failure
+still triggers global revocation when module cancellation races it. Global authentication
 revocation and authoritative Agent disconnect still abort the daemon with exit
 code 2, including during local retry. All workers settle before final queue
 persistence and Vault cleanup; startup failure also runs that cleanup.

--- a/packages/cli/scripts/prepare-hermes-dashboard-fixture.sh
+++ b/packages/cli/scripts/prepare-hermes-dashboard-fixture.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Native auth modules use the exact source pinned by the official installer fixture.
+hermes_dashboard_fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/clawdi-hermes-dashboard.XXXXXX")"
+trap 'rm -rf "$hermes_dashboard_fixture_root"; if [[ -n "${hermes_fixture_root:-}" ]]; then rm -rf "$hermes_fixture_root"; fi' EXIT
+hermes_dashboard_dockerfile="$package_root/tests/fixtures/runtime-official-installer-systemd/Dockerfile"
+hermes_dashboard_commit=$(sed -n 's/^ARG HERMES_COMMIT=//p' "$hermes_dashboard_dockerfile")
+hermes_dashboard_digest=$(sed -n 's/^ADD --checksum=sha256:\([0-9a-f]*\).*/\1/p' "$hermes_dashboard_dockerfile" | tail -1)
+mkdir -p "$hermes_dashboard_fixture_root/source"
+curl --fail --silent --show-error --location --max-time 120 --max-filesize 104857600 \
+ "https://github.com/NousResearch/hermes-agent/archive/$hermes_dashboard_commit.tar.gz" -o "$hermes_dashboard_fixture_root/source.tar.gz"
+printf '%s  %s\n' "$hermes_dashboard_digest" "$hermes_dashboard_fixture_root/source.tar.gz" | sha256sum --check
+tar -xzf "$hermes_dashboard_fixture_root/source.tar.gz" --strip-components=1 -C "$hermes_dashboard_fixture_root/source"
+export CLAWDI_TEST_HERMES_DASHBOARD_VENV="$hermes_dashboard_fixture_root/venv"
+export CLAWDI_TEST_HERMES_DASHBOARD_SOURCE="$hermes_dashboard_fixture_root/source"
+uv venv "$CLAWDI_TEST_HERMES_DASHBOARD_VENV"
+uv pip install --python "$CLAWDI_TEST_HERMES_DASHBOARD_VENV/bin/python" \
+ 'fastapi==0.141.1' 'uvicorn==0.52.4' 'PyYAML==6.0.3' 'rich==15.0.0' 'python-dotenv==1.2.3'

--- a/packages/cli/scripts/test-internal.sh
+++ b/packages/cli/scripts/test-internal.sh
@@ -20,6 +20,13 @@ if [[ "$hermes_fixture_needed" == true && -z "${CLAWDI_TEST_HERMES_VENV:-}" ]]; 
 	source "$script_dir/prepare-hermes-native-fixture.sh"
 fi
 
+for test_arg in "$@"; do
+	if [[ "$test_arg" == *hermes-dashboard-auth.test.ts ]]; then
+		source "$script_dir/prepare-hermes-dashboard-fixture.sh"
+		break
+	fi
+done
+
 if [[ $# -gt 0 ]]; then
 	bun test "${test_args[@]}" "$@"
 	exit $?

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -166,9 +166,13 @@ export interface SessionBatchScan {
 	batches: AsyncIterable<SessionScanBatch>;
 }
 
+export interface SyncReadContext {
+	signal: AbortSignal;
+}
+
 export interface SessionModule {
-	contentProtocol(): Promise<"events-v1" | "snapshot-v1">;
-	collect(request: SessionScanRequest): Promise<SessionScanResult>;
+	contentProtocol(context?: SyncReadContext): Promise<"events-v1" | "snapshot-v1">;
+	collect(request: SessionScanRequest, context?: SyncReadContext): Promise<SessionScanResult>;
 	/**
 	 * Bounded scan for large or monolithic stores. Implementations may omit it;
 	 * callers then treat `collect` as one batch.
@@ -176,8 +180,9 @@ export interface SessionModule {
 	scan?(
 		request: SessionScanRequest,
 		knownSourceRevisions: ReadonlyMap<string, string>,
+		context?: SyncReadContext,
 	): Promise<SessionBatchScan>;
-	resolve(localSessionId: string): Promise<RawSession | null>;
+	resolve(localSessionId: string, context?: SyncReadContext): Promise<RawSession | null>;
 	/** Paths watched as one backing-store stability group. */
 	watchPaths(): string[];
 }
@@ -186,9 +191,12 @@ export async function scanSessionModule(
 	module: SessionModule,
 	request: SessionScanRequest,
 	knownSourceRevisions: ReadonlyMap<string, string> = new Map(),
+	context?: SyncReadContext,
 ): Promise<SessionBatchScan> {
-	if (module.scan) return module.scan(request, knownSourceRevisions);
-	const result = await module.collect(request);
+	context?.signal.throwIfAborted();
+	if (module.scan) return module.scan(request, knownSourceRevisions, context);
+	const result = await module.collect(request, context);
+	context?.signal.throwIfAborted();
 	return {
 		coverage: result.coverage,
 		batches: (async function* () {
@@ -214,8 +222,8 @@ export interface RawSkill {
 }
 
 export interface SkillModule {
-	collect(): Promise<RawSkill[]>;
-	listKeys(): Promise<string[]>;
+	collect(context?: SyncReadContext): Promise<RawSkill[]>;
+	listKeys(context?: SyncReadContext): Promise<string[]>;
 	path(key: string): string;
 	rootDir(): string;
 	sharedPath(skillKey: string, ownerHandle: string): string;

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
@@ -20,6 +21,7 @@ import type {
 	RawSkill,
 	SessionScanRequest,
 	SessionScanResult,
+	SyncReadContext,
 } from "./base";
 import { getClaudeHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import {
@@ -150,14 +152,19 @@ type ParsedSession = Omit<RawSession, "localSessionId" | "rawFilePath"> & {
 export class ClaudeCodeAdapter implements AgentAdapterCore {
 	readonly agentType = "claude_code" as const;
 	readonly sessions = {
-		contentProtocol: async () => "events-v1" as const,
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: async (context?: SyncReadContext) => {
+			context?.signal.throwIfAborted();
+			return "events-v1" as const;
+		},
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
 	readonly skills = {
-		collect: () => this.collectSkills(),
-		listKeys: () => this.listSkillKeys(),
+		collect: (context?: SyncReadContext) => this.collectSkills(context),
+		listKeys: (context?: SyncReadContext) => this.listSkillKeys(context),
 		path: (key: string) => this.getSkillPath(key),
 		rootDir: () => this.getSkillsRootDir(),
 		sharedPath: (skillKey: string, ownerHandle: string) =>
@@ -199,7 +206,11 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 		return absPath.replace(/\//g, "-");
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
 		if (!existsSync(projectsDir())) {
 			return { sessions: [], dedupedCount: 0, coverage: "complete" };
 		}
@@ -217,12 +228,12 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 					parts.length !== 2 ||
 					!parts[1].endsWith(".jsonl")
 				) {
-					return this.collectSessions({ kind: "complete", projectFilter });
+					return this.collectSessions({ kind: "complete", projectFilter }, context);
 				}
 				projectDirNames.add(parts[0]);
 			}
 			if (projectDirNames.size > 0) {
-				return this.collectProjectSessions([...projectDirNames], absFilter, "partial");
+				return this.collectProjectSessions([...projectDirNames], absFilter, "partial", context);
 			}
 		}
 
@@ -246,10 +257,15 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 			projectDirs.map((projectDir) => projectDir.name),
 			absFilter,
 			"complete",
+			context,
 		);
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
 		if (!existsSync(projectsDir()) || basename(localSessionId) !== localSessionId) return null;
 		const matches: Array<{ filePath: string; projectDirName: string }> = [];
 		for (const projectDir of readdirSync(projectsDir(), { withFileTypes: true })) {
@@ -260,29 +276,31 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 		if (matches.length !== 1) {
 			if (matches.length === 0) return null;
 			return (
-				(await this.collectSessions({ kind: "complete" })).sessions.find(
+				(await this.collectSessions({ kind: "complete" }, context)).sessions.find(
 					(session) => session.localSessionId === localSessionId,
 				) ?? null
 			);
 		}
 		return (
-			this.collectProjectSessions([matches[0].projectDirName], null, "partial").sessions.find(
-				(session) => session.localSessionId === localSessionId,
-			) ?? null
+			(
+				await this.collectProjectSessions([matches[0].projectDirName], null, "partial", context)
+			).sessions.find((session) => session.localSessionId === localSessionId) ?? null
 		);
 	}
 
-	private collectProjectSessions(
+	private async collectProjectSessions(
 		projectDirNames: readonly string[],
 		absFilter: string | null,
 		coverage: SessionScanResult["coverage"],
-	): SessionScanResult {
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
 		const sessions: RawSession[] = [];
 		const uuidsBySession = new Map<RawSession, Set<string>>();
 		for (const projectDirName of projectDirNames) {
 			const projectPath = join(projectsDir(), projectDirName);
 			if (!existsSync(projectPath)) continue;
 			for (const file of readdirSync(projectPath).filter((name) => name.endsWith(".jsonl"))) {
+				if (context) await setImmediate(undefined, { signal: context.signal });
 				try {
 					const parsed = this.parseRawSession(join(projectPath, file), projectDirName);
 					if (!parsed) continue;
@@ -409,7 +427,8 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 		};
 	}
 
-	private async collectSkills(): Promise<RawSkill[]> {
+	private async collectSkills(context?: SyncReadContext): Promise<RawSkill[]> {
+		context?.signal.throwIfAborted();
 		const skillsDir = join(claudeDir(), "skills");
 		migrateLegacyLocalSetupSkill({
 			targetDir: join(skillsDir, "clawdi"),
@@ -459,7 +478,8 @@ export class ClaudeCodeAdapter implements AgentAdapterCore {
 		return join(claudeDir(), "skills", `${skillKey}__${ownerHandle}`);
 	}
 
-	private async listSkillKeys(): Promise<string[]> {
+	private async listSkillKeys(context?: SyncReadContext): Promise<string[]> {
+		context?.signal.throwIfAborted();
 		// Flat layout: top-level dirs under skills/. Mirrors the
 		// filtering of `collectSkills` so the daemon's hot-path
 		// rescan returns the same set the bulk push would consider

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,5 +1,6 @@
 import { type Dirent, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
@@ -20,6 +21,7 @@ import type {
 	RawSkill,
 	SessionScanRequest,
 	SessionScanResult,
+	SyncReadContext,
 } from "./base";
 import { getCodexHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import {
@@ -430,14 +432,19 @@ export class CodexAdapter implements AgentAdapterCore {
 	readonly agentType = "codex" as const;
 	private sessionPaths = new Map<string, string>();
 	readonly sessions = {
-		contentProtocol: async () => "events-v1" as const,
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: async (context?: SyncReadContext) => {
+			context?.signal.throwIfAborted();
+			return "events-v1" as const;
+		},
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
 	readonly skills = {
-		collect: () => this.collectSkills(),
-		listKeys: () => this.listSkillKeys(),
+		collect: (context?: SyncReadContext) => this.collectSkills(context),
+		listKeys: (context?: SyncReadContext) => this.listSkillKeys(context),
 		path: (key: string) => this.getSkillPath(key),
 		rootDir: () => this.getSkillsRootDir(),
 		sharedPath: (skillKey: string, ownerHandle: string) =>
@@ -464,17 +471,27 @@ export class CodexAdapter implements AgentAdapterCore {
 		return readCommandVersion("codex", ["--version"]);
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
 		const absFilter = resolveProjectFilter(request.projectFilter);
 		if (request.kind === "paths") {
 			if (request.paths.length === 0) {
-				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+				return this.collectSessions(
+					{ kind: "complete", projectFilter: request.projectFilter },
+					context,
+				);
 			}
 			const roots = sessionRoots().map((root) => resolve(root));
 			const files = new Set<string>();
 			for (const path of request.paths.map((candidate) => resolve(candidate))) {
 				if (!isPathWithinRoots(path, roots) || !path.endsWith(".jsonl")) {
-					return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+					return this.collectSessions(
+						{ kind: "complete", projectFilter: request.projectFilter },
+						context,
+					);
 				}
 				for (const [sessionId, knownPath] of this.sessionPaths) {
 					if (knownPath === path && !existsSync(path)) this.sessionPaths.delete(sessionId);
@@ -483,6 +500,7 @@ export class CodexAdapter implements AgentAdapterCore {
 			}
 			const sessionsById = new Map<string, RawSession>();
 			for (const filePath of files) {
+				if (context) await setImmediate(undefined, { signal: context.signal });
 				const session = parseSessionFile(filePath, absFilter);
 				if (session) {
 					sessionsById.set(session.localSessionId, session);
@@ -496,6 +514,7 @@ export class CodexAdapter implements AgentAdapterCore {
 		const pathsById = new Map<string, string>();
 		for (const root of sessionRoots()) {
 			for (const filePath of collectJsonlFiles(root)) {
+				if (context) await setImmediate(undefined, { signal: context.signal });
 				const session = parseSessionFile(filePath, absFilter);
 				if (session && !sessionsById.has(session.localSessionId)) {
 					sessionsById.set(session.localSessionId, session);
@@ -515,7 +534,11 @@ export class CodexAdapter implements AgentAdapterCore {
 		return { sessions: [...sessionsById.values()], dedupedCount: 0, coverage: "complete" };
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
 		const knownPath = this.sessionPaths.get(localSessionId);
 		if (knownPath) {
 			const current = parseSessionFile(knownPath, null);
@@ -523,13 +546,14 @@ export class CodexAdapter implements AgentAdapterCore {
 			this.sessionPaths.delete(localSessionId);
 		}
 		return (
-			(await this.collectSessions({ kind: "complete" })).sessions.find(
+			(await this.collectSessions({ kind: "complete" }, context)).sessions.find(
 				(session) => session.localSessionId === localSessionId,
 			) ?? null
 		);
 	}
 
-	private async collectSkills(): Promise<RawSkill[]> {
+	private async collectSkills(context?: SyncReadContext): Promise<RawSkill[]> {
+		context?.signal.throwIfAborted();
 		migrateLegacyLocalSetupSkill({
 			targetDir: join(skillsDir(), "clawdi"),
 			id: "clawdi",
@@ -568,7 +592,8 @@ export class CodexAdapter implements AgentAdapterCore {
 		return join(skillsDir(), key, "SKILL.md");
 	}
 
-	private async listSkillKeys(): Promise<string[]> {
+	private async listSkillKeys(context?: SyncReadContext): Promise<string[]> {
+		context?.signal.throwIfAborted();
 		// Flat layout. Mirrors `collectSkills` filtering so the
 		// daemon's rescan and the bulk push see the same set.
 		migrateLegacyLocalSetupSkill({

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
@@ -28,6 +29,7 @@ import type {
 	SessionScanRequest,
 	SessionScanResult,
 	SessionUserActivity,
+	SyncReadContext,
 } from "./base";
 import { getHermesHome, SKIP_DIRS } from "./paths";
 import {
@@ -510,16 +512,21 @@ function parseModelField(raw: string | null): string | null {
 export class HermesAdapter implements AgentAdapterCore {
 	readonly agentType = "hermes" as const;
 	readonly sessions = {
-		contentProtocol: () => this.getContentProtocol(),
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		scan: (request: SessionScanRequest, knownSourceRevisions: ReadonlyMap<string, string>) =>
-			this.scanSessions(request, knownSourceRevisions),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: (context?: SyncReadContext) => this.getContentProtocol(context),
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		scan: (
+			request: SessionScanRequest,
+			knownSourceRevisions: ReadonlyMap<string, string>,
+			context?: SyncReadContext,
+		) => this.scanSessions(request, knownSourceRevisions, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
 	readonly skills = {
-		collect: () => this.collectSkills(),
-		listKeys: () => this.listSkillKeys(),
+		collect: (context?: SyncReadContext) => this.collectSkills(context),
+		listKeys: (context?: SyncReadContext) => this.listSkillKeys(context),
 		path: (key: string) => this.getSkillPath(key),
 		rootDir: () => this.getSkillsRootDir(),
 		sharedPath: (skillKey: string, ownerHandle: string) =>
@@ -540,18 +547,26 @@ export class HermesAdapter implements AgentAdapterCore {
 		return readCommandVersion("hermes", ["--version"]);
 	}
 
-	private async getContentProtocol(): Promise<"events-v1" | "snapshot-v1"> {
+	private async getContentProtocol(
+		context?: SyncReadContext,
+	): Promise<"events-v1" | "snapshot-v1"> {
+		context?.signal.throwIfAborted();
 		if (!existsSync(stateDbPath())) return "snapshot-v1";
 		const db = await openReadonlySqlite(stateDbPath());
 		try {
+			context?.signal.throwIfAborted();
 			return hasStableModernMessageIds(messageTableInfo(db)) ? "events-v1" : "snapshot-v1";
 		} finally {
 			db.close();
 		}
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
-		const scan = await this.scanSessions(request, new Map());
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
+		const scan = await this.scanSessions(request, new Map(), context);
 		const sessions: RawSession[] = [];
 		let dedupedCount = 0;
 		for await (const batch of scan.batches) {
@@ -564,6 +579,7 @@ export class HermesAdapter implements AgentAdapterCore {
 	private async scanSessions(
 		_request: SessionScanRequest,
 		knownSourceRevisions: ReadonlyMap<string, string>,
+		context?: SyncReadContext,
 	): Promise<SessionBatchScan> {
 		if (!existsSync(stateDbPath())) {
 			return {
@@ -573,17 +589,24 @@ export class HermesAdapter implements AgentAdapterCore {
 			};
 		}
 		const db = await openReadonlySqlite(stateDbPath());
-		const activity = hermesUserActivity(db);
-		return {
-			coverage: "complete",
-			userActivity: activity,
-			batches: this.readSessionBatches(db, knownSourceRevisions),
-		};
+		try {
+			context?.signal.throwIfAborted();
+			const activity = hermesUserActivity(db);
+			return {
+				coverage: "complete",
+				userActivity: activity,
+				batches: this.readSessionBatches(db, knownSourceRevisions, context),
+			};
+		} catch (error) {
+			db.close();
+			throw error;
+		}
 	}
 
 	private async *readSessionBatches(
 		db: ReadonlySqliteDatabase,
 		knownSourceRevisions: ReadonlyMap<string, string>,
+		context?: SyncReadContext,
 	): AsyncGenerator<{
 		sessions: RawSession[];
 		observedLocalSessionIds: readonly string[];
@@ -593,6 +616,8 @@ export class HermesAdapter implements AgentAdapterCore {
 			const readers = this.sessionReaders(db);
 			let cursor: Pick<SessionRow, "started_at" | "id"> | null = null;
 			while (true) {
+				if (context) await setImmediate(undefined, { signal: context.signal });
+				context?.signal.throwIfAborted();
 				const rows = db
 					.prepare(`
 						SELECT id, source, model, title, started_at, ended_at,
@@ -633,10 +658,15 @@ export class HermesAdapter implements AgentAdapterCore {
 		}
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
 		if (!existsSync(stateDbPath())) return null;
 		const db = await openReadonlySqlite(stateDbPath());
 		try {
+			context?.signal.throwIfAborted();
 			const row = db
 				.prepare(`
 					SELECT id, source, model, title, started_at, ended_at,
@@ -739,7 +769,8 @@ export class HermesAdapter implements AgentAdapterCore {
 		};
 	}
 
-	private async collectSkills(): Promise<RawSkill[]> {
+	private async collectSkills(context?: SyncReadContext): Promise<RawSkill[]> {
+		context?.signal.throwIfAborted();
 		migrateLegacyLocalSetupSkill({
 			targetDir: join(skillsDir(), "clawdi"),
 			id: "clawdi",
@@ -801,7 +832,8 @@ export class HermesAdapter implements AgentAdapterCore {
 		return join(skillsDir(), "shared", `${skillKey}__${ownerHandle}`);
 	}
 
-	private async listSkillKeys(): Promise<string[]> {
+	private async listSkillKeys(context?: SyncReadContext): Promise<string[]> {
+		context?.signal.throwIfAborted();
 		// Hermes nests skills under category dirs:
 		//   `~/.hermes/skills/category/foo/SKILL.md`
 		// Recurse — same logic `_scanSkillsDir` uses for the

--- a/packages/cli/src/adapters/openclaw-command.ts
+++ b/packages/cli/src/adapters/openclaw-command.ts
@@ -6,16 +6,32 @@ let commandTail: Promise<void> = Promise.resolve();
 
 export function runOpenClawCommand(
 	args: string[],
-	options: Pick<ExecFileOptions, "timeout" | "maxBuffer">,
+	options: Pick<ExecFileOptions, "timeout" | "maxBuffer" | "signal">,
 ): Promise<string> {
 	// Session reads and async Skill discovery share a subprocess slot, not the event loop.
 	const command = commandTail.then(async () => {
-		const { stdout } = await execFileAsync("openclaw", args, {
-			...options,
+		options.signal?.throwIfAborted();
+		const { signal, ...limits } = options;
+		const running = execFileAsync("openclaw", args, {
+			...limits,
+			killSignal: "SIGKILL",
 			encoding: "utf8",
 			env: process.env,
 		});
-		return stdout;
+		const closed = new Promise<void>((resolve) => running.child.once("close", () => resolve()));
+		const abort = () => {
+			running.child.kill("SIGKILL");
+		};
+		signal?.addEventListener("abort", abort, { once: true });
+		if (signal?.aborted) abort();
+		try {
+			const { stdout } = await running;
+			signal?.throwIfAborted();
+			return stdout;
+		} finally {
+			signal?.removeEventListener("abort", abort);
+			await closed;
+		}
 	});
 	commandTail = command.then(
 		() => {},

--- a/packages/cli/src/adapters/openclaw-workspace.test.ts
+++ b/packages/cli/src/adapters/openclaw-workspace.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import {
 	listOpenClawAgentWorkspaces,
 	resolveOpenClawAgentWorkspace,
@@ -75,4 +84,43 @@ test.each([
 	const message = "OpenClaw workspace resolution requires `openclaw agents list --json`";
 	expect(() => resolveOpenClawAgentWorkspace()).toThrow(message);
 	await expect(resolveOpenClawAgentWorkspaceAsync()).rejects.toMatchObject({ message });
+});
+
+test("cancels an unresponsive roster read and joins its process before another command", async () => {
+	const roster = installRosterCommand();
+	const pidFile = join(root, "pid");
+	const command = join(root, "bin", "openclaw");
+	writeFileSync(
+		command,
+		`#!/bin/sh
+trap '' TERM
+echo $$ > "${pidFile}"
+while :; do :; done
+`,
+	);
+	const abort = new AbortController();
+	const running = resolveOpenClawAgentWorkspaceAsync("main", abort.signal);
+	const result = running.then(
+		() => null,
+		(error) => error,
+	);
+	try {
+		for (let attempt = 0; attempt < 100 && !existsSync(pidFile); attempt++) await delay(10);
+		expect(existsSync(pidFile)).toBe(true);
+		const pid = Number(readFileSync(pidFile, "utf8").trim());
+		abort.abort();
+		expect(await result).toBeInstanceOf(Error);
+		expect(() => process.kill(pid, 0)).toThrow();
+		writeFileSync(
+			command,
+			`#!/bin/sh
+cat "${roster}"
+`,
+		);
+		writeFileSync(roster, JSON.stringify([{ id: "main", workspace: root }]));
+		expect(await resolveOpenClawAgentWorkspaceAsync()).toBe(root);
+	} finally {
+		abort.abort();
+		await result;
+	}
 });

--- a/packages/cli/src/adapters/openclaw-workspace.ts
+++ b/packages/cli/src/adapters/openclaw-workspace.ts
@@ -45,14 +45,17 @@ export function resolveOpenClawAgentWorkspace(agentId = openClawAgentId()): stri
 
 export async function resolveOpenClawAgentWorkspaceAsync(
 	agentId = openClawAgentId(),
+	signal?: AbortSignal,
 ): Promise<string> {
 	let stdout: string;
 	try {
 		stdout = await runOpenClawCommand(["agents", "list", "--json"], {
+			signal,
 			maxBuffer: 1024 * 1024,
 			timeout: 15_000,
 		});
 	} catch {
+		signal?.throwIfAborted();
 		throw new Error(WORKSPACE_RESOLUTION_ERROR);
 	}
 	return workspaceForAgent(requireOpenClawAgentWorkspaces(stdout), agentId);

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import {
 	OPENCLAW_SDK_EXPORT_PATHS,
@@ -38,6 +39,7 @@ import type {
 	SessionScanRequest,
 	SessionScanResult,
 	SessionUserActivity,
+	SyncReadContext,
 } from "./base";
 import { runOpenClawCommand } from "./openclaw-command";
 import {
@@ -357,27 +359,37 @@ function mergeUserActivity(
 
 const OPENCLAW_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 
-async function runOpenClawJson(args: string[]): Promise<JsonObject | null> {
+async function runOpenClawJson(
+	args: string[],
+	context?: SyncReadContext,
+): Promise<JsonObject | null> {
 	try {
 		const stdout = await runOpenClawCommand(args, {
+			signal: context?.signal,
 			maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
 			timeout: 120_000,
 		});
 		return jsonObject(JSON.parse(stdout)) ?? null;
 	} catch {
+		context?.signal.throwIfAborted();
 		return null;
 	}
 }
 
-async function readOfficialSessionInventory(): Promise<OfficialSessionInventory | null> {
+async function readOfficialSessionInventory(
+	context?: SyncReadContext,
+): Promise<OfficialSessionInventory | null> {
 	const override = process.env.OPENCLAW_AGENT_ID?.trim();
-	const payload = await runOpenClawJson([
-		"sessions",
-		"--json",
-		...(override ? ["--agent", override] : ["--all-agents"]),
-		"--limit",
-		"all",
-	]);
+	const payload = await runOpenClawJson(
+		[
+			"sessions",
+			"--json",
+			...(override ? ["--agent", override] : ["--all-agents"]),
+			"--limit",
+			"all",
+		],
+		context,
+	);
 	if (!payload || !Array.isArray(payload.sessions)) return null;
 
 	let complete = true;
@@ -444,6 +456,7 @@ async function readOfficialSessionInventory(): Promise<OfficialSessionInventory 
 
 async function readOfficialSessionMessagesFromSdk(
 	entry: OfficialSessionEntry,
+	context?: SyncReadContext,
 ): Promise<JsonObject[] | null> {
 	if (!entry.sessionId) return null;
 	const sdkPath = resolveOpenClawSdkExport(
@@ -461,11 +474,13 @@ async function readOfficialSessionMessagesFromSdk(
 			typeof sdk.readVisibleSessionTranscriptMessageEntries !== "function"
 		)
 			return null;
+		context?.signal.throwIfAborted();
 		const result: unknown = await sdk.readVisibleSessionTranscriptMessageEntries({
 			agentId: entry.agentId,
 			sessionId: entry.sessionId,
 			sessionKey: entry.key,
 		});
+		context?.signal.throwIfAborted();
 		if (!Array.isArray(result)) return null;
 		return result.flatMap((value): JsonObject[] => {
 			const item = jsonObject(value);
@@ -481,32 +496,37 @@ async function readOfficialSessionMessagesFromSdk(
 			];
 		});
 	} catch {
+		context?.signal.throwIfAborted();
 		return null;
 	}
 }
 
 async function readOfficialSessionMessagesFromGateway(
 	entry: OfficialSessionEntry,
+	context?: SyncReadContext,
 ): Promise<JsonObject[] | null> {
 	let offset = 0;
 	let messages: JsonObject[] = [];
 	const seenOffsets = new Set<number>();
 	while (!seenOffsets.has(offset)) {
 		seenOffsets.add(offset);
-		const payload = await runOpenClawJson([
-			"gateway",
-			"call",
-			"chat.history",
-			"--params",
-			JSON.stringify({
-				agentId: entry.agentId,
-				limit: 1000,
-				maxChars: 500_000,
-				offset,
-				sessionKey: entry.key,
-			}),
-			"--json",
-		]);
+		const payload = await runOpenClawJson(
+			[
+				"gateway",
+				"call",
+				"chat.history",
+				"--params",
+				JSON.stringify({
+					agentId: entry.agentId,
+					limit: 1000,
+					maxChars: 500_000,
+					offset,
+					sessionKey: entry.key,
+				}),
+				"--json",
+			],
+			context,
+		);
 		if (!payload || !Array.isArray(payload.messages)) return null;
 		const page = payload.messages.flatMap((value): JsonObject[] => {
 			const message = jsonObject(value);
@@ -780,16 +800,24 @@ function materializeOpenClawJsonlSession(input: {
 export class OpenClawAdapter implements AgentAdapterCore {
 	readonly agentType = "openclaw" as const;
 	readonly sessions = {
-		contentProtocol: async () => "events-v1" as const,
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		scan: (request: SessionScanRequest, knownSourceRevisions: ReadonlyMap<string, string>) =>
-			this.scanSessions(request, knownSourceRevisions),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: async (context?: SyncReadContext) => {
+			context?.signal.throwIfAborted();
+			return "events-v1" as const;
+		},
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		scan: (
+			request: SessionScanRequest,
+			knownSourceRevisions: ReadonlyMap<string, string>,
+			context?: SyncReadContext,
+		) => this.scanSessions(request, knownSourceRevisions, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
 	readonly skills = {
-		collect: () => this.collectSkills(),
-		listKeys: () => this.listSkillKeys(),
+		collect: (context?: SyncReadContext) => this.collectSkills(context),
+		listKeys: (context?: SyncReadContext) => this.listSkillKeys(context),
 		path: (key: string) => this.getSkillPath(key),
 		rootDir: () => this.getSkillsRootDir(),
 		sharedPath: (skillKey: string, ownerHandle: string) =>
@@ -817,8 +845,12 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		);
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
-		const scan = await this.scanSessions(request, new Map());
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
+		const scan = await this.scanSessions(request, new Map(), context);
 		const sessions: RawSession[] = [];
 		let dedupedCount = 0;
 		for await (const batch of scan.batches) {
@@ -831,16 +863,18 @@ export class OpenClawAdapter implements AgentAdapterCore {
 	private async scanSessions(
 		request: SessionScanRequest,
 		knownSourceRevisions: ReadonlyMap<string, string>,
+		context?: SyncReadContext,
 	): Promise<SessionBatchScan> {
 		const materializeCanonicalActivity =
 			request.kind === "complete" && knownSourceRevisions.size === 0;
-		const officialInventory = await readOfficialSessionInventory();
+		const officialInventory = await readOfficialSessionInventory(context);
 		if (officialInventory) {
 			const collection = await this.collectOfficialSessionsMatching(
 				officialInventory,
 				request,
 				undefined,
 				knownSourceRevisions,
+				context,
 			);
 			if (materializeCanonicalActivity) {
 				collection.userActivity = mergeUserActivity(
@@ -851,7 +885,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			return singleSessionBatch("complete", collection);
 		}
 
-		const collection = await this.collectLegacySessions(request, knownSourceRevisions);
+		const collection = await this.collectLegacySessions(request, knownSourceRevisions, context);
 		if (collection.coverage === "complete" && materializeCanonicalActivity) {
 			collection.userActivity = mergeUserActivity(
 				collection.userActivity,
@@ -864,6 +898,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 	private async collectLegacySessions(
 		request: SessionScanRequest,
 		knownSourceRevisions: ReadonlyMap<string, string>,
+		context?: SyncReadContext,
 	): Promise<SessionCollection & { coverage: SessionScanResult["coverage"] }> {
 		if (request.kind === "complete") {
 			return {
@@ -872,6 +907,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 					undefined,
 					undefined,
 					knownSourceRevisions,
+					context,
 				)),
 				coverage: "complete",
 			};
@@ -880,6 +916,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			return this.collectLegacySessions(
 				{ kind: "complete", projectFilter: request.projectFilter },
 				knownSourceRevisions,
+				context,
 			);
 		}
 		const sessionRoots = listAgentDirs().map((dir) => resolve(dir, "sessions"));
@@ -894,6 +931,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				return this.collectLegacySessions(
 					{ kind: "complete", projectFilter: request.projectFilter },
 					knownSourceRevisions,
+					context,
 				);
 			}
 			transcriptPaths.add(normalized);
@@ -904,20 +942,26 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			transcriptPaths,
 			undefined,
 			knownSourceRevisions,
+			context,
 		);
 		for (const path of transcriptPaths) {
 			if (existsSync(path) && !collection.matchedTranscriptPaths.has(path)) {
 				return this.collectLegacySessions(
 					{ kind: "complete", projectFilter: request.projectFilter },
 					knownSourceRevisions,
+					context,
 				);
 			}
 		}
 		return { ...collection, coverage: "partial" };
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
-		const officialInventory = await readOfficialSessionInventory();
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
+		const officialInventory = await readOfficialSessionInventory(context);
 		if (officialInventory) {
 			return (
 				(
@@ -926,12 +970,13 @@ export class OpenClawAdapter implements AgentAdapterCore {
 						{},
 						localSessionId,
 						new Map(),
+						context,
 					)
 				).sessions[0] ?? null
 			);
 		}
 		return (
-			(await this.collectLegacySessionsMatching({}, undefined, localSessionId, new Map()))
+			(await this.collectLegacySessionsMatching({}, undefined, localSessionId, new Map(), context))
 				.sessions[0] ?? null
 		);
 	}
@@ -941,7 +986,9 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		transcriptPaths?: ReadonlySet<string>,
 		localSessionId?: string,
 		knownSourceRevisions: ReadonlyMap<string, string> = new Map(),
+		context?: SyncReadContext,
 	): Promise<SessionCollection> {
+		context?.signal.throwIfAborted();
 		const agentDirectoryListing = listAgentDirsWithCompleteness();
 		const agentDirs = agentDirectoryListing.dirs;
 		if (agentDirs.length === 0) {
@@ -1046,6 +1093,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		opts: { projectFilter?: string },
 		localSessionId?: string,
 		knownSourceRevisions: ReadonlyMap<string, string> = new Map(),
+		context?: SyncReadContext,
 	): Promise<SessionCollection> {
 		const absFilter = opts.projectFilter ? resolve(opts.projectFilter) : null;
 		const sessions: RawSession[] = [];
@@ -1056,6 +1104,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			complete: inventory.complete,
 		};
 		for (const entry of inventory.entries) {
+			if (context) await setImmediate(undefined, { signal: context.signal });
 			const sessionId = entry.sessionId;
 			if (localSessionId !== undefined && sessionId !== localSessionId) continue;
 			if (!sessionId && isInternalOpenClawSession(entry.key, entry)) continue;
@@ -1074,8 +1123,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			const sourceRevision = sessionId ? `${sessionId}:${updatedAt}` : null;
 			if (sessionId && knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
-			let transcript = await readOfficialSessionMessagesFromSdk(entry);
-			transcript ??= await readOfficialSessionMessagesFromGateway(entry);
+			let transcript = await readOfficialSessionMessagesFromSdk(entry, context);
+			transcript ??= await readOfficialSessionMessagesFromGateway(entry, context);
 			if (transcript === null && entry.sessionFile && sessionId && sourceRevision) {
 				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
 				const transcriptPath = isAbsolute(entry.sessionFile)
@@ -1189,7 +1238,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		};
 	}
 
-	private async collectSkills(): Promise<RawSkill[]> {
+	private async collectSkills(context?: SyncReadContext): Promise<RawSkill[]> {
+		context?.signal.throwIfAborted();
 		const skills: RawSkill[] = [];
 		const seen = new Map<string, string>(); // skillKey → first-winning agentDir
 		migrateLegacyLocalSetupSkill({
@@ -1263,7 +1313,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		return join(skillsDir(), `${skillKey}__${ownerHandle}`);
 	}
 
-	private async listSkillKeys(): Promise<string[]> {
+	private async listSkillKeys(context?: SyncReadContext): Promise<string[]> {
+		context?.signal.throwIfAborted();
 		// Restricted to the CURRENT agent's `skillsDir()` —
 		// `collectSkills` walks every agent dir for `clawdi push`
 		// (one-shot, batch view), but the daemon's hot path is
@@ -1274,7 +1325,10 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		// silently dropping those skills. Pre-fix the cross-agent
 		// enumerator silently lost OpenClaw skills under any
 		// agent other than the active one.
-		const root = join(await resolveOpenClawAgentWorkspaceAsync(agentId()), "skills");
+		const root = join(
+			await resolveOpenClawAgentWorkspaceAsync(agentId(), context?.signal),
+			"skills",
+		);
 		migrateLegacyLocalSetupSkill({
 			targetDir: join(root, "clawdi"),
 			id: "clawdi",

--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
@@ -15,6 +16,7 @@ import type {
 	SessionEventSemantics,
 	SessionScanRequest,
 	SessionScanResult,
+	SyncReadContext,
 } from "./base";
 import { getOpenCodeDataDir, getOpenCodeDbPath } from "./paths";
 import {
@@ -528,9 +530,14 @@ function parseSession(db: ReadonlySqliteDatabase, row: OpenCodeSessionRow): RawS
 export class OpenCodeAdapter implements AgentAdapterCore {
 	readonly agentType = "opencode" as const;
 	readonly sessions = {
-		contentProtocol: async () => "events-v1" as const,
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: async (context?: SyncReadContext) => {
+			context?.signal.throwIfAborted();
+			return "events-v1" as const;
+		},
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
 
@@ -542,26 +549,36 @@ export class OpenCodeAdapter implements AgentAdapterCore {
 		return readCommandVersion("opencode", ["--version"]);
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
-		const sessions = await this.collectCurrentSessions(undefined, request.projectFilter);
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
+		const sessions = await this.collectCurrentSessions(undefined, request.projectFilter, context);
 		return { sessions, dedupedCount: 0, coverage: "complete" };
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
 		const sourceId = localSessionId.startsWith("opencode.")
 			? localSessionId.slice("opencode.".length)
 			: localSessionId;
-		return (await this.collectCurrentSessions(sourceId))[0] ?? null;
+		return (await this.collectCurrentSessions(sourceId, undefined, context))[0] ?? null;
 	}
 
 	private async collectCurrentSessions(
 		sourceId?: string,
 		projectFilter?: string,
+		context?: SyncReadContext,
 	): Promise<RawSession[]> {
 		const databasePath = getOpenCodeDbPath();
 		if (!existsSync(databasePath)) return [];
 		const db = await openReadonlySqlite(databasePath);
 		try {
+			context?.signal.throwIfAborted();
 			assertSupportedSchema(db);
 			const rows = db
 				.prepare(
@@ -575,10 +592,14 @@ export class OpenCodeAdapter implements AgentAdapterCore {
 				)
 				.all(...(sourceId === undefined ? [] : [sourceId])) as OpenCodeSessionRow[];
 			const normalizedFilter = projectFilter ? resolve(projectFilter) : null;
-			return rows
-				.filter((row) => normalizedFilter === null || resolve(row.directory) === normalizedFilter)
-				.map((row) => parseSession(db, row))
-				.filter((session): session is RawSession => session !== null);
+			const sessions: RawSession[] = [];
+			for (const row of rows) {
+				if (context) await setImmediate(undefined, { signal: context.signal });
+				if (normalizedFilter !== null && resolve(row.directory) !== normalizedFilter) continue;
+				const session = parseSession(db, row);
+				if (session) sessions.push(session);
+			}
+			return sessions;
 		} finally {
 			db.close();
 		}

--- a/packages/cli/src/adapters/pi.ts
+++ b/packages/cli/src/adapters/pi.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
@@ -10,7 +11,13 @@ import {
 	type SessionEventDraft,
 	sequenceSessionEvents,
 } from "../lib/session-events";
-import type { AgentAdapterCore, RawSession, SessionScanRequest, SessionScanResult } from "./base";
+import type {
+	AgentAdapterCore,
+	RawSession,
+	SessionScanRequest,
+	SessionScanResult,
+	SyncReadContext,
+} from "./base";
 import { getPiHome, getPiSessionsDir, isPathWithinRoots } from "./paths";
 import {
 	completeJsonlRecords,
@@ -513,9 +520,14 @@ function parseSession(filePath: string, projectFilter?: string): RawSession | nu
 export class PiAdapter implements AgentAdapterCore {
 	readonly agentType = "pi" as const;
 	readonly sessions = {
-		contentProtocol: async () => "events-v1" as const,
-		collect: (request: SessionScanRequest) => this.collectSessions(request),
-		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		contentProtocol: async (context?: SyncReadContext) => {
+			context?.signal.throwIfAborted();
+			return "events-v1" as const;
+		},
+		collect: (request: SessionScanRequest, context?: SyncReadContext) =>
+			this.collectSessions(request, context),
+		resolve: (localSessionId: string, context?: SyncReadContext) =>
+			this.resolveSession(localSessionId, context),
 		watchPaths: () => [getPiSessionsDir()],
 	};
 
@@ -527,15 +539,25 @@ export class PiAdapter implements AgentAdapterCore {
 		return readCommandVersion("pi", ["--version"]);
 	}
 
-	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+	private async collectSessions(
+		request: SessionScanRequest,
+		context?: SyncReadContext,
+	): Promise<SessionScanResult> {
+		context?.signal.throwIfAborted();
 		const root = resolve(getPiSessionsDir());
 		if (request.kind === "paths") {
 			if (request.paths.length === 0) {
-				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+				return this.collectSessions(
+					{ kind: "complete", projectFilter: request.projectFilter },
+					context,
+				);
 			}
 			const paths = request.paths.map((path) => resolve(path));
 			if (paths.some((path) => !isPathWithinRoots(path, [root]) || !path.endsWith(".jsonl"))) {
-				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+				return this.collectSessions(
+					{ kind: "complete", projectFilter: request.projectFilter },
+					context,
+				);
 			}
 			const sessions = paths
 				.filter((path) => existsSync(path))
@@ -543,15 +565,23 @@ export class PiAdapter implements AgentAdapterCore {
 				.filter((session): session is RawSession => session !== null);
 			return { sessions, dedupedCount: 0, coverage: "partial" };
 		}
-		const sessions = listJsonlFiles(root)
-			.map((path) => parseSession(path, request.projectFilter))
-			.filter((session): session is RawSession => session !== null);
+		const sessions: RawSession[] = [];
+		for (const path of listJsonlFiles(root)) {
+			if (context) await setImmediate(undefined, { signal: context.signal });
+			const session = parseSession(path, request.projectFilter);
+			if (session) sessions.push(session);
+		}
 		return { sessions, dedupedCount: 0, coverage: "complete" };
 	}
 
-	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+	private async resolveSession(
+		localSessionId: string,
+		context?: SyncReadContext,
+	): Promise<RawSession | null> {
+		context?.signal.throwIfAborted();
 		const sourceId = localSessionId.startsWith("pi.") ? localSessionId.slice(3) : localSessionId;
 		for (const path of listJsonlFiles(getPiSessionsDir())) {
+			if (context) await setImmediate(undefined, { signal: context.signal });
 			const session = parseSession(path);
 			if (session?.localSessionId === `pi.${sourceId}`) return session;
 		}

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -28,6 +28,7 @@ import {
 	reconcilePendingRuntimeCliUpgrade,
 	rollbackPendingRuntimeCliUpgrade,
 } from "../runtime/cli-update";
+import { persistComponentActivations } from "../runtime/component-observation";
 import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
 import { readHostPolicy } from "../runtime/host-policy";
 import { failedHostedAgentPluginsObservation } from "../runtime/hosted-agent-plugin-observation";
@@ -66,6 +67,7 @@ import {
 	type RuntimeManifestFailure,
 	type RuntimeManifestLoad,
 } from "../runtime/manifest-source";
+import { readComponentServiceState } from "../runtime/observed";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
 import {
 	buildRuntimeBootStatus,
@@ -352,6 +354,9 @@ export function commitRuntimeAppliedState(input: {
 			nativeCredentialProviderIds: input.convergence.nativeCredentialProviderIds,
 		},
 		input.paths,
+	);
+	persistComponentActivations(input.load, input.paths, (scope, unit) =>
+		readComponentServiceState(input.paths, scope, unit),
 	);
 }
 

--- a/packages/cli/src/lib/session-upload.ts
+++ b/packages/cli/src/lib/session-upload.ts
@@ -55,8 +55,9 @@ const capabilityRequests = new WeakMap<
 export async function negotiateSessionProtocol(
 	api: ApiClient,
 	module: SessionModule,
+	context?: import("../adapters/base").SyncReadContext,
 ): Promise<SelectedSessionProtocol> {
-	if ((await module.contentProtocol()) === "snapshot-v1") return "snapshot-v1";
+	if ((await module.contentProtocol(context)) === "snapshot-v1") return "snapshot-v1";
 	const capabilities = await eventUploadCapabilities(api);
 	return capabilities === null ? "snapshot-v1" : "events-v1";
 }

--- a/packages/cli/src/runtime/component-observation.ts
+++ b/packages/cli/src/runtime/component-observation.ts
@@ -1,0 +1,247 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { components } from "@clawdi/shared/api";
+import JSON5 from "json5";
+import { z } from "zod";
+import { log } from "../serve/log";
+import {
+	type RuntimeAppliedState,
+	readRuntimeAppliedState,
+	runtimeContentSha256,
+} from "./applied-state";
+import type { RuntimeManifestLoad } from "./manifest-source";
+import type { RuntimePaths } from "./paths";
+import { readRuntimeServiceRunConfig, runtimeRunConfigPath } from "./run-config";
+import { runtimeSecretValue } from "./secret-values";
+import { writeRuntimePlatformFileAtomic } from "./state";
+import { readSystemdComponentFingerprint } from "./systemd-transaction";
+
+type Activation = Omit<components["schemas"]["HostedRuntimeObservedComponentV1"], "status">;
+const evidenceSchema = z
+	.object({
+		schemaVersion: z.literal(1),
+		appliedStateRevision: z.string().regex(/^[a-f0-9]{64}$/),
+		entries: z
+			.array(
+				z
+					.object({
+						component: z.enum(["files", "hermes-ui", "openclaw-ui"]),
+						configRevision: z.string().regex(/^[a-f0-9]{64}$/),
+						accessRevision: z.string().regex(/^[a-f0-9]{64}$/),
+						invocationId: z.string().regex(/^[a-f0-9]{32}$/),
+					})
+					.strict(),
+			)
+			.max(3),
+	})
+	.strict();
+
+function evidencePath(paths: RuntimePaths): string {
+	return join(dirname(paths.appliedState), "component-activations.json");
+}
+
+export function persistComponentActivations(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	readServiceState: ReadComponentServiceState,
+): void {
+	if (paths.mode !== "hosted") return;
+	try {
+		const applied = readRuntimeAppliedState(paths);
+		if (!applied?.applyReceiptId || !applied.bootNonce) return;
+		const evidence = {
+			schemaVersion: 1,
+			appliedStateRevision: runtimeContentSha256(applied),
+			entries: captureComponentActivations(load, paths, applied.activated, readServiceState),
+		};
+		writeRuntimePlatformFileAtomic(
+			paths,
+			evidencePath(paths),
+			`${JSON.stringify(evidenceSchema.parse(evidence))}\n`,
+			{ mode: 0o600, dirMode: 0o755 },
+		);
+	} catch {
+		log.warn("runtime.component_proof_unavailable", {
+			message:
+				"Component activation proof could not be persisted; complete-runtime admission remains required.",
+		});
+	}
+}
+
+function readComponentActivations(
+	paths: RuntimePaths,
+	applied: RuntimeAppliedState,
+): Activation[] | undefined {
+	try {
+		const stat = lstatSync(evidencePath(paths));
+		if (!stat.isFile() || stat.size > 16 * 1024) return undefined;
+		const parsed = evidenceSchema.parse(JSON.parse(readFileSync(evidencePath(paths), "utf8")));
+		if (new Set(parsed.entries.map((entry) => entry.component)).size !== parsed.entries.length)
+			return undefined;
+		return parsed.appliedStateRevision === runtimeContentSha256(applied)
+			? parsed.entries
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+type Component = Activation["component"];
+export interface ComponentServiceState {
+	invocationId: string;
+	configurationRevision: string;
+}
+export type ReadComponentServiceState = (
+	scope: "system" | "user",
+	unit: string,
+) => ComponentServiceState | null;
+const services = {
+	files: { scope: "system", unit: "clawdi-files.service" },
+	"hermes-ui": { scope: "user", unit: "clawdi-hermes-dashboard.service" },
+	"openclaw-ui": { scope: "user", unit: "openclaw-gateway.service" },
+} as const;
+
+function hasIncludes(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	return Object.hasOwn(value, "$include") || Object.values(value).some(hasIncludes);
+}
+
+function configRevision(
+	component: Component,
+	paths: RuntimePaths,
+	expectedUnit: string | undefined,
+): string | null {
+	try {
+		const service = services[component];
+		const unit = readSystemdComponentFingerprint(paths, service.scope, service.unit);
+		if (!unit || unit !== expectedUnit) return null;
+		let files: string[];
+		if (component === "files") files = [paths.fileBrowserConfig];
+		else if (component === "openclaw-ui")
+			files = [join(paths.userHome, ".openclaw", "openclaw.json")];
+		else {
+			const run = readRuntimeServiceRunConfig("hermes", "dashboard", paths);
+			if (run.status !== "ok" || !run.config.secretFilePath) return null;
+			files = [runtimeRunConfigPath("hermes", paths, "dashboard"), run.config.secretFilePath];
+		}
+		const contents = files.map((path) => {
+			const stat = lstatSync(path);
+			if (!stat.isFile() || stat.size > 1024 * 1024)
+				throw new Error("Component config unavailable");
+			return readFileSync(path, "utf8");
+		});
+		// Included native configuration has a separate mutation authority. Until its
+		// resolved dependency set is recorded, retain aggregate-only admission.
+		if (component === "openclaw-ui") {
+			const config: unknown = JSON5.parse(contents[0] ?? "null");
+			if (hasIncludes(config) || !config || typeof config !== "object" || !("gateway" in config))
+				return null;
+			const gateway = config.gateway;
+			if (!gateway || typeof gateway !== "object" || ("port" in gateway && gateway.port !== 18789))
+				return null;
+		}
+		return runtimeContentSha256([unit, ...contents]);
+	} catch {
+		return null;
+	}
+}
+
+export function captureComponentActivations(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	activated: Record<string, string>,
+	readServiceState: ReadComponentServiceState,
+): Activation[] {
+	const manifest = load.manifest;
+	const secrets = load.secretValues ?? {};
+	const revisions: Partial<Record<Component, string>> = {};
+	if (manifest.companions?.filebrowser) {
+		const auth = manifest.companions.filebrowser.auth;
+		revisions.files = runtimeContentSha256(["files", auth.accessRevision, auth.secret]);
+	}
+	const openclaw = manifest.openclawGatewayAuth;
+	if (openclaw) {
+		const token = runtimeSecretValue(secrets, openclaw.tokenRef);
+		if (token) revisions["openclaw-ui"] = runtimeContentSha256(["openclaw-ui", token]);
+	}
+	const hermes = manifest.hermesDashboardAuth;
+	if (hermes) {
+		const password = runtimeSecretValue(secrets, hermes.passwordSecretRef);
+		const session = runtimeSecretValue(secrets, hermes.sessionSecretRef);
+		if (password && session)
+			revisions["hermes-ui"] = runtimeContentSha256([
+				"hermes-ui",
+				hermes.username,
+				password,
+				session,
+			]);
+	}
+	const result: Activation[] = [];
+	for (const component of Object.keys(services) as Component[]) {
+		const service = services[component];
+		const accessRevision = revisions[component];
+		if (!accessRevision || !activated[service.unit]) continue;
+		const manager = readServiceState(service.scope, service.unit);
+		const config = configRevision(component, paths, activated[service.unit]);
+		const after = readServiceState(service.scope, service.unit);
+		if (
+			manager &&
+			after &&
+			config &&
+			manager.invocationId === after.invocationId &&
+			manager.configurationRevision === after.configurationRevision
+		) {
+			result.push({
+				component,
+				configRevision: runtimeContentSha256([config, manager.configurationRevision]),
+				accessRevision,
+				invocationId: manager.invocationId,
+			});
+		}
+	}
+	return result;
+}
+
+export async function observeComponents(
+	paths: RuntimePaths,
+	applied: RuntimeAppliedState,
+	readServiceState: ReadComponentServiceState,
+	probe: (component: Component) => Promise<boolean>,
+): Promise<components["schemas"]["HostedRuntimeObservedComponentsV1"] | undefined> {
+	if (!applied.applyReceiptId || !applied.bootNonce) return undefined;
+	const activations = readComponentActivations(paths, applied);
+	if (!activations) return undefined;
+	const entries = await Promise.all(
+		activations.map(async (activation) => {
+			let invocationId = activation.invocationId;
+			let status: "ok" | "unknown" = "unknown";
+			try {
+				const service = services[activation.component];
+				const current = readServiceState(service.scope, service.unit);
+				invocationId = current?.invocationId ?? invocationId;
+				const configurationMatches = (manager: ComponentServiceState) => {
+					const config = configRevision(
+						activation.component,
+						paths,
+						applied.activated[service.unit],
+					);
+					return (
+						config !== null &&
+						runtimeContentSha256([config, manager.configurationRevision]) ===
+							activation.configRevision
+					);
+				};
+				if (current && configurationMatches(current) && (await probe(activation.component))) {
+					const after = readServiceState(service.scope, service.unit);
+					if (after?.invocationId === current.invocationId && configurationMatches(after))
+						status = "ok";
+				}
+			} catch {
+				// An unavailable component must not discard its peers' observations.
+			}
+			return { ...activation, invocationId, status };
+		}),
+	);
+	const current = readRuntimeAppliedState(paths);
+	if (!current || runtimeContentSha256(current) !== runtimeContentSha256(applied)) return undefined;
+	return { schemaVersion: 1, entries };
+}

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -143,7 +143,7 @@ describe("hosted runtime heartbeat observation", () => {
 		});
 	});
 
-	test("captures one immutable apply identity for the entire boot session", async () => {
+	test("does not issue fresh evidence for an apply identity replaced on disk", async () => {
 		const paths = tempRuntimePaths();
 		writeRuntimeAppliedState(companionAppliedState(7), paths);
 		const session = new HostedRuntimeHeartbeatSession({
@@ -189,20 +189,11 @@ describe("hosted runtime heartbeat observation", () => {
 		expect(session.acknowledge(first.event.eventId)).toBe(true);
 
 		writeRuntimeAppliedState(companionAppliedState(8), paths);
-		const second = await session.nextEvent();
-		if (!second) throw new Error("expected second companion event");
-		expect(second.event).toMatchObject({
-			generation: 7,
-			manifestETag: '"frozen-manifest-7"',
-			applyReceiptId: "apply-receipt-0007",
-			bootNonce: "boot-nonce-000007",
-			bootSessionId: "boot-session-0001",
-			sequence: 2,
-			eventId: "event-0000000002",
-			applied: {
-				generation: 7,
-				etag: `"sha256:${"c".repeat(64)}"`,
-			},
+		expect(await session.nextEvent()).toBeNull();
+		expect(JSON.parse(readFileSync(statePath, "utf-8"))).toMatchObject({
+			bootIdentity: { generation: 7, bootSessionId: "boot-session-0001" },
+			nextSequence: 2,
+			pending: null,
 		});
 	});
 

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -220,6 +220,7 @@ export class HostedRuntimeHeartbeatSession {
 			includeAgentPlugins: true,
 			includeSkills: true,
 			includeUserActivity: true,
+			includeComponents: true,
 		});
 		// A refresh or another capture during probes must not mix heartbeat identities.
 		if (

--- a/packages/cli/src/runtime/hermes-dashboard-auth.test.ts
+++ b/packages/cli/src/runtime/hermes-dashboard-auth.test.ts
@@ -3,91 +3,97 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { writeRuntimeAppliedState } from "./applied-state";
 import { readHostedRuntimeObserved, runtimeComponentIsReady } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { writeRuntimeWatchStatus } from "./state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
-test.skipIf(!process.env.CLAWDI_TEST_HERMES_DASHBOARD_VENV)(
-	"native Hermes form-auth preserves UI admission through gateway failure",
-	async () => {
-		const saved = { ...process.env };
-		const root = mkdtempSync(join(tmpdir(), "clawdi-native-dashboard-"));
-		const state = join(root, "status.json");
-		writeFileSync(state, JSON.stringify({ gateway: true }));
-		const identity = userInfo();
-		Object.assign(process.env, {
-			HOME: root,
-			HERMES_HOME: root,
-			CLAWDI_RUNTIME_HOME: root,
-			CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
-			CLAWDI_SYSTEMD_SYSTEM_ROOT: join(root, "system"),
-			CLAWDI_RUNTIME_USER: identity.username,
-			CLAWDI_RUNTIME_UID: String(identity.uid),
-			CLAWDI_RUNTIME_GID: String(identity.gid),
-		});
-		const child = Bun.spawn(
-			[
-				`${saved.CLAWDI_TEST_HERMES_DASHBOARD_VENV}/bin/python`,
-				"tests/fixtures/hermes-dashboard-auth.py",
-				state,
-			],
-			{ stdout: "ignore", stderr: "inherit" },
-		);
-		try {
-			let ready = false;
-			for (let i = 0; i < 100 && !ready; i++) {
-				try {
-					ready = (
-						await fetch("http://127.0.0.1:9119/api/status", { signal: AbortSignal.timeout(100) })
-					).ok;
-				} catch {}
-				if (!ready) await delay(25);
-			}
-			expect(ready).toBe(true);
-			const redirect = await fetch("http://127.0.0.1:9119/", { redirect: "manual" });
-			expect(redirect.status).toBe(302);
-			expect(redirect.headers.get("location")).toMatch(/^\/login(?:\?|$)/);
-			expect((await fetch("http://127.0.0.1:9119/login")).status).toBe(200);
-			const paths = getRuntimePaths({ mode: "hosted" });
-			mkdirSync(paths.serviceStateRoot, { recursive: true });
-			mkdirSync(paths.systemdUserRoot, { recursive: true });
-			writeFileSync(
-				join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
-				GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
-			);
-			const systemctl = join(root, "systemctl");
-			writeFileSync(systemctl, "#!/bin/sh\nprintf 'ActiveState=active\\nSubState=running\\n'\n", {
-				mode: 0o700,
-			});
-			process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
-			writeRuntimeAppliedState(
-				{
-					schemaVersion: "clawdi.runtimeAppliedState.v2",
-					appliedAt: new Date().toISOString(),
-					instanceId: "fixture",
-					etag: '"fixture"',
-					sourceRevision: "a".repeat(64),
-					generation: 1,
-					contentIdentity: { sourcePath: "fixture", sha256: "b".repeat(64) },
-					activated: {},
-					providerIds: [],
-					projectedProviderIds: {},
-				},
-				paths,
-			);
-			writeRuntimeWatchStatus({ status: "not_modified" }, paths);
-			expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
-			expect((await readHostedRuntimeObserved(paths))?.status).toBe("ok");
-			writeFileSync(state, JSON.stringify({ gateway: false }));
-			expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
-			expect((await readHostedRuntimeObserved(paths))?.status).toBe("unknown");
-		} finally {
-			child.kill("SIGKILL");
-			await child.exited;
-			process.env = saved;
-			rmSync(root, { recursive: true, force: true });
+test.skipIf(
+	!process.env.CLAWDI_TEST_HERMES_DASHBOARD_VENV && process.env.CLAWDI_TEST_SYSTEMD_COMMAND !== "1",
+)("native Hermes form-auth preserves UI admission through gateway failure", async () => {
+	const saved = { ...process.env };
+	const root = mkdtempSync(join(tmpdir(), "clawdi-native-dashboard-"));
+	const state = join(root, "status.json");
+	writeFileSync(state, JSON.stringify({ gateway: true }));
+	const identity = userInfo();
+	Object.assign(process.env, {
+		HOME: root,
+		HERMES_HOME: root,
+		CLAWDI_RUNTIME_HOME: root,
+		CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
+		CLAWDI_SYSTEMD_SYSTEM_ROOT: join(root, "system"),
+		CLAWDI_RUNTIME_USER: identity.username,
+		CLAWDI_RUNTIME_UID: String(identity.uid),
+		CLAWDI_RUNTIME_GID: String(identity.gid),
+	});
+	const child = Bun.spawn(
+		[
+			`${saved.CLAWDI_TEST_HERMES_DASHBOARD_VENV}/bin/python`,
+			fileURLToPath(new URL("../../tests/fixtures/hermes-dashboard-auth.py", import.meta.url)),
+			state,
+		],
+		{ stdout: "ignore", stderr: "inherit" },
+	);
+	try {
+		let ready = false;
+		for (let i = 0; i < 100 && !ready; i++) {
+			try {
+				ready = (
+					await fetch("http://127.0.0.1:9119/api/status", { signal: AbortSignal.timeout(100) })
+				).ok;
+			} catch {}
+			if (!ready) await delay(25);
 		}
-	},
-);
+		expect(ready).toBe(true);
+		const redirect = await fetch("http://127.0.0.1:9119/", { redirect: "manual" });
+		expect(redirect.status).toBe(302);
+		expect(redirect.headers.get("location")).toMatch(/^\/login(?:\?|$)/);
+		const login = await fetch("http://127.0.0.1:9119/login");
+		expect(login.status).toBe(200);
+		expect(login.headers.get("cache-control")).toContain("no-store");
+		expect(await login.text()).toContain("/auth/password-login");
+		expect(await (await fetch("http://127.0.0.1:9119/api/auth/providers")).json()).toMatchObject({
+			providers: [{ name: "basic", supports_password: true }],
+		});
+		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
+		mkdirSync(paths.systemdUserRoot, { recursive: true });
+		writeFileSync(
+			join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
+			GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
+		);
+		const systemctl = join(root, "systemctl");
+		writeFileSync(systemctl, "#!/bin/sh\nprintf 'ActiveState=active\\nSubState=running\\n'\n", {
+			mode: 0o700,
+		});
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+		writeRuntimeAppliedState(
+			{
+				schemaVersion: "clawdi.runtimeAppliedState.v2",
+				appliedAt: new Date().toISOString(),
+				instanceId: "fixture",
+				etag: '"fixture"',
+				sourceRevision: "a".repeat(64),
+				generation: 1,
+				contentIdentity: { sourcePath: "fixture", sha256: "b".repeat(64) },
+				activated: {},
+				providerIds: [],
+				projectedProviderIds: {},
+			},
+			paths,
+		);
+		writeRuntimeWatchStatus({ status: "not_modified" }, paths);
+		expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
+		expect((await readHostedRuntimeObserved(paths))?.status).toBe("ok");
+		writeFileSync(state, JSON.stringify({ gateway: false }));
+		expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
+		expect((await readHostedRuntimeObserved(paths))?.status).toBe("unknown");
+	} finally {
+		child.kill("SIGKILL");
+		await child.exited;
+		process.env = saved;
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/cli/src/runtime/hermes-dashboard-auth.test.ts
+++ b/packages/cli/src/runtime/hermes-dashboard-auth.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { writeRuntimeAppliedState } from "./applied-state";
+import { readHostedRuntimeObserved, runtimeComponentIsReady } from "./observed";
+import { getRuntimePaths } from "./paths";
+import { writeRuntimeWatchStatus } from "./state";
+import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
+
+test.skipIf(!process.env.CLAWDI_TEST_HERMES_DASHBOARD_VENV)(
+	"native Hermes form-auth preserves UI admission through gateway failure",
+	async () => {
+		const saved = { ...process.env };
+		const root = mkdtempSync(join(tmpdir(), "clawdi-native-dashboard-"));
+		const state = join(root, "status.json");
+		writeFileSync(state, JSON.stringify({ gateway: true }));
+		const identity = userInfo();
+		Object.assign(process.env, {
+			HOME: root,
+			HERMES_HOME: root,
+			CLAWDI_RUNTIME_HOME: root,
+			CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
+			CLAWDI_SYSTEMD_SYSTEM_ROOT: join(root, "system"),
+			CLAWDI_RUNTIME_USER: identity.username,
+			CLAWDI_RUNTIME_UID: String(identity.uid),
+			CLAWDI_RUNTIME_GID: String(identity.gid),
+		});
+		const child = Bun.spawn(
+			[
+				`${saved.CLAWDI_TEST_HERMES_DASHBOARD_VENV}/bin/python`,
+				"tests/fixtures/hermes-dashboard-auth.py",
+				state,
+			],
+			{ stdout: "ignore", stderr: "inherit" },
+		);
+		try {
+			let ready = false;
+			for (let i = 0; i < 100 && !ready; i++) {
+				try {
+					ready = (
+						await fetch("http://127.0.0.1:9119/api/status", { signal: AbortSignal.timeout(100) })
+					).ok;
+				} catch {}
+				if (!ready) await delay(25);
+			}
+			expect(ready).toBe(true);
+			const redirect = await fetch("http://127.0.0.1:9119/", { redirect: "manual" });
+			expect(redirect.status).toBe(302);
+			expect(redirect.headers.get("location")).toMatch(/^\/login(?:\?|$)/);
+			expect((await fetch("http://127.0.0.1:9119/login")).status).toBe(200);
+			const paths = getRuntimePaths({ mode: "hosted" });
+			mkdirSync(paths.serviceStateRoot, { recursive: true });
+			mkdirSync(paths.systemdUserRoot, { recursive: true });
+			writeFileSync(
+				join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
+				GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
+			);
+			const systemctl = join(root, "systemctl");
+			writeFileSync(systemctl, "#!/bin/sh\nprintf 'ActiveState=active\\nSubState=running\\n'\n", {
+				mode: 0o700,
+			});
+			process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+			writeRuntimeAppliedState(
+				{
+					schemaVersion: "clawdi.runtimeAppliedState.v2",
+					appliedAt: new Date().toISOString(),
+					instanceId: "fixture",
+					etag: '"fixture"',
+					sourceRevision: "a".repeat(64),
+					generation: 1,
+					contentIdentity: { sourcePath: "fixture", sha256: "b".repeat(64) },
+					activated: {},
+					providerIds: [],
+					projectedProviderIds: {},
+				},
+				paths,
+			);
+			writeRuntimeWatchStatus({ status: "not_modified" }, paths);
+			expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
+			expect((await readHostedRuntimeObserved(paths))?.status).toBe("ok");
+			writeFileSync(state, JSON.stringify({ gateway: false }));
+			expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
+			expect((await readHostedRuntimeObserved(paths))?.status).toBe("unknown");
+		} finally {
+			child.kill("SIGKILL");
+			await child.exited;
+			process.env = saved;
+			rmSync(root, { recursive: true, force: true });
+		}
+	},
+);

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { RuntimeAppliedState } from "./applied-state";
+import { writeRuntimeAppliedState } from "./applied-state";
 import { readHostedAgentPluginsObservation } from "./hosted-agent-plugin-observation";
 import {
 	hostedAgentPluginOwnershipIdentity,
@@ -147,6 +148,7 @@ describe("hosted Agent Plugin heartbeat observation", () => {
 		const paths = tempPaths();
 		const desired = installation("1.0.0", "d");
 		const applied = appliedState();
+		writeRuntimeAppliedState(applied, paths);
 		writeAppliedManifest(paths, desired);
 		writeReceipt(paths, desired);
 

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -27,6 +27,11 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "./applied-state";
+import {
+	captureComponentActivations,
+	observeComponents,
+	persistComponentActivations,
+} from "./component-observation";
 import { gcFileBrowserCompanionCandidates } from "./file-browser-companion";
 import type {
 	PreparedHostedAgentPlugin,
@@ -72,6 +77,7 @@ import {
 	runtimeSecretValue,
 } from "./secret-values";
 import { ensureRuntimeStateDirs } from "./state";
+import { readSystemdUnitSnapshot } from "./systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const successfulPrerequisiteActivation = () => ({
@@ -5117,4 +5123,76 @@ esac
 			"runtime manifest convergence requires an explicit apply context",
 		);
 	});
+});
+
+test("component proof requires committed configuration and a stable live invocation", async () => {
+	const paths = tempRuntimePaths();
+	const manifest = fileBrowserManifest(paths, { generation: 1, binary: "fixture" });
+	mkdirSync(paths.systemdSystemRoot, { recursive: true });
+	mkdirSync(dirname(paths.fileBrowserConfig), { recursive: true });
+	writeFileSync(
+		join(paths.systemdSystemRoot, "clawdi-files.service"),
+		`${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n[Service]\nExecStart=/fixture/files\n`,
+	);
+	writeFileSync(paths.fileBrowserConfig, "fixture-config");
+	const activated = Object.fromEntries(readSystemdUnitSnapshot(paths).system);
+	let invocation = "a".repeat(32);
+	let managerConfiguration = "1".repeat(64);
+	const readInvocation = () => ({
+		invocationId: invocation,
+		configurationRevision: managerConfiguration,
+	});
+	const componentActivations = captureComponentActivations(
+		fileBrowserManifestLoad(manifest),
+		paths,
+		activated,
+		readInvocation,
+	);
+	expect(componentActivations).toHaveLength(1);
+	const applied = {
+		schemaVersion: "clawdi.runtimeAppliedState.v2" as const,
+		appliedAt: new Date().toISOString(),
+		instanceId: manifest.instanceId,
+		sourceRevision: "b".repeat(64),
+		etag: `"sha256:${"b".repeat(64)}"`,
+		generation: 1,
+		manifestETag: '"fixture-manifest"',
+		applyReceiptId: "fixture-apply-receipt",
+		bootNonce: "fixture-boot-nonce",
+		contentIdentity: { sourcePath: "fixture", sha256: "c".repeat(64) },
+		activated,
+		providerIds: [],
+		projectedProviderIds: {},
+	};
+	mkdirSync(paths.serviceStateRoot, { recursive: true });
+	writeRuntimeAppliedState(applied, paths);
+	persistComponentActivations(fileBrowserManifestLoad(manifest), paths, readInvocation);
+	const observe = () => observeComponents(paths, applied, readInvocation, async () => true);
+	mkdirSync(join(paths.systemdSystemRoot, "clawdi-broken-peer.service"));
+	expect((await observe())?.entries[0]?.status).toBe("ok");
+	const failedProbe = await observeComponents(paths, applied, readInvocation, async () => {
+		throw new Error("HTTP unavailable");
+	});
+	expect(failedProbe?.entries[0]?.status).toBe("unknown");
+	managerConfiguration = "2".repeat(64);
+	expect((await observe())?.entries[0]?.status).toBe("unknown");
+	managerConfiguration = "1".repeat(64);
+	invocation = "d".repeat(32);
+	expect((await observe())?.entries[0]).toMatchObject({ status: "ok", invocationId: invocation });
+	const changing = await observeComponents(paths, applied, readInvocation, async () => {
+		invocation = "e".repeat(32);
+		return true;
+	});
+	expect(changing?.entries[0]?.status).toBe("unknown");
+	invocation = "a".repeat(32);
+	writeFileSync(paths.fileBrowserConfig, "changed-credential-config");
+	expect((await observe())?.entries[0]?.status).toBe("unknown");
+	expect(
+		await observeComponents(
+			paths,
+			{ ...applied, appliedAt: "2000-01-01T00:00:00.000Z" },
+			readInvocation,
+			async () => true,
+		),
+	).toBeUndefined();
 });

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -4,7 +4,7 @@ import { tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { getCliVersion } from "../lib/version";
 import { readRuntimeAppliedState, writeRuntimeAppliedState } from "./applied-state";
-import { readHostedRuntimeObserved } from "./observed";
+import { readHostedRuntimeObserved, runtimeComponentIsReady } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { buildRuntimeBootStatus, writeRuntimeBootStatus, writeRuntimeWatchStatus } from "./state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
@@ -296,7 +296,12 @@ describe("hosted runtime observed v2", () => {
 						return new Response(
 							typeof nativeStatus === "string" ? nativeStatus : JSON.stringify(nativeStatus),
 						);
-					if (path === "/control/") return new Response(null, { status: uiStatus });
+					if (path === "/" && request.method === "HEAD") return new Response(null, { status: 405 });
+					if (path === "/" || path === "/control/")
+						return new Response("<!doctype html><html></html>", {
+							status: uiStatus,
+							headers: { "Content-Type": "text/html" },
+						});
 					if (path !== "/readyz" && path !== "/api/status")
 						return new Response(null, { status: 404 });
 					return new Response(typeof body === "string" ? body : JSON.stringify(body), {
@@ -432,6 +437,18 @@ printf '%s' '{"port":${server.port},"controlUi":{"basePath":"/control"}}'
 					});
 					expect((await readHostedRuntimeObserved(paths))?.status).toBe("unknown");
 				} else {
+					body = {
+						gateway_running: false,
+						gateway_state: "stopped",
+						auth_required: true,
+						auth_providers: ["basic"],
+					};
+					expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(true);
+					expect((await readHostedRuntimeObserved(paths))?.status).not.toBe("ok");
+					uiStatus = 503;
+					expect(await runtimeComponentIsReady("hermes-ui", paths)).toBe(false);
+					uiStatus = 200;
+					body = ready;
 					writeFileSync(
 						systemctl,
 						`#!/bin/sh

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -8,6 +8,7 @@ import {
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
 } from "./applied-state";
+import { HostedRuntimeHeartbeatSession } from "./heartbeat-observation";
 import { readHostedRuntimeObserved, runtimeComponentIsReady } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { buildRuntimeBootStatus, writeRuntimeBootStatus, writeRuntimeWatchStatus } from "./state";
@@ -597,6 +598,8 @@ test("unknown component evidence downgrades healthy aggregate without replacing 
 	const paths = healthyAppliedRuntimePaths();
 	const applied = readRuntimeAppliedState(paths);
 	if (!applied) throw new Error("Expected applied fixture");
+	applied.etag = `"sha256:${applied.sourceRevision}"`;
+	writeRuntimeAppliedState(applied, paths);
 	writeFileSync(
 		join(dirname(paths.appliedState), "component-activations.json"),
 		JSON.stringify({
@@ -612,12 +615,20 @@ test("unknown component evidence downgrades healthy aggregate without replacing 
 			],
 		}),
 	);
-	const unavailable = await readHostedRuntimeObserved(paths);
+	expect(await readHostedRuntimeObserved(paths)).not.toHaveProperty("components");
+	const unavailable = await readHostedRuntimeObserved(paths, { includeComponents: true });
 	expect(unavailable?.components?.entries[0]?.status).toBe("unknown");
 	expect(unavailable?.status).toBe("unknown");
+	const companion = new HostedRuntimeHeartbeatSession({
+		environmentId: "fixture-component",
+		paths,
+	});
+	expect((await companion.nextEvent())?.event.components?.entries[0]?.status).toBe("unknown");
 	writeFileSync(
 		paths.runtimeWatchStatus,
 		JSON.stringify({ event: { status: "error", error: "required apply failed" } }),
 	);
-	expect((await readHostedRuntimeObserved(paths))?.status).toBe("error");
+	expect((await readHostedRuntimeObserved(paths, { includeComponents: true }))?.status).toBe(
+		"error",
+	);
 });

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -281,6 +281,7 @@ describe("hosted runtime observed v2", () => {
 			});
 			process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
 			let body: unknown = ready;
+			let mutateParent: (() => void) | undefined;
 			let uiStatus = 200;
 			let probeStatus = 200;
 			let nativeStatus: unknown;
@@ -291,6 +292,9 @@ describe("hosted runtime observed v2", () => {
 				port: unit === "openclaw-gateway.service" ? 0 : 9119,
 				async fetch(request) {
 					if (probeWait) await probeWait;
+					const mutate = mutateParent;
+					mutateParent = undefined;
+					mutate?.();
 					const path = new URL(request.url).pathname;
 					if (path === "/native-status")
 						return new Response(
@@ -325,6 +329,19 @@ describe("hosted runtime observed v2", () => {
 					expect(observed?.status).toBe(response === ready ? "ok" : "unknown");
 				}
 				body = ready;
+				const parent = readRuntimeAppliedState(paths);
+				if (!parent) throw new Error("Expected applied fixture");
+				mutateParent = () =>
+					writeRuntimeAppliedState({ ...parent, appliedAt: "2026-09-12T12:00:00.000Z" }, paths);
+				expect(await readHostedRuntimeObserved(paths)).toBeNull();
+				writeRuntimeAppliedState(parent, paths);
+				mutateParent = () =>
+					writeFileSync(
+						paths.runtimeWatchStatus,
+						JSON.stringify({ event: { status: "error", error: "apply failed during probe" } }),
+					);
+				expect(await readHostedRuntimeObserved(paths)).toBeNull();
+				rmSync(paths.runtimeWatchStatus);
 				probeStatus = 503;
 				expect((await readHostedRuntimeObserved(paths))?.status).toBe("unknown");
 				probeStatus = 200;

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -3,7 +3,11 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:f
 import { tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { getCliVersion } from "../lib/version";
-import { readRuntimeAppliedState, writeRuntimeAppliedState } from "./applied-state";
+import {
+	readRuntimeAppliedState,
+	runtimeContentSha256,
+	writeRuntimeAppliedState,
+} from "./applied-state";
 import { readHostedRuntimeObserved, runtimeComponentIsReady } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { buildRuntimeBootStatus, writeRuntimeBootStatus, writeRuntimeWatchStatus } from "./state";
@@ -301,7 +305,9 @@ describe("hosted runtime observed v2", () => {
 							typeof nativeStatus === "string" ? nativeStatus : JSON.stringify(nativeStatus),
 						);
 					if (path === "/" && request.method === "HEAD") return new Response(null, { status: 405 });
-					if (path === "/" || path === "/control/")
+					if (path === "/")
+						return new Response(null, { status: 302, headers: { Location: "/login" } });
+					if (path === "/login" || path === "/control/")
 						return new Response("<!doctype html><html></html>", {
 							status: uiStatus,
 							headers: { "Content-Type": "text/html" },
@@ -329,6 +335,18 @@ describe("hosted runtime observed v2", () => {
 					expect(observed?.status).toBe(response === ready ? "ok" : "unknown");
 				}
 				body = ready;
+				const idleWatch = {
+					schemaVersion: "clawdi.runtimeWatchStatus.v1",
+					event: { status: "not_modified" },
+					timestamp: "2026-09-12T00:00:00.000Z",
+				};
+				writeFileSync(paths.runtimeWatchStatus, JSON.stringify(idleWatch));
+				mutateParent = () =>
+					writeFileSync(
+						paths.runtimeWatchStatus,
+						JSON.stringify({ ...idleWatch, timestamp: "2026-09-12T00:00:15.000Z" }),
+					);
+				expect((await readHostedRuntimeObserved(paths))?.status).toBe("ok");
 				const parent = readRuntimeAppliedState(paths);
 				if (!parent) throw new Error("Expected applied fixture");
 				mutateParent = () =>
@@ -573,4 +591,33 @@ esac
 		expect(observed?.systemd?.units.filter((unit) => unit.scope === "system")).toHaveLength(15);
 		expect(observed?.systemd?.units.filter((unit) => unit.scope === "user")).toHaveLength(15);
 	});
+});
+
+test("unknown component evidence downgrades healthy aggregate without replacing a definite error", async () => {
+	const paths = healthyAppliedRuntimePaths();
+	const applied = readRuntimeAppliedState(paths);
+	if (!applied) throw new Error("Expected applied fixture");
+	writeFileSync(
+		join(dirname(paths.appliedState), "component-activations.json"),
+		JSON.stringify({
+			schemaVersion: 1,
+			appliedStateRevision: runtimeContentSha256(applied),
+			entries: [
+				{
+					component: "files",
+					configRevision: "a".repeat(64),
+					accessRevision: "b".repeat(64),
+					invocationId: "c".repeat(32),
+				},
+			],
+		}),
+	);
+	const unavailable = await readHostedRuntimeObserved(paths);
+	expect(unavailable?.components?.entries[0]?.status).toBe("unknown");
+	expect(unavailable?.status).toBe("unknown");
+	writeFileSync(
+		paths.runtimeWatchStatus,
+		JSON.stringify({ event: { status: "error", error: "required apply failed" } }),
+	);
+	expect((await readHostedRuntimeObserved(paths))?.status).toBe("error");
 });

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -133,7 +133,8 @@ export async function readHostedRuntimeObserved(
 		);
 		if (proof) {
 			observed.components = proof;
-			if (proof.entries.some((entry) => entry.status !== "ok")) observed.status = "error";
+			if (observed.status === "ok" && proof.entries.some((entry) => entry.status !== "ok"))
+				observed.status = "unknown";
 		}
 	}
 
@@ -143,8 +144,8 @@ export async function readHostedRuntimeObserved(
 	if (
 		runtimeContentSha256(readRuntimeAppliedState(paths)) !== runtimeContentSha256(appliedState) ||
 		runtimeContentSha256(readRuntimeBootStatus(paths)) !== runtimeContentSha256(boot) ||
-		runtimeContentSha256(readJsonRecord(paths.runtimeWatchStatus)) !==
-			runtimeContentSha256(watchStatus)
+		watchStatusRevision(readJsonRecord(paths.runtimeWatchStatus)) !==
+			watchStatusRevision(watchStatus)
 	)
 		return null;
 
@@ -152,6 +153,12 @@ export async function readHostedRuntimeObserved(
 	const convergeError = runtimeConvergeError(watchStatus);
 	if (convergeError) observed.convergeError = convergeError;
 	return observed;
+}
+
+function watchStatusRevision(value: JsonRecord | null): string {
+	if (value === null) return runtimeContentSha256(null);
+	const { timestamp: _timestamp, ...semantic } = value;
+	return runtimeContentSha256(semantic);
 }
 
 function observedUserActivity(
@@ -485,7 +492,7 @@ export async function runtimeComponentIsReady(
 				(await runtimeReadinessProbe("http://127.0.0.1:9119/api/status")).body,
 			);
 			if (!hermesUiAuthenticationIsReady(status)) return false;
-			const page = await runtimeReadinessProbe("http://127.0.0.1:9119/");
+			const page = await runtimeReadinessProbe("http://127.0.0.1:9119/login");
 			return /<!doctype html|<html[\s>]/i.test(page.body);
 		}
 		return runtimeServiceIsReady("openclaw-gateway.service", paths);

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -33,7 +33,7 @@ type ObservedStatus = "ok" | "error" | "unknown";
 export type HostedRuntimeObserved = components["schemas"]["HostedRuntimeObservedV2"] &
 	Pick<
 		components["schemas"]["RuntimeObservationEventV2"],
-		"agentPlugins" | "userActivity" | "skills"
+		"agentPlugins" | "userActivity" | "skills" | "components"
 	>;
 type HostedRuntimeObservedBoot = components["schemas"]["HostedRuntimeObservedBootV1"];
 type HostedRuntimeObservedCli = components["schemas"]["HostedRuntimeObservedCliV1"];
@@ -59,6 +59,7 @@ export async function readHostedRuntimeObserved(
 		includeAgentPlugins?: boolean;
 		includeSkills?: boolean;
 		includeUserActivity?: boolean;
+		includeComponents?: boolean;
 	} = {},
 ): Promise<HostedRuntimeObserved | null> {
 	if (paths.mode !== "hosted") return null;
@@ -124,7 +125,7 @@ export async function readHostedRuntimeObserved(
 		const userActivity = observedUserActivity(boot.status, observed.reportedAt);
 		if (userActivity) observed.userActivity = userActivity;
 	}
-	if (appliedState) {
+	if (appliedState && options.includeComponents) {
 		const proof = await observeComponents(
 			paths,
 			appliedState,

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -7,9 +7,14 @@ import JSON5 from "json5";
 import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
 import { getCliVersion } from "../lib/version";
 import { toErrorMessage } from "../serve/log";
-import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-state";
+import {
+	type RuntimeAppliedState,
+	readRuntimeAppliedState,
+	runtimeContentSha256,
+} from "./applied-state";
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import { type RuntimeCliBootstrapStatus, readRuntimeCliBootstrapStatus } from "./cli-update";
+import { type ComponentServiceState, observeComponents } from "./component-observation";
 import { readHostedAgentPluginsObservation } from "./hosted-agent-plugin-observation";
 import { installedOpenClawCommandPath } from "./hosted-openclaw-context";
 import { readHostedSkillsObservation } from "./hosted-skill-observation";
@@ -119,6 +124,19 @@ export async function readHostedRuntimeObserved(
 		const userActivity = observedUserActivity(boot.status, observed.reportedAt);
 		if (userActivity) observed.userActivity = userActivity;
 	}
+	if (appliedState) {
+		const proof = await observeComponents(
+			paths,
+			appliedState,
+			(scope, unit) => readComponentServiceState(paths, scope, unit),
+			(component) => runtimeComponentIsReady(component, paths),
+		);
+		if (proof) {
+			observed.components = proof;
+			if (proof.entries.some((entry) => entry.status !== "ok")) observed.status = "error";
+		}
+	}
+
 	if (boot.error) observed.error = boot.error;
 	const convergeError = runtimeConvergeError(watchStatus);
 	if (convergeError) observed.convergeError = convergeError;
@@ -353,6 +371,55 @@ function managedSystemdUnitNames(root: string): string[] {
 	return [...new Set(managedRuntimeSystemdUnitEntries(root).map((entry) => entry.unitName))].sort();
 }
 
+export function readComponentServiceState(
+	paths: RuntimePaths,
+	scope: "system" | "user",
+	unit: string,
+): ComponentServiceState | null {
+	const invocationId = readComponentInvocation(paths, scope, unit);
+	if (!invocationId) return null;
+	const args = ["cat", "--no-pager", unit];
+	const config = scope === "system" ? runSystemctl(args) : runRuntimeUserSystemctl(paths, args);
+	if (
+		config.exitCode !== 0 ||
+		!config.output ||
+		readComponentInvocation(paths, scope, unit) !== invocationId
+	)
+		return null;
+	// systemctl owns effective fragment/drop-in precedence. Its cat output has no
+	// per-process timestamps and includes overrides outside Clawdi's unit root.
+	return { invocationId, configurationRevision: runtimeContentSha256(config.output) };
+}
+
+/** A component receipt is bound to one fully loaded, idle service invocation. */
+export function readComponentInvocation(
+	paths: RuntimePaths,
+	scope: "system" | "user",
+	unit: string,
+): string | null {
+	const args = [
+		"show",
+		"--all",
+		unit,
+		"--property=InvocationID",
+		"--property=LoadState",
+		"--property=ActiveState",
+		"--property=NeedDaemonReload",
+		"--property=Job",
+	];
+	const result = scope === "system" ? runSystemctl(args) : runRuntimeUserSystemctl(paths, args);
+	const fields = parseSystemctlShow(result.output);
+	return result.exitCode === 0 &&
+		fields.LoadState === "loaded" &&
+		fields.ActiveState === "active" &&
+		fields.NeedDaemonReload === "no" &&
+		fields.Job === "" &&
+		/^[a-f0-9]{32}$/.test(fields.InvocationID ?? "") &&
+		fields.InvocationID !== "0".repeat(32)
+		? fields.InvocationID
+		: null;
+}
+
 function systemdUnitStatus(
 	scope: "system" | "user",
 	unit: string,
@@ -393,6 +460,32 @@ function systemdUnitStatus(
 					? null
 					: (nonSensitiveFailureEvidence(result.output) ?? "systemctl show failed"),
 	};
+}
+
+export async function runtimeComponentIsReady(
+	component: components["schemas"]["HostedRuntimeObservedComponentV1"]["component"],
+	paths: RuntimePaths,
+): Promise<boolean> {
+	try {
+		if (component === "files")
+			return (await runtimeReadinessProbe("http://127.0.0.1:9120/health")).status === 200;
+		if (component === "hermes-ui") {
+			const status: unknown = JSON.parse(
+				(await runtimeReadinessProbe("http://127.0.0.1:9119/api/status")).body,
+			);
+			if (!hermesUiAuthenticationIsReady(status)) return false;
+			const page = await runtimeReadinessProbe("http://127.0.0.1:9119/");
+			return /<!doctype html|<html[\s>]/i.test(page.body);
+		}
+		return runtimeServiceIsReady("openclaw-gateway.service", paths);
+	} catch {
+		return false;
+	}
+}
+
+function hermesUiAuthenticationIsReady(status: unknown): boolean {
+	const value = recordValue(status);
+	return value?.auth_required === true && arrayValue(value.auth_providers).includes("basic");
 }
 
 /** Native service activation precedes application startup; heartbeat health needs both. */
@@ -475,8 +568,7 @@ async function runtimeServiceIsReady(unit: string, paths: RuntimePaths): Promise
 		return (
 			status?.gateway_running === true &&
 			status.gateway_state === "running" &&
-			status.auth_required === true &&
-			arrayValue(status.auth_providers).includes("basic")
+			hermesUiAuthenticationIsReady(status)
 		);
 	} catch {
 		return false;

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -137,6 +137,17 @@ export async function readHostedRuntimeObserved(
 		}
 	}
 
+	// Reject the whole snapshot when its parent authority or health changed while
+	// any asynchronous probe ran. Dropping only component proof leaves a stale
+	// aggregate success available to legacy admission readers.
+	if (
+		runtimeContentSha256(readRuntimeAppliedState(paths)) !== runtimeContentSha256(appliedState) ||
+		runtimeContentSha256(readRuntimeBootStatus(paths)) !== runtimeContentSha256(boot) ||
+		runtimeContentSha256(readJsonRecord(paths.runtimeWatchStatus)) !==
+			runtimeContentSha256(watchStatus)
+	)
+		return null;
+
 	if (boot.error) observed.error = boot.error;
 	const convergeError = runtimeConvergeError(watchStatus);
 	if (convergeError) observed.convergeError = convergeError;

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -94,9 +94,10 @@ function systemdUnitFingerprint(
 function readManagedSystemdUnits(
 	paths: ReturnType<typeof getRuntimePaths>,
 	root: string,
+	selectedUnits?: ReadonlySet<string>,
 ): Map<string, string> {
 	const units = new Map<string, string>();
-	for (const entry of managedRuntimeSystemdUnitEntries(root, readFileIfExists)) {
+	for (const entry of managedRuntimeSystemdUnitEntries(root, readFileIfExists, selectedUnits)) {
 		if (entry.kind === "base-unit") {
 			const contents = entry.generatedContents ?? readFileIfExists(entry.path);
 			if (contents !== null) {
@@ -111,6 +112,20 @@ function readManagedSystemdUnits(
 		);
 	}
 	return units;
+}
+
+export function readSystemdComponentFingerprint(
+	paths: ReturnType<typeof getRuntimePaths>,
+	scope: "system" | "user",
+	unit: string,
+): string | null {
+	return (
+		readManagedSystemdUnits(
+			paths,
+			scope === "system" ? paths.systemdSystemRoot : paths.systemdUserRoot,
+			new Set([unit]),
+		).get(unit) ?? null
+	);
 }
 
 function changedSystemdUnits(

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { readComponentInvocation, readComponentServiceState } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { buildRuntimeUserCommand, PRIVILEGE_DROP_STRATEGIES } from "./runtime-user-command";
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
@@ -221,6 +222,16 @@ esac
 				runCommandResult("systemctl", ["daemon-reload"]);
 				expect(runCommandResult("systemctl", ["restart", unit]).status).toBe(0);
 				expect(applySystemdRuntimeUpdate(paths, snapshot, snapshot, {}).applied).toBe(true);
+				const invocation = readComponentInvocation(paths, "system", unit);
+				const component = readComponentServiceState(paths, "system", unit);
+				if (!component || !invocation) throw new Error("Native component evidence missing");
+				expect(component.invocationId).toBe(invocation);
+				expect(invocation).toMatch(/^[a-f0-9]{32}$/);
+				expect(runCommandResult("systemctl", ["restart", unit]).status).toBe(0);
+				expect(readComponentInvocation(paths, "system", unit)).not.toBe(invocation);
+				expect(readComponentServiceState(paths, "system", unit)?.configurationRevision).toBe(
+					component?.configurationRevision,
+				);
 				console.log(
 					`native crash-loop proof: ${observed.trim().replaceAll("\n", ", ")}; readiness required after repair`,
 				);

--- a/packages/cli/src/runtime/systemd.ts
+++ b/packages/cli/src/runtime/systemd.ts
@@ -15,10 +15,16 @@ export type ManagedRuntimeSystemdUnitEntry = {
 export function managedRuntimeSystemdUnitEntries(
 	root: string,
 	readContents: (path: string) => string | null = readRuntimeSystemdContents,
+	selectedUnits?: ReadonlySet<string>,
 ): ManagedRuntimeSystemdUnitEntry[] {
 	if (!existsSync(root)) return [];
 	const managed: ManagedRuntimeSystemdUnitEntry[] = [];
 	for (const entry of readdirSync(root)) {
+		if (
+			selectedUnits &&
+			!selectedUnits.has(entry.endsWith(".service.d") ? entry.slice(0, -2) : entry)
+		)
+			continue;
 		if (entry.endsWith(".service")) {
 			const path = join(root, entry);
 			if (entry.startsWith("clawdi-")) {

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -413,7 +413,12 @@ export class RetryQueue {
 	 * Used by the daemon drain loop so an idle queue can sleep until
 	 * enqueue() provides real work. */
 	waitForItem(abort: AbortSignal, timeoutMs: number): Promise<void> {
-		if (this.items.length > 0 || abort.aborted || timeoutMs <= 0) return Promise.resolve();
+		if (this.items.length > 0) return Promise.resolve();
+		return this.waitForChange(abort, timeoutMs);
+	}
+
+	waitForChange(abort: AbortSignal, timeoutMs: number): Promise<void> {
+		if (abort.aborted || timeoutMs <= 0) return Promise.resolve();
 		return new Promise((resolve) => {
 			let settled = false;
 			let timer: ReturnType<typeof setTimeout> | null = null;
@@ -428,11 +433,11 @@ export class RetryQueue {
 			timer = setTimeout(finish, timeoutMs);
 			this.itemWaiters.add(finish);
 			abort.addEventListener("abort", finish, { once: true });
-			if (this.items.length > 0) finish();
+			if (abort.aborted) finish();
 		});
 	}
 
-	private notifyItemWaiters(): void {
+	notifyItemWaiters(): void {
 		if (this.itemWaiters.size === 0) return;
 		const waiters = [...this.itemWaiters];
 		this.itemWaiters.clear();
@@ -506,8 +511,8 @@ export class RetryQueue {
 
 	/** Peek without removing — sync-engine calls `markDone(item)` after
 	 * a successful upload, or leaves the item in place to retry. */
-	peek(): QueueItem | undefined {
-		return this.items[0];
+	peek(eligible: (item: QueueItem) => boolean = () => true): QueueItem | undefined {
+		return this.items.find(eligible);
 	}
 
 	all(): readonly QueueItem[] {

--- a/packages/cli/src/serve/sessions-watcher.test.ts
+++ b/packages/cli/src/serve/sessions-watcher.test.ts
@@ -390,7 +390,9 @@ test("debounces rapid fs events into one concrete changed-path batch", async () 
 			{
 				paths: [root],
 				abort: abort.signal,
-				onPathStable: (change) => changes.push(change),
+				onPathStable: (change) => {
+					changes.push(change);
+				},
 			},
 			{
 				createWatcher: (_path, _options, callback) => {

--- a/packages/cli/src/serve/sessions-watcher.ts
+++ b/packages/cli/src/serve/sessions-watcher.ts
@@ -1,3 +1,4 @@
+import { SyncScope } from "./sync-module";
 /**
  * Session-directory watcher with file-stable debounce.
  *
@@ -29,7 +30,7 @@ import { log, toErrorMessage } from "./log";
 export interface SessionWatcherOptions {
 	paths: string[];
 	abort: AbortSignal;
-	onPathStable: (event: SessionWatchEvent) => void;
+	onPathStable: (event: SessionWatchEvent) => void | Promise<void>;
 	forcePoll?: boolean;
 }
 
@@ -85,6 +86,27 @@ export const SESSION_IDLE_POLL_INTERVAL_MS = 60_000;
 export async function watchSessions(
 	opts: SessionWatcherOptions,
 	dependencies: SessionWatcherDependencies = defaultSessionWatcherDependencies,
+): Promise<void> {
+	const scope = new SyncScope(opts.abort);
+	const original = opts;
+	opts = {
+		...opts,
+		abort: scope.signal,
+		onPathStable: (event) => {
+			scope.invoke(() => original.onPathStable(event));
+		},
+	};
+	try {
+		await runSessionWatcher(opts, dependencies);
+	} finally {
+		await scope.join();
+	}
+	if (scope.failure !== undefined && !original.abort.aborted) throw scope.failure;
+}
+
+async function runSessionWatcher(
+	opts: SessionWatcherOptions,
+	dependencies: SessionWatcherDependencies,
 ): Promise<void> {
 	if (opts.forcePoll) {
 		log.info("sessions_watcher.mode", { mode: "poll", reason: "forced" });

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -459,6 +459,7 @@ describe("Agent filesystem projection reconcile", () => {
 		const originalHome = process.env.HOME;
 		const originalState = process.env.CLAWDI_STATE_DIR;
 		const originalHermesHome = process.env.HERMES_HOME;
+		let queue: RetryQueue | undefined;
 		try {
 			process.env.HOME = root;
 			process.env.CLAWDI_STATE_DIR = join(root, "serve");
@@ -468,10 +469,11 @@ describe("Agent filesystem projection reconcile", () => {
 			const keys = new Set<string>();
 			const skills = adapterRegistry.hermes.create().skills;
 			if (!skills) throw new Error("Hermes fixture requires Skills");
-			const queue = new RetryQueue({ agentType: "hermes" });
+			const activeQueue = new RetryQueue({ agentType: "hermes" });
+			queue = activeQueue;
 			await run({
 				root: skillsRoot,
-				queue,
+				queue: activeQueue,
 				keys,
 				skills,
 				reconcile: (claims, trustedLegacyRemoteKeys) =>
@@ -481,14 +483,14 @@ describe("Agent filesystem projection reconcile", () => {
 							adapter: { agentType: "hermes" },
 						},
 						skills,
-						queue,
+						queue: activeQueue,
 						claims,
 						projectId: "project-1",
 						trustedLegacyRemoteKeys,
 					}),
 			});
-			await queue.flushPersist();
 		} finally {
+			await queue?.flushPersist();
 			if (originalHome === undefined) delete process.env.HOME;
 			else process.env.HOME = originalHome;
 			if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
@@ -939,73 +941,87 @@ describe("Agent filesystem projection reconcile", () => {
 		});
 	});
 
-	it("uploads a symlink projection with the hash of the exact dereferenced archive", async () => {
-		await withProjectionCase(async ({ root, queue, keys, skills, reconcile }) => {
-			const originalHermesHome = process.env.HERMES_HOME;
-			const originalFetch = globalThis.fetch;
-			const rootDir = spyOn(skills, "rootDir");
-			try {
-				process.env.HERMES_HOME = dirname(root);
-				const shared = join(root, "shared");
-				mkdirSync(shared, { recursive: true });
-				writeFileSync(join(shared, "body.md"), "shared body\n");
-				const local = join(root, "demo");
-				mkdirSync(local, { recursive: true });
-				writeFileSync(join(local, "SKILL.md"), "# Demo\n");
-				symlinkSync(join(shared, "body.md"), join(local, "body.md"));
-				keys.add("demo");
-				await reconcile(new Map());
-				rootDir.mockClear();
-				const item = queue.peek();
-				if (!item) throw new Error("expected queued projection");
+	it.each([false, true])(
+		"uploads exact symlink bytes and retains cancelled work (cancel=%s)",
+		async (cancel) => {
+			await withProjectionCase(async ({ root, queue, keys, skills, reconcile }) => {
+				const originalHermesHome = process.env.HERMES_HOME;
+				const originalFetch = globalThis.fetch;
+				const rootDir = spyOn(skills, "rootDir");
+				try {
+					process.env.HERMES_HOME = dirname(root);
+					const shared = join(root, "shared");
+					mkdirSync(shared, { recursive: true });
+					writeFileSync(join(shared, "body.md"), "shared body\n");
+					const local = join(root, "demo");
+					mkdirSync(local, { recursive: true });
+					writeFileSync(join(local, "SKILL.md"), "# Demo\n");
+					symlinkSync(join(shared, "body.md"), join(local, "body.md"));
+					keys.add("demo");
+					await reconcile(new Map());
+					rootDir.mockClear();
+					const item = queue.peek();
+					if (!item) throw new Error("expected queued projection");
 
-				let verifiedHash: string | null = null;
-				globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-					const request = input instanceof Request ? input : new Request(input, init);
-					const form = await request.formData();
-					const archive = form.get("file");
-					const suppliedHash = form.get("content_hash");
-					if (!(archive instanceof Blob) || typeof suppliedHash !== "string") {
-						return new Response("invalid multipart", { status: 400 });
-					}
-					verifiedHash = await computeSkillArchiveHash(
-						Buffer.from(await archive.arrayBuffer()),
-						"demo",
+					const abortController = new AbortController();
+					const pushed = new Map<string, string>();
+					let verifiedHash: string | null = null;
+					globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+						const request = input instanceof Request ? input : new Request(input, init);
+						const form = await request.formData();
+						const archive = form.get("file");
+						const suppliedHash = form.get("content_hash");
+						if (!(archive instanceof Blob) || typeof suppliedHash !== "string") {
+							return new Response("invalid multipart", { status: 400 });
+						}
+						verifiedHash = await computeSkillArchiveHash(
+							Buffer.from(await archive.arrayBuffer()),
+							"demo",
+						);
+						expect(suppliedHash).toBe(verifiedHash);
+						if (cancel) abortController.abort();
+						return new Response(JSON.stringify({ version: 1 }), {
+							headers: { "content-type": "application/json" },
+						});
+					}) as typeof fetch;
+
+					const adapter = adapterRegistry.hermes.create();
+					adapter.skills = skills;
+					const processing = processQueueItem(
+						{
+							environmentId: "agent-1",
+							adapter,
+							abort: abortController.signal,
+							abortController,
+						},
+						new ApiClient({ requireAuth: false }),
+						queue,
+						item,
+						queueModules(adapter),
+						pushed,
+						new Map(),
+						new Map(),
 					);
-					expect(suppliedHash).toBe(verifiedHash);
-					return new Response(JSON.stringify({ version: 1 }), {
-						headers: { "content-type": "application/json" },
-					});
-				}) as typeof fetch;
-
-				const adapter = adapterRegistry.hermes.create();
-				adapter.skills = skills;
-				const abortController = new AbortController();
-				await processQueueItem(
-					{
-						environmentId: "agent-1",
-						adapter,
-						abort: abortController.signal,
-						abortController,
-					},
-					new ApiClient({ requireAuth: false }),
-					queue,
-					item,
-					queueModules(adapter),
-					new Map(),
-					new Map(),
-					new Map(),
-				);
-				expect(verifiedHash).not.toBeNull();
-				expect(rootDir).toHaveBeenCalledTimes(1);
-			} finally {
-				rootDir.mockRestore();
-				globalThis.fetch = originalFetch;
-				if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
-				else process.env.HERMES_HOME = originalHermesHome;
-			}
-		});
-	});
+					if (cancel) {
+						await expect(processing).rejects.toThrow();
+						expect(queue.peek()).toEqual(item);
+						expect(pushed.size).toBe(0);
+						expect(readSkillProjectionClaimsForAgent("hermes", "agent-1")).toEqual([]);
+					} else {
+						await processing;
+						expect(queue.depth).toBe(0);
+					}
+					expect(verifiedHash).not.toBeNull();
+					expect(rootDir).toHaveBeenCalledTimes(1);
+				} finally {
+					rootDir.mockRestore();
+					globalThis.fetch = originalFetch;
+					if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
+					else process.env.HERMES_HOME = originalHermesHome;
+				}
+			});
+		},
+	);
 
 	it("re-derives missed alias absence after eviction and restart at the same revision", async () => {
 		await withProjectionCase(async ({ root, keys, skills }) => {

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1513,6 +1513,157 @@ describe("daemon startup Agent lookup", () => {
 		}
 	}
 
+	it("retains a preparing session while Skills and heartbeats progress, then recovers without restart", async () => {
+		let heartbeats = 0;
+		let skillDeleted = false;
+		let attempts = 0;
+		let resolved = false;
+		await withStartupCase(
+			async (request) => {
+				const path = new URL(request.url).pathname;
+				if (path.endsWith("sync-heartbeat")) {
+					heartbeats++;
+					return Response.json({ status: "ok" });
+				}
+				if (request.method === "DELETE") {
+					skillDeleted = true;
+					return Response.json({ status: "deleted" });
+				}
+				if (path === "/v1/agents/agent-isolated")
+					return Response.json({ id: "agent-isolated", default_project_id: "project-1" });
+				if (path.includes("/skills"))
+					return Response.json({ skills: [], revision: 1 }, { headers: { ETag: '"skills-1"' } });
+				return new Response("", { status: 404 });
+			},
+			async ({ abortController, root }) => {
+				const adapter: AgentAdapter = {
+					agentType: "codex",
+					detect: async () => true,
+					getVersion: async () => null,
+					sessions: {
+						contentProtocol: async () => {
+							attempts++;
+							if (!skillDeleted || !heartbeats) throw new Error("protocol temporarily unavailable");
+							return "snapshot-v1";
+						},
+						collect: async () => ({ sessions: [], coverage: "complete", dedupedCount: 0 }),
+						resolve: async () => {
+							resolved = true;
+							abortController.abort();
+							return null;
+						},
+						watchPaths: () => [],
+					},
+					skills: {
+						rootDir: () => root,
+						path: (key) => join(root, key),
+						sharedPath: (key) => join(root, key),
+						collect: async () => [],
+						listKeys: async () => [],
+						writeArchive: async () => {},
+						writeSharedArchive: async () => {},
+						remove: async () => {},
+					},
+				};
+				const queue = new RetryQueue({ agentType: "codex" });
+				queue.enqueue({
+					kind: "session_push",
+					local_session_id: "retained",
+					content_hash: "hash",
+					...sessionQueueFence(new ApiClient(), adapter, "retained", "agent-isolated"),
+					enqueued_at: new Date().toISOString(),
+					attempts: 0,
+				});
+				queue.enqueue({
+					kind: "skill_delete",
+					skill_key: "old",
+					agent_id: "agent-isolated",
+					project_id: "project-1",
+					enqueued_at: new Date().toISOString(),
+					attempts: 0,
+				});
+				await queue.flushPersist();
+				const deadline = setTimeout(() => abortController.abort(), 5000);
+				try {
+					await runSyncEngine({
+						environmentId: "agent-isolated",
+						adapter,
+						abort: abortController.signal,
+						abortController,
+						forcePollWatcher: true,
+					});
+					expect(skillDeleted).toBe(true);
+					expect(heartbeats).toBeGreaterThan(0);
+					expect(attempts).toBeGreaterThan(1);
+					expect(resolved).toBe(true);
+					const retained = new RetryQueue({ agentType: "codex" });
+					retained.load();
+					expect(retained.all()).toMatchObject([{ kind: "session_push", attempts: 0 }]);
+				} finally {
+					clearTimeout(deadline);
+					abortController.abort();
+				}
+			},
+		);
+	});
+
+	it("globally revokes auth during local preparation retry without consuming queued work", async () => {
+		let beats = 0;
+		await withStartupCase(
+			async (request) => {
+				if (new URL(request.url).pathname.endsWith("sync-heartbeat")) {
+					beats++;
+					return beats > 1
+						? new Response("revoked", { status: 401 })
+						: Response.json({ status: "ok" });
+				}
+				return Response.json({ id: "agent-retry", default_project_id: "project-1" });
+			},
+			async ({ abortController }) => {
+				const adapter: AgentAdapter = {
+					agentType: "pi",
+					detect: async () => true,
+					getVersion: async () => null,
+					sessions: {
+						contentProtocol: async () => {
+							throw new Error("retry protocol");
+						},
+						collect: async () => ({ sessions: [], coverage: "complete", dedupedCount: 0 }),
+						resolve: async () => null,
+						watchPaths: () => [],
+					},
+				};
+				const queue = new RetryQueue({ agentType: "pi" });
+				queue.enqueue({
+					kind: "session_push",
+					local_session_id: "retained",
+					content_hash: "hash",
+					...sessionQueueFence(new ApiClient(), adapter, "retained", "agent-retry"),
+					enqueued_at: new Date().toISOString(),
+					attempts: 0,
+				});
+				await queue.flushPersist();
+				const deadline = setTimeout(() => abortController.abort(), 2000);
+				try {
+					await runSyncEngine({
+						environmentId: "agent-retry",
+						adapter,
+						abort: abortController.signal,
+						abortController,
+						heartbeatIntervalMs: 10,
+					});
+					expect(process.exitCode).toBe(2);
+					const retained = new RetryQueue({ agentType: "pi" });
+					retained.load();
+					expect(retained.all()).toMatchObject([{ kind: "session_push", attempts: 0 }]);
+				} finally {
+					clearTimeout(deadline);
+					abortController.abort();
+				}
+			},
+		);
+	});
+
 	it("backfills a legacy registration only after the owning Agent lookup succeeds", async () => {
 		await withStartupCase(
 			async () => Response.json({ id: "agent-owned", default_project_id: "project-1" }),

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1414,6 +1414,11 @@ describe("Pi sessions-only daemon", () => {
 			expect(paths).toContain("/v1/agents/agent-pi");
 			expect(paths).not.toContain("/v1/sync/events");
 			expect(paths.some((path) => path.includes("/skills"))).toBe(false);
+			const heartbeat = requests.find((request) =>
+				new URL(request.url).pathname.endsWith("/sync-heartbeat"),
+			);
+			if (!heartbeat) throw new Error("Expected startup heartbeat");
+			expect(await heartbeat.json()).toMatchObject({ last_sync_error: null });
 		} finally {
 			abortController.abort();
 			globalThis.fetch = originalFetch;

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -105,6 +105,7 @@ import {
 	type SkillServerEvent,
 	type SseReconnectInfo,
 } from "./sse-client";
+import { SyncModule, type SyncScope } from "./sync-module";
 import { watchSkills } from "./watcher";
 
 export function isSkillSyncServerEvent(event: ServerEvent): event is SkillServerEvent {
@@ -423,13 +424,14 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	};
 
 	let authFailureFired = false;
+	let shutdownHeartbeat: Promise<unknown> | undefined;
 	const triggerAuthFailureAbort = (origin: string): void => {
 		if (authFailureFired) return;
 		authFailureFired = true;
 		vaultSync?.revoke();
 		log.error("engine.auth_failed", { origin });
 		health.set("transport", "auth", "auth_revoked: api key rejected by server");
-		void shutdownApi
+		shutdownHeartbeat = shutdownApi
 			.POST("/v1/agents/{agent_id}/sync-heartbeat", {
 				params: { path: { agent_id: opts.environmentId } },
 				body: {
@@ -474,81 +476,102 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			} else log.info("engine.vault_sync", { message });
 		},
 	});
-	const reconcileVaultFiles = async (force = false): Promise<void> => {
-		try {
-			await vaultSync?.reconcile(force);
-		} catch {
-			health.set(
-				"projection",
-				"vault_files",
-				"Vault reconciliation failed; retrying on the next heartbeat.",
-			);
-		}
-	};
-	const registration = readEnvironmentRegistration(opts.adapter.agentType);
-	let agentIdentity: components["schemas"]["AgentResponse"];
 	try {
-		agentIdentity = unwrap(
-			await api.GET("/v1/agents/{agent_id}", {
-				params: { path: { agent_id: opts.environmentId } },
-			}),
-		);
-	} catch (error) {
-		if (handleStartupFailure(error, "boot_agent_fetch")) return;
-		throw error;
-	}
-	if (registration && registration.id !== opts.environmentId) {
-		stopDisconnectedAgent(
-			"The local Agent registration changed while background sync was starting. Restart Clawdi after the current setup finishes.",
-		);
-		return;
-	}
-	const userId = getAuth()?.userId;
-	if (registration?.id === opts.environmentId && !registration.userId && userId) {
-		const bound = bindEnvironmentRegistrationUser(
-			opts.adapter.agentType,
-			opts.environmentId,
-			userId,
-		);
-		if (!bound) {
+		const reconcileVaultFiles = async (force = false): Promise<void> => {
+			try {
+				await vaultSync?.reconcile(force);
+			} catch {
+				health.set(
+					"projection",
+					"vault_files",
+					"Vault reconciliation failed; retrying on the next heartbeat.",
+				);
+			}
+		};
+		const registration = readEnvironmentRegistration(opts.adapter.agentType);
+		try {
+			unwrap(
+				await api.GET("/v1/agents/{agent_id}", {
+					params: { path: { agent_id: opts.environmentId } },
+				}),
+			);
+		} catch (error) {
+			if (handleStartupFailure(error, "boot_agent_fetch")) return;
+			throw error;
+		}
+		if (registration && registration.id !== opts.environmentId) {
 			stopDisconnectedAgent(
 				"The local Agent registration changed while background sync was starting. Restart Clawdi after the current setup finishes.",
 			);
 			return;
 		}
-	}
-	if (opts.abort.aborted) return;
+		const userId = getAuth()?.userId;
+		if (registration?.id === opts.environmentId && !registration.userId && userId) {
+			const bound = bindEnvironmentRegistrationUser(
+				opts.adapter.agentType,
+				opts.environmentId,
+				userId,
+			);
+			if (!bound) {
+				stopDisconnectedAgent(
+					"The local Agent registration changed while background sync was starting. Restart Clawdi after the current setup finishes.",
+				);
+				return;
+			}
+		}
+		if (opts.abort.aborted) return;
 
-	const common: CommonSyncRuntime = {
-		api,
-		queue,
-		health,
-		inFlightSessionHash,
-		stopForDisconnectedAgent: stopDisconnectedAgent,
-		triggerAuthFailureAbort,
-		initialDefaultProjectId: agentIdentity.default_project_id,
-		setLastSeenRevision: (revision) => {
-			lastSeenRevision = revision;
-		},
-	};
-	let sessionSync: PreparedSessionSync | null;
-	let skillSync: PreparedSkillSync | null;
-	try {
-		sessionSync = sessions ? await prepareSessionSync(opts, sessions, common) : null;
-		skillSync = skills ? await prepareSkillSync(opts, skills, common) : null;
-	} catch (error) {
-		if (handleStartupFailure(error, "boot_sync_prepare")) return;
-		throw error;
-	}
-	if (opts.abort.aborted) return;
-	const moduleTasks: Promise<void>[] = [];
-	if (sessions && sessionSync) moduleTasks.push(runSessionSync(opts, sessions, sessionSync));
-	if (skills && skillSync) moduleTasks.push(runSkillSync(opts, skills, skillSync));
+		const common: Omit<CommonSyncRuntime, "scope"> = {
+			api,
+			queue,
+			health,
+			inFlightSessionHash,
+			stopForDisconnectedAgent: stopDisconnectedAgent,
+			triggerAuthFailureAbort,
+			setLastSeenRevision: (revision) => {
+				lastSeenRevision = revision;
+			},
+		};
+		const moduleOptions = (name: string) => ({
+			signal: opts.abort,
+			changed: (state: import("./sync-module").ModuleState, error?: unknown) => {
+				queue.notifyItemWaiters();
+				if (state === "ready") health.clear("projection", `module:${name}`);
+				else if (state !== "unsupported" && state !== "stopped")
+					health.set(
+						"projection",
+						`module:${name}`,
+						`${name} ${state}${error ? `: ${toErrorMessage(error)}` : ""}`,
+					);
+			},
+			failed: (error: unknown) => {
+				if (isAuthFailure(error)) triggerAuthFailureAbort(`${name}_sync`);
+			},
+		});
+		const attemptCommon = (scope: SyncScope): CommonSyncRuntime => ({
+			...common,
+			api: new ApiClient({ abortSignal: scope.signal }),
+			scope,
+		});
+		const sessionSlot = new SyncModule<PreparedSessionSync>({
+			...moduleOptions("sessions"),
+			prepare: sessions
+				? (scope) =>
+						prepareSessionSync({ ...opts, abort: scope.signal }, sessions, attemptCommon(scope))
+				: null,
+		});
+		const skillSlot = new SyncModule<PreparedSkillSync>({
+			...moduleOptions("skills"),
+			prepare: skills
+				? (scope) =>
+						prepareSkillSync({ ...opts, abort: scope.signal }, skills, attemptCommon(scope))
+				: null,
+		});
+		const moduleTasks = [sessionSlot.run(), skillSlot.run()];
 
-	try {
-		await Promise.all([
+		const tasks = [
 			...moduleTasks,
-			...(skillSync || vaultSync.enabled
+			...(skills || vaultSync.enabled
 				? [
 						consumeSse({
 							apiUrl: api.baseUrl,
@@ -562,7 +585,12 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 									event.environment_id === opts.environmentId
 								)
 									void reconcileVaultFiles();
-								await skillSync?.onEvent(event);
+								const lease = skillSlot.acquire();
+								try {
+									await lease?.binding.onEvent(event);
+								} finally {
+									lease?.release();
+								}
 							},
 							onConnect: () => {
 								health.clear("transport", "sse");
@@ -573,7 +601,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 								if (error !== null) health.set("transport", "sse", error);
 							},
 							onAuthFailure: () => {
-								if (skillSync) triggerAuthFailureAbort("sse_channel");
+								if (skills) triggerAuthFailureAbort("sse_channel");
 								else {
 									// A Vault-only stream may lack skills:read while session/Vault grants remain valid.
 									health.set(
@@ -591,12 +619,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				opts,
 				api,
 				queue,
-				{
-					sessions: sessionSync?.queueModule ?? null,
-					skills: skillSync?.queueModule ?? null,
-				},
-				skillSync?.lastPushedHash ?? new Map(),
-				sessionSync?.lastPushedHash ?? new Map(),
+				{ sessions: sessionSlot, skills: skillSlot },
 				inFlightSessionHash,
 				health,
 				triggerAuthFailureAbort,
@@ -612,22 +635,31 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 				}),
 				stopDisconnectedAgent,
 				reconcileVaultFiles,
+				triggerAuthFailureAbort,
 			),
-		]);
+		];
+		try {
+			await Promise.all(tasks);
+		} finally {
+			opts.abortController.abort();
+			await Promise.allSettled(tasks);
+		}
+		log.info("engine.stop", {});
 	} finally {
+		await queue.flushPersist();
 		await vaultSync.finish();
+		await shutdownHeartbeat;
 	}
-	log.info("engine.stop", {});
 }
 
 interface CommonSyncRuntime {
+	scope: SyncScope;
 	api: ApiClient;
 	queue: RetryQueue;
 	health: SyncHealth;
 	inFlightSessionHash: Map<string, string>;
 	stopForDisconnectedAgent(hint: string): void;
 	triggerAuthFailureAbort(origin: string): void;
-	initialDefaultProjectId: string;
 	setLastSeenRevision(revision: number | null): void;
 }
 
@@ -672,18 +704,26 @@ async function prepareSkillSync(
 	// supervisor restarts — without a project_id we can't tell which
 	// SSE events belong to us.
 	const fetchDefaultProjectId = async (): Promise<string> => {
-		const envInfo = unwrap(
-			await api.GET("/v1/agents/{agent_id}", {
-				params: { path: { agent_id: opts.environmentId } },
-			}),
-		);
-		const projectId = envInfo.default_project_id;
-		if (!projectId) {
-			throw new Error(`environment ${opts.environmentId} has no default_project_id; cannot upload`);
+		try {
+			const envInfo = unwrap(
+				await api.GET("/v1/agents/{agent_id}", {
+					params: { path: { agent_id: opts.environmentId } },
+				}),
+			);
+			const projectId = envInfo.default_project_id;
+			if (!projectId) {
+				throw new Error(
+					`environment ${opts.environmentId} has no default_project_id; cannot upload`,
+				);
+			}
+			return projectId;
+		} catch (error) {
+			const hint = agentLookupStopHint(error);
+			if (hint) stopDisconnectedAgent(hint);
+			throw error;
 		}
-		return projectId;
 	};
-	let defaultProjectId = common.initialDefaultProjectId;
+	const defaultProjectId = await fetchDefaultProjectId();
 	log.info("engine.project_resolved", { default_project_id: defaultProjectId });
 	for (const [skillKey, hash] of readSkillProjectionState(
 		opts.adapter.agentType,
@@ -720,6 +760,10 @@ async function prepareSkillSync(
 			await reconcileProjectSkills();
 			syncHealth.clear("projection", "project_skills");
 		} catch (error) {
+			if (isAuthFailure(error)) {
+				triggerAuthFailureAbort("skill_sync");
+				throw error;
+			}
 			syncHealth.set("projection", "project_skills", `Project Skills: ${toErrorMessage(error)}`);
 			log.warn("engine.project_skills_reconcile_failed", {
 				origin: "startup",
@@ -748,49 +792,11 @@ async function prepareSkillSync(
 				syncHealth.clear("transport", "project_refresh");
 				if (fresh !== defaultProjectId) {
 					log.info("engine.project_changed", { from: defaultProjectId, to: fresh });
-					defaultProjectId = fresh;
-					lastReconciledListingEtag = null;
-					lastPushedHash.clear();
-					for (const [skillKey, hash] of readSkillProjectionState(
-						opts.adapter.agentType,
-						opts.environmentId,
-						fresh,
-					).claims) {
-						lastPushedHash.set(skillKey, hash);
-					}
-					// Re-scan under the new identity fence. A current push
-					// first removes exact old-Project claims, then projects
-					// the latest local bytes; it never redirects a stale item.
-					await reconcileAgentSkillProjection({
-						opts,
-						skills,
-						queue,
-						claims: lastPushedHash,
-						projectId: fresh,
-					}).catch((e) => {
-						log.warn("engine.project_change_rescan_failed", {
-							error: toErrorMessage(e),
-						});
-					});
-					try {
-						const catchUp = await reconcileAgentSkillProjectionListing({
-							api,
-							opts,
-							skills,
-							queue,
-							claims: lastPushedHash,
-							projectId: fresh,
-							previousEtag: null,
-						});
-						if (catchUp.complete) {
-							lastReconciledListingEtag = catchUp.etag;
-							updateLastSeenRevision(catchUp.revision);
-						}
-					} catch (error) {
-						log.warn("engine.project_change_listing_failed", {
-							error: toErrorMessage(error),
-						});
-					}
+					// Retire the captured Project binding before loading another set of claims.
+					common.scope.controller.abort(
+						new Error("Agent Project changed; refreshing sync binding"),
+					);
+					return;
 				}
 				consecutiveFailures = 0;
 			} catch (e) {
@@ -860,7 +866,7 @@ async function prepareSkillSync(
 	// Push side: wire watcher → enqueue.
 	const onLocalChange = (skillKey: string) => {
 		const scanResource = `skill_scan:${skillKey}`;
-		void enqueueIfChanged(opts, skills, queue, lastPushedHash, skillKey, () => defaultProjectId)
+		return enqueueIfChanged(opts, skills, queue, lastPushedHash, skillKey, () => defaultProjectId)
 			.then(() => {
 				syncHealth.clear("push", scanResource);
 			})
@@ -875,7 +881,7 @@ async function prepareSkillSync(
 		inventoryScanRequested = true;
 		if (inventoryScanRunning) return;
 		inventoryScanRunning = true;
-		void (async () => {
+		return (async () => {
 			try {
 				while (inventoryScanRequested && !opts.abort.aborted) {
 					inventoryScanRequested = false;
@@ -889,6 +895,10 @@ async function prepareSkillSync(
 				}
 				syncHealth.clear("push", "skills_scan");
 			} catch (error) {
+				if (isAuthFailure(error)) {
+					triggerAuthFailureAbort("skill_sync");
+					throw error;
+				}
 				syncHealth.set("push", "skills_scan", `skills scan: ${toErrorMessage(error)}`);
 				log.warn("engine.skills_rescan_failed", { error: toErrorMessage(error) });
 			} finally {
@@ -908,6 +918,10 @@ async function prepareSkillSync(
 				await reconcileProjectSkills();
 				syncHealth.clear("projection", "project_skills");
 			} catch (error) {
+				if (isAuthFailure(error)) {
+					triggerAuthFailureAbort("skill_sync");
+					throw error;
+				}
 				syncHealth.set("projection", "project_skills", `Project Skills: ${toErrorMessage(error)}`);
 				log.warn("engine.project_skills_reconcile_failed", { error: toErrorMessage(error) });
 			}
@@ -944,6 +958,10 @@ async function prepareSkillSync(
 			});
 			syncHealth.clear("push", scanResource);
 		} catch (error) {
+			if (isAuthFailure(error)) {
+				triggerAuthFailureAbort("skill_sync");
+				throw error;
+			}
 			syncHealth.set(
 				"push",
 				scanResource,
@@ -961,7 +979,7 @@ async function prepareSkillSync(
 		queueModule: { module: skills, getProjectId: () => defaultProjectId },
 		lastPushedHash,
 		run: async () => {
-			await Promise.all([
+			await common.scope.run([
 				watchSkills({
 					rootDir,
 					abort: opts.abort,
@@ -988,7 +1006,7 @@ async function prepareSkillSync(
 					// without its own SKILL.md) and any nested edit
 					// either reports the wrong key OR is missed entirely
 					// because the dir's own mtime didn't change.
-					listSkillKeys: () => skills.listKeys(),
+					listSkillKeys: () => skills.listKeys({ signal: opts.abort }),
 					onInventoryChanged: onSkillInventoryChanged,
 				}),
 
@@ -1046,16 +1064,6 @@ async function prepareSkillSync(
 	};
 }
 
-async function runSkillSync(
-	_opts: EngineOpts,
-	skills: SkillModule,
-	prepared: PreparedSkillSync,
-): Promise<void> {
-	if (prepared.queueModule.module !== skills)
-		throw new Error("Skills module changed during startup");
-	await prepared.run();
-}
-
 interface PreparedSessionSync {
 	queueModule: { module: SessionModule; protocol: SelectedSessionProtocol };
 	lastPushedHash: Map<string, string>;
@@ -1068,7 +1076,7 @@ async function prepareSessionSync(
 	common: CommonSyncRuntime,
 ): Promise<PreparedSessionSync> {
 	const { api, queue, health, inFlightSessionHash } = common;
-	const protocol = await negotiateSessionProtocol(api, sessions);
+	const protocol = await negotiateSessionProtocol(api, sessions, { signal: opts.abort });
 	const lastPushedSessionHash = loadFencedSessionHashes(api, opts);
 	for (const entry of currentFencedSessionEntries(api, opts)) {
 		if (entry.blocked) {
@@ -1092,6 +1100,7 @@ async function prepareSessionSync(
 				sessions,
 				request,
 				materializeActivity ? new Map() : loadFencedSessionSourceRevisions(api, opts, protocol),
+				{ signal: opts.abort },
 			);
 			const observedResources = new Set<string>();
 			const confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[] = [];
@@ -1125,6 +1134,7 @@ async function prepareSessionSync(
 				confirmedSourceRevisions.push(...result.confirmedSourceRevisions);
 				if (opts.abort.aborted) return;
 			}
+			opts.abort.throwIfAborted();
 			recordRuntimeUserActivityScan({
 				agentType: opts.adapter.agentType,
 				userActivity: scan.userActivity ?? { lastUserInputAt: null, complete: false },
@@ -1174,13 +1184,13 @@ async function prepareSessionSync(
 		queueModule: { module: sessions, protocol },
 		lastPushedHash: lastPushedSessionHash,
 		run: async () => {
-			await Promise.all([
+			await common.scope.run([
 				requestScan(),
 				watchSessions({
 					paths: sessions.watchPaths(),
 					abort: opts.abort,
 					onPathStable: (change) => {
-						if (!opts.abort.aborted) void requestScan(change);
+						if (!opts.abort.aborted) return requestScan(change);
 					},
 					forcePoll: opts.forcePollWatcher,
 				}),
@@ -1193,16 +1203,6 @@ async function prepareSessionSync(
 			]);
 		},
 	};
-}
-
-async function runSessionSync(
-	_opts: EngineOpts,
-	sessions: SessionModule,
-	prepared: PreparedSessionSync,
-): Promise<void> {
-	if (prepared.queueModule.module !== sessions)
-		throw new Error("Sessions module changed during startup");
-	await prepared.run();
 }
 
 function loadFencedSessionHashes(api: ApiClient, opts: EngineOpts): Map<string, string> {
@@ -1454,14 +1454,9 @@ export function isOversizedUploadError(e: unknown): boolean {
 
 async function drainQueueLoop(
 	opts: EngineOpts,
-	api: ApiClient,
+	_api: ApiClient,
 	queue: RetryQueue,
-	modules: {
-		sessions: { module: SessionModule; protocol: SelectedSessionProtocol } | null;
-		skills: { module: SkillModule; getProjectId: () => string } | null;
-	},
-	lastPushedHash: Map<string, string>,
-	lastPushedSessionHash: Map<string, string>,
+	slots: { sessions: SyncModule<PreparedSessionSync>; skills: SyncModule<PreparedSkillSync> },
 	inFlightSessionHash: Map<string, string>,
 	health: SyncHealth,
 	onAuthFailure: (origin: string) => void,
@@ -1494,20 +1489,29 @@ async function drainQueueLoop(
 		queue.markDoneIfVersion(item);
 	};
 	while (!opts.abort.aborted) {
-		const item = queue.peek();
+		const item = queue.peek((item) => {
+			const slot = item.kind === "session_push" ? slots.sessions : slots.skills;
+			return slot.available || slot.state === "unsupported";
+		});
 		if (!item) {
-			await queue.waitForItem(opts.abort, QUEUE_IDLE_WAKEUP_MS);
+			await queue.waitForChange(opts.abort, QUEUE_IDLE_WAKEUP_MS);
 			continue;
 		}
+		const sessionLease = item.kind === "session_push" ? slots.sessions.acquire() : null;
+		const skillLease = item.kind !== "session_push" ? slots.skills.acquire() : null;
+		const signal = sessionLease?.signal ?? skillLease?.signal ?? opts.abort;
 		try {
 			const outcome = await processQueueItem(
-				opts,
-				api,
+				{ ...opts, abort: signal },
+				new ApiClient({ abortSignal: signal }),
 				queue,
 				item,
-				modules,
-				lastPushedHash,
-				lastPushedSessionHash,
+				{
+					sessions: sessionLease?.binding.queueModule ?? null,
+					skills: skillLease?.binding.queueModule ?? null,
+				},
+				skillLease?.binding.lastPushedHash ?? new Map(),
+				sessionLease?.binding.lastPushedHash ?? new Map(),
 				inFlightSessionHash,
 			);
 			if (outcome === "applied" || outcome === "absent") {
@@ -1527,6 +1531,7 @@ async function drainQueueLoop(
 				);
 			}
 		} catch (e) {
+			if (signal.aborted) continue;
 			const msg = toErrorMessage(e);
 			const resource = healthResource(item);
 			// Auth dead → daemon abort, not queue drop. Every
@@ -1645,6 +1650,9 @@ async function drainQueueLoop(
 				health.set("push", resource, msg, true);
 				await sleep(QUEUE_RETRY_INTERVAL_MS, opts.abort);
 			}
+		} finally {
+			sessionLease?.release();
+			skillLease?.release();
 		}
 	}
 }
@@ -1718,6 +1726,7 @@ export async function processQueueItem(
 			).filter((claim) => claim.skill_key === item.skill_key);
 			for (const claim of claims) {
 				await api.deleteAgentSkill(opts.environmentId, item.skill_key, claim.project_id);
+				opts.abort.throwIfAborted();
 				removeSkillProjectionClaim({
 					agentType: opts.adapter.agentType,
 					agentId: opts.environmentId,
@@ -1740,6 +1749,7 @@ export async function processQueueItem(
 			projectId,
 		)) {
 			await api.deleteAgentSkill(opts.environmentId, item.skill_key, staleProjectId);
+			opts.abort.throwIfAborted();
 			removeSkillProjectionClaim({
 				agentType: opts.adapter.agentType,
 				agentId: opts.environmentId,
@@ -1752,6 +1762,7 @@ export async function processQueueItem(
 			// fenced to the stamped old Project, then re-scan so the latest local
 			// state is enqueued for the current Project. Never redirect old bytes.
 			await api.deleteAgentSkill(opts.environmentId, item.skill_key, item.project_id);
+			opts.abort.throwIfAborted();
 			removeSkillProjectionClaim({
 				agentType: opts.adapter.agentType,
 				agentId: opts.environmentId,
@@ -1771,6 +1782,7 @@ export async function processQueueItem(
 		}
 		if (item.kind === "skill_delete") {
 			await api.deleteAgentSkill(opts.environmentId, item.skill_key, item.project_id);
+			opts.abort.throwIfAborted();
 			removeSkillProjectionClaim({
 				agentType: opts.adapter.agentType,
 				agentId: opts.environmentId,
@@ -1801,6 +1813,7 @@ export async function processQueueItem(
 		const skillDir = join(modules.skills.module.rootDir(), item.skill_key);
 		if (shouldIgnoreUserSkill(skillDir, item.skill_key)) {
 			await api.deleteAgentSkill(opts.environmentId, item.skill_key, item.project_id);
+			opts.abort.throwIfAborted();
 			removeSkillProjectionClaim({
 				agentType: opts.adapter.agentType,
 				agentId: opts.environmentId,
@@ -1819,6 +1832,7 @@ export async function processQueueItem(
 		// it in the queue so the next drain picks it up. The
 		// upload we just finished was the OLD version; the new
 		// one still needs to ship.
+		opts.abort.throwIfAborted();
 		const removed = queue.markDoneIfVersion(item);
 		if (!removed) {
 			log.info("engine.queue_superseded", {
@@ -1879,6 +1893,7 @@ export async function processQueueItem(
 		// independently decides whether resource health is resolved.
 		// Leave the in-memory state untouched so the next watcher
 		// tick can decide.
+		opts.abort.throwIfAborted();
 		if (result.outcome === "applied" || result.outcome === "blocked") {
 			lastPushedSessionHash.set(item.local_session_id, result.actualHash);
 		}
@@ -1886,6 +1901,7 @@ export async function processQueueItem(
 		if (cur === item.content_hash) {
 			inFlightSessionHash.delete(item.local_session_id);
 		}
+		opts.abort.throwIfAborted();
 		const removed = queue.markDoneIfVersion(item);
 		if (!removed) {
 			log.info("engine.queue_superseded", {
@@ -1924,7 +1940,8 @@ async function uploadSessionFromQueue(
 	| { outcome: "not_applied" }
 > {
 	if (!hasSessionFence(item)) return { outcome: "not_applied" };
-	const session = await sessions.resolve(item.source_session_key);
+	const session = await sessions.resolve(item.source_session_key, { signal: opts.abort });
+	opts.abort.throwIfAborted();
 	if (!session) {
 		log.info("engine.session_gone", { local_session_id: item.local_session_id });
 		return { outcome: "absent" };
@@ -2063,6 +2080,7 @@ async function uploadSkillFromQueue(
 		actualHash,
 	);
 	lastPushedHash.set(item.skill_key, actualHash);
+	opts.abort.throwIfAborted();
 	recordSkillProjectionClaim({
 		agentType: opts.adapter.agentType,
 		agentId: opts.environmentId,
@@ -2227,6 +2245,7 @@ export async function reconcileAgentSkillProjectionListing(input: {
 	opts: {
 		environmentId: string;
 		adapter: Pick<AgentAdapter, "agentType">;
+		abort?: AbortSignal;
 	};
 	skills: SkillModule;
 	queue: RetryQueue;
@@ -2278,6 +2297,7 @@ export async function reconcileAgentSkillProjection(input: {
 	opts: {
 		environmentId: string;
 		adapter: Pick<AgentAdapter, "agentType">;
+		abort?: AbortSignal;
 	};
 	skills: SkillModule;
 	queue: RetryQueue;
@@ -2289,7 +2309,12 @@ export async function reconcileAgentSkillProjection(input: {
 }): Promise<void> {
 	const { opts, skills, queue, claims, projectId } = input;
 	const rootDir = skills.rootDir();
-	const localKeys = new Set(filterValidSkillKeysForSync(await skills.listKeys()));
+	const localKeys = new Set(
+		filterValidSkillKeysForSync(
+			await skills.listKeys(opts.abort ? { signal: opts.abort } : undefined),
+		),
+	);
+	opts.abort?.throwIfAborted();
 	const exactAgentClaims = readSkillProjectionClaimsForAgent(
 		opts.adapter.agentType,
 		opts.environmentId,
@@ -2308,6 +2333,7 @@ export async function reconcileAgentSkillProjection(input: {
 	]);
 
 	for (const skillKey of [...allKeys].sort()) {
+		opts.abort?.throwIfAborted();
 		if (
 			readProjectSkillMaterialization({
 				agentType: opts.adapter.agentType,
@@ -2501,6 +2527,7 @@ export async function heartbeatLoop(
 	snapshot: () => { last_revision_seen: number | null; last_sync_error: string | null },
 	stopForDisconnectedAgent: (hint: string) => void,
 	vaultTick?: () => Promise<void>,
+	onAuthFailure?: (origin: string) => void,
 ): Promise<void> {
 	let heartbeatFailureStreak = 0;
 	const send = async () => {
@@ -2535,6 +2562,10 @@ export async function heartbeatLoop(
 			// count is permanently lost on every flaky-network
 			// cycle, which is precisely when drops are most likely.
 			queue.restoreDroppedDelta(dropped);
+			if (isAuthFailure(e) && onAuthFailure) {
+				onAuthFailure("heartbeat");
+				return;
+			}
 			const stopHint = agentLookupStopHint(e);
 			if (stopHint !== null) {
 				stopForDisconnectedAgent(stopHint);

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -537,7 +537,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			changed: (state: import("./sync-module").ModuleState, error?: unknown) => {
 				queue.notifyItemWaiters();
 				if (state === "ready") health.clear("projection", `module:${name}`);
-				else if (state !== "unsupported" && state !== "stopped")
+				else if (error !== undefined && !opts.abort.aborted)
 					health.set(
 						"projection",
 						`module:${name}`,

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1531,7 +1531,7 @@ async function drainQueueLoop(
 				);
 			}
 		} catch (e) {
-			if (signal.aborted) continue;
+			if (signal.aborted && !isAuthFailure(e)) continue;
 			const msg = toErrorMessage(e);
 			const resource = healthResource(item);
 			// Auth dead → daemon abort, not queue drop. Every
@@ -2079,8 +2079,8 @@ async function uploadSkillFromQueue(
 		`${item.skill_key}.tar.gz`,
 		actualHash,
 	);
-	lastPushedHash.set(item.skill_key, actualHash);
 	opts.abort.throwIfAborted();
+	lastPushedHash.set(item.skill_key, actualHash);
 	recordSkillProjectionClaim({
 		agentType: opts.adapter.agentType,
 		agentId: opts.environmentId,

--- a/packages/cli/src/serve/sync-module.test.ts
+++ b/packages/cli/src/serve/sync-module.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { SyncModule } from "./sync-module";
+
+function deferred() {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+test("replacement waits for both a captured upload lease and failed worker cleanup", async () => {
+	const abort = new AbortController();
+	const ready = deferred();
+	const draining = deferred();
+	const failed = deferred();
+	const cleanup = deferred();
+	let attempts = 0;
+	const slot = new SyncModule({
+		signal: abort.signal,
+		changed: (state) => {
+			if (state === "ready") ready.resolve();
+			if (state === "draining") draining.resolve();
+		},
+		failed: () => {},
+		prepare: async (scope) => {
+			attempts++;
+			scope.track(cleanup.promise);
+			return {
+				run: async () => {
+					await failed.promise;
+					throw new Error("watcher failed");
+				},
+			};
+		},
+	});
+	const running = slot.run();
+	let release = () => {};
+	try {
+		await ready.promise;
+		const lease = slot.acquire();
+		release = lease?.release ?? release;
+		expect(lease).not.toBeNull();
+		failed.resolve();
+		await draining.promise;
+		expect(slot.acquire()).toBeNull();
+		expect(lease?.signal.aborted).toBe(true);
+		cleanup.resolve();
+		await Promise.resolve();
+		expect(attempts).toBe(1);
+		expect(slot.state).toBe("draining");
+		abort.abort();
+		lease?.release();
+		await running;
+		expect(slot.state).toBe("stopped");
+	} finally {
+		abort.abort();
+		release();
+		failed.resolve();
+		cleanup.resolve();
+		await running;
+	}
+});

--- a/packages/cli/src/serve/sync-module.ts
+++ b/packages/cli/src/serve/sync-module.ts
@@ -94,7 +94,11 @@ export class SyncModule<T extends { run(): Promise<void> }> {
 		let delay = 1000;
 		while (!this.options.signal.aborted) {
 			const scope = new SyncScope(this.options.signal);
-			const draining = () => this.publish("draining", scope.signal.reason);
+			let healthyEndedAt: number | null = null;
+			const draining = () => {
+				healthyEndedAt ??= Date.now();
+				this.publish("draining", scope.signal.reason);
+			};
 			scope.signal.addEventListener("abort", draining, { once: true });
 			let readyAt: number | null = null;
 			let failure: unknown;
@@ -113,7 +117,7 @@ export class SyncModule<T extends { run(): Promise<void> }> {
 				failure = error;
 				if (!this.options.signal.aborted) this.options.failed(error);
 			} finally {
-				healthyDuration = readyAt === null ? 0 : Date.now() - readyAt;
+				healthyDuration = readyAt === null ? 0 : (healthyEndedAt ?? Date.now()) - readyAt;
 				this.publish("draining", failure);
 				await scope.join();
 				scope.signal.removeEventListener("abort", draining);

--- a/packages/cli/src/serve/sync-module.ts
+++ b/packages/cli/src/serve/sync-module.ts
@@ -1,0 +1,136 @@
+import { setTimeout } from "node:timers/promises";
+
+export type ModuleState =
+	| "unsupported"
+	| "preparing"
+	| "ready"
+	| "draining"
+	| "retry_wait"
+	| "stopped";
+
+/** An attempt owns all callbacks and workers until they actually settle. */
+export class SyncScope {
+	readonly controller = new AbortController();
+	readonly signal: AbortSignal;
+	private readonly tasks = new Set<Promise<unknown>>();
+	failure: unknown;
+	constructor(parent: AbortSignal) {
+		this.signal = AbortSignal.any([parent, this.controller.signal]);
+	}
+	track<T>(task: Promise<T>): Promise<T> {
+		this.tasks.add(task);
+		void task.then(
+			() => this.tasks.delete(task),
+			() => this.tasks.delete(task),
+		);
+		return task;
+	}
+	invoke(callback: () => void | Promise<void>): void {
+		if (this.signal.aborted) return;
+		try {
+			this.track(
+				Promise.resolve(callback()).catch((error) => {
+					this.failure = error;
+					this.controller.abort(error);
+				}),
+			);
+		} catch (error) {
+			this.failure = error;
+			this.controller.abort(error);
+		}
+	}
+	async join(): Promise<void> {
+		this.controller.abort();
+		while (this.tasks.size) await Promise.allSettled([...this.tasks]);
+	}
+	async run(tasks: Promise<void>[]): Promise<void> {
+		try {
+			await Promise.all(tasks.map((task) => this.track(task)));
+		} finally {
+			await this.join();
+		}
+	}
+}
+
+export interface ModuleLease<T> {
+	binding: T;
+	signal: AbortSignal;
+	release(): void;
+}
+
+export class SyncModule<T extends { run(): Promise<void> }> {
+	state: ModuleState;
+	private current: { binding: T; scope: SyncScope } | null = null;
+	constructor(
+		private readonly options: {
+			signal: AbortSignal;
+			prepare: ((scope: SyncScope) => Promise<T | null>) | null;
+			changed(state: ModuleState, error?: unknown): void;
+			failed(error: unknown): void;
+		},
+	) {
+		this.state = options.prepare ? "preparing" : "unsupported";
+	}
+	get available(): boolean {
+		return this.state === "ready" && this.current !== null && !this.current.scope.signal.aborted;
+	}
+	acquire(): ModuleLease<T> | null {
+		const current = this.current;
+		if (this.state !== "ready" || !current || current.scope.signal.aborted) return null;
+		let release = () => {};
+		current.scope.track(
+			new Promise<void>((resolve) => {
+				release = resolve;
+			}),
+		);
+		return { binding: current.binding, signal: current.scope.signal, release };
+	}
+	private publish(state: ModuleState, error?: unknown): void {
+		this.state = state;
+		this.options.changed(state, error);
+	}
+	async run(): Promise<void> {
+		if (!this.options.prepare) return;
+		let delay = 1000;
+		while (!this.options.signal.aborted) {
+			const scope = new SyncScope(this.options.signal);
+			const draining = () => this.publish("draining", scope.signal.reason);
+			scope.signal.addEventListener("abort", draining, { once: true });
+			let readyAt: number | null = null;
+			let failure: unknown;
+			let healthyDuration = 0;
+			this.publish("preparing");
+			try {
+				const binding = await this.options.prepare(scope);
+				scope.signal.throwIfAborted();
+				if (!binding) throw new Error("Sync preparation returned no binding");
+				this.current = { binding, scope };
+				readyAt = Date.now();
+				this.publish("ready");
+				await binding.run();
+				if (!scope.signal.aborted) throw new Error("Sync worker stopped unexpectedly");
+			} catch (error) {
+				failure = error;
+				if (!this.options.signal.aborted) this.options.failed(error);
+			} finally {
+				healthyDuration = readyAt === null ? 0 : Date.now() - readyAt;
+				this.publish("draining", failure);
+				await scope.join();
+				scope.signal.removeEventListener("abort", draining);
+				this.current = null;
+			}
+			if (this.options.signal.aborted) break;
+			if (healthyDuration >= 60000) delay = 1000;
+			this.publish("retry_wait", failure);
+			try {
+				await setTimeout(Math.round(delay * (0.8 + Math.random() * 0.4)), undefined, {
+					signal: this.options.signal,
+				});
+			} catch (error) {
+				if (!this.options.signal.aborted) throw error;
+			}
+			delay = Math.min(60000, delay * 2);
+		}
+		this.publish("stopped");
+	}
+}

--- a/packages/cli/src/serve/watcher.test.ts
+++ b/packages/cli/src/serve/watcher.test.ts
@@ -64,7 +64,9 @@ describe("skill inventory polling", () => {
 							if (!sample) throw new Error("unexpected extra poll");
 							return sample;
 						},
-						onSkillChanged: (key) => changed.push(key),
+						onSkillChanged: (key) => {
+							changed.push(key);
+						},
 						onInventoryChanged: () => {
 							inventoryChanges++;
 							abort.abort();

--- a/packages/cli/src/serve/watcher.ts
+++ b/packages/cli/src/serve/watcher.ts
@@ -1,3 +1,4 @@
+import { SyncScope } from "./sync-module";
 /**
  * Local skill-directory watcher.
  *
@@ -49,7 +50,7 @@ interface Opts {
 	 * Hermes-style category dir that holds nested skills). */
 	rootDir: string;
 	abort: AbortSignal;
-	onSkillChanged: (skillKey: string) => void;
+	onSkillChanged: (skillKey: string) => void | Promise<void>;
 	/** Force poll mode even if fs.watch is available. The serve
 	 * command sets this from CLAWDI_SERVE_MODE=container. */
 	forcePoll?: boolean;
@@ -78,10 +79,31 @@ interface Opts {
 	 * Hermes keys may be nested), so the sync engine uses this callback to
 	 * diff the adapter inventory against its durable projection claims.
 	 */
-	onInventoryChanged?: () => void;
+	onInventoryChanged?: () => void | Promise<void>;
 }
 
 export async function watchSkills(opts: Opts, delay: typeof sleep = sleep): Promise<void> {
+	const scope = new SyncScope(opts.abort);
+	const original = opts;
+	opts = {
+		...opts,
+		abort: scope.signal,
+		onSkillChanged: (key) => {
+			scope.invoke(() => original.onSkillChanged(key));
+		},
+		onInventoryChanged: () => {
+			scope.invoke(() => original.onInventoryChanged?.());
+		},
+	};
+	try {
+		await runSkillWatcher(opts, delay);
+	} finally {
+		await scope.join();
+	}
+	if (scope.failure !== undefined && !original.abort.aborted) throw scope.failure;
+}
+
+async function runSkillWatcher(opts: Opts, delay: typeof sleep): Promise<void> {
 	if (opts.forcePoll) {
 		log.info("watcher.mode", { mode: "poll", reason: "forced" });
 		await pollLoop(opts, delay);

--- a/packages/cli/tests/fixtures/hermes-dashboard-auth.py
+++ b/packages/cli/tests/fixtures/hermes-dashboard-auth.py
@@ -1,0 +1,50 @@
+"""Pinned native middleware/provider with fixture status and HTML handlers.
+
+This does not load the full Hermes gateway or build its SPA.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ["CLAWDI_TEST_HERMES_DASHBOARD_SOURCE"])
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from hermes_cli.dashboard_auth import list_session_providers, register_provider
+from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+from plugins.dashboard_auth.basic import BasicAuthProvider, hash_password
+
+register_provider(
+    BasicAuthProvider(
+        username="fixture",
+        password_hash=hash_password("fixture"),
+        secret=b"isolated-native-auth-fixture-secret",
+    )
+)
+app = FastAPI()
+app.state.auth_required = True
+app.middleware("http")(gated_auth_middleware)
+state_path = Path(sys.argv[1])
+
+
+@app.get("/api/status")
+async def status():
+    state = json.loads(state_path.read_text())
+    return {
+        "gateway_running": state["gateway"],
+        "gateway_state": "running" if state["gateway"] else "stopped",
+        "auth_required": app.state.auth_required,
+        "auth_providers": [provider.name for provider in list_session_providers()],
+    }
+
+
+@app.get("/login")
+@app.get("/")
+async def page():
+    return HTMLResponse("<!doctype html><html>Fixture login page</html>")
+
+
+uvicorn.run(app, host="127.0.0.1", port=9119, log_level="error")

--- a/packages/cli/tests/fixtures/hermes-dashboard-auth.py
+++ b/packages/cli/tests/fixtures/hermes-dashboard-auth.py
@@ -1,4 +1,4 @@
-"""Pinned native middleware/provider with fixture status and HTML handlers.
+"""Pinned native middleware, provider and login router with fixture gateway status.
 
 This does not load the full Hermes gateway or build its SPA.
 """
@@ -12,9 +12,9 @@ sys.path.insert(0, os.environ["CLAWDI_TEST_HERMES_DASHBOARD_SOURCE"])
 
 import uvicorn
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
 from hermes_cli.dashboard_auth import list_session_providers, register_provider
 from hermes_cli.dashboard_auth.middleware import gated_auth_middleware
+from hermes_cli.dashboard_auth.routes import router as _dashboard_auth_router
 from plugins.dashboard_auth.basic import BasicAuthProvider, hash_password
 
 register_provider(
@@ -27,6 +27,7 @@ register_provider(
 app = FastAPI()
 app.state.auth_required = True
 app.middleware("http")(gated_auth_middleware)
+app.include_router(_dashboard_auth_router)
 state_path = Path(sys.argv[1])
 
 
@@ -39,12 +40,6 @@ async def status():
         "auth_required": app.state.auth_required,
         "auth_providers": [provider.name for provider in list_session_providers()],
     }
-
-
-@app.get("/login")
-@app.get("/")
-async def page():
-    return HTMLResponse("<!doctype html><html>Fixture login page</html>")
 
 
 uvicorn.run(app, host="127.0.0.1", port=9119, log_level="error")

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7768,10 +7768,12 @@ fi
 				sourcePath: "https://runtime.test/v1/runtime/manifest",
 				sha256: "b".repeat(64),
 			},
+			activated: {},
 			providerIds: [],
 			projectedProviderIds: {},
 		};
 
+		writeRuntimeAppliedState(appliedState, paths);
 		const restarting = await readHostedRuntimeObserved(paths, { appliedState });
 
 		expect(restarting?.status).toBe("ok");

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6910,7 +6910,6 @@ export interface components {
             applied: components["schemas"]["HostedRuntimeObservedAppliedV2"] | null;
             boot: components["schemas"]["HostedRuntimeObservedBootV1"] | null;
             cli: components["schemas"]["HostedRuntimeObservedCliV1"] | null;
-            components?: components["schemas"]["HostedRuntimeObservedComponentsV1"] | null;
             systemd?: components["schemas"]["HostedRuntimeObservedSystemdV1"] | null;
             supervisor?: components["schemas"]["HostedRuntimeObservedSupervisorV1"] | null;
             /** Providers */

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6717,6 +6717,35 @@ export interface components {
             /** Version */
             version?: string | null;
         };
+        /** HostedRuntimeObservedComponentV1 */
+        HostedRuntimeObservedComponentV1: {
+            /**
+             * Component
+             * @enum {string}
+             */
+            component: "files" | "hermes-ui" | "openclaw-ui";
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "unknown";
+            /** Configrevision */
+            configRevision: string;
+            /** Accessrevision */
+            accessRevision: string;
+            /** Invocationid */
+            invocationId: string;
+        };
+        /** HostedRuntimeObservedComponentsV1 */
+        HostedRuntimeObservedComponentsV1: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 1;
+            /** Entries */
+            entries: components["schemas"]["HostedRuntimeObservedComponentV1"][];
+        };
         /** HostedRuntimeObservedProviderPayload */
         HostedRuntimeObservedProviderPayload: {
             [key: string]: components["schemas"]["JsonValue"];
@@ -6881,6 +6910,7 @@ export interface components {
             applied: components["schemas"]["HostedRuntimeObservedAppliedV2"] | null;
             boot: components["schemas"]["HostedRuntimeObservedBootV1"] | null;
             cli: components["schemas"]["HostedRuntimeObservedCliV1"] | null;
+            components?: components["schemas"]["HostedRuntimeObservedComponentsV1"] | null;
             systemd?: components["schemas"]["HostedRuntimeObservedSystemdV1"] | null;
             supervisor?: components["schemas"]["HostedRuntimeObservedSupervisorV1"] | null;
             /** Providers */
@@ -8216,6 +8246,7 @@ export interface components {
             applied: components["schemas"]["HostedRuntimeObservedAppliedV2"];
             boot: components["schemas"]["HostedRuntimeObservedBootV1"] | null;
             cli: components["schemas"]["HostedRuntimeObservedCliV1"] | null;
+            components?: components["schemas"]["HostedRuntimeObservedComponentsV1"] | null;
             systemd?: components["schemas"]["HostedRuntimeObservedSystemdV1"] | null;
             supervisor?: components["schemas"]["HostedRuntimeObservedSupervisorV1"] | null;
             /** Providers */

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -2258,6 +2258,8 @@ export interface components {
         };
         /** V2HermesRuntimeUiEndpointInfo */
         V2HermesRuntimeUiEndpointInfo: {
+            /** Component Readiness */
+            component_readiness?: 1 | null;
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
@@ -2564,6 +2566,8 @@ export interface components {
         };
         /** V2HostedFilesEndpointInfo */
         V2HostedFilesEndpointInfo: {
+            /** Component Readiness */
+            component_readiness?: 1 | null;
             /** Url */
             url: string;
         };
@@ -2719,6 +2723,8 @@ export interface components {
         };
         /** V2OpenClawRuntimeUiEndpointInfo */
         V2OpenClawRuntimeUiEndpointInfo: {
+            /** Component Readiness */
+            component_readiness?: 1 | null;
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}

--- a/scripts/test-systemd-command.sh
+++ b/scripts/test-systemd-command.sh
@@ -41,6 +41,8 @@ timeout --kill-after=15s 120s tar -C "$repo_root" \
 timeout --kill-after=15s 930s docker exec "$container" timeout 900 bash -euo pipefail -c '
 	cd /work
 	bun install --frozen-lockfile --ignore-scripts
+	package_root=/work/packages/cli
+	source "$package_root/scripts/prepare-hermes-dashboard-fixture.sh"
 	CLAWDI_TEST_SYSTEMD_COMMAND=1 timeout 60 bun test --isolate --max-concurrency=1 \
-		--timeout=15000 packages/cli/src/runtime/systemd.test.ts
+		--timeout=15000 packages/cli/src/runtime/systemd.test.ts packages/cli/src/runtime/hermes-dashboard-auth.test.ts
 '


### PR DESCRIPTION
Session or Skill preparation failure could terminate the entire sync engine, while aggregate runtime readiness blocked otherwise healthy component access. Add independently recoverable sync lifecycles with retained queued work, cancellation-aware adapters, tracked cleanup, leases and bounded retry. Global identity/auth revocation still stops all work.

Add optional versioned component observations bound to the committed apply receipt, configuration, service invocation and existing access revision. Hermes probes its real public login route; timestamp-only watch updates do not discard observations. Unknown component evidence never certifies aggregate health. Hosted companion readers authorize partial access; legacy clients retain aggregate admission.

Validation: focused sync/adapter, observation, schema and UI checks passed, with type checks/build/SSR. The official runtime-systemd CI lane now runs pinned real Hermes login router, middleware and BasicAuthProvider (9 tests/53 assertions locally); gateway status and systemd inputs remain fixtures. Fable approved prior implementation; final batch/fixture delta review and full CI are pending.

Deploy Cloud and Hosted readers before releasing the producing CLI. CLI version remains unchanged; no tenant upgrade is performed by this PR. Shared memory/disk/container failures remain common dependencies.
