### PR TITLE
Preserve native channel and memory configuration ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### CLI 0.14.79
+
+- Managed channel changes preserve native accounts, access policies, and independent
+  Hermes platform settings. Conflicting updates fail without replacing user credentials.
+- OpenClaw managed chat-provider changes preserve existing memory search providers,
+  models, and options, including during supported configuration migrations.
+
 ### CLI 0.14.78
 
 - Session and Skill synchronization recover independently after startup or watcher

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.78",
+      "version": "0.14.79",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.78",
+	"version": "0.14.79",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -47,6 +47,28 @@ const codexOAuthCatalog: AiProviderCatalog = {
 };
 
 describe("AI provider projection", () => {
+	test("managed chat apply and removal do not mutate native memory selection", () => {
+		const catalog: AiProviderCatalog = {
+			...byokOpenAiCatalog,
+			defaults: {},
+			providers: byokOpenAiCatalog.providers.map((provider) => ({
+				...provider,
+				id: CLAWDI_MANAGED_PROVIDER_ID,
+				type: "custom_openai_compatible",
+				runtime_env_name: "CLAWDI_AI_API_KEY",
+				managed_by: "clawdi",
+			})),
+		};
+		const primaryModel = { provider_id: CLAWDI_MANAGED_PROVIDER_ID, model: "gpt-5.6-sol" };
+		for (const input of [{ catalog, primaryModel }, null]) {
+			const patch = JSON.parse(
+				buildOpenClawHostedProviderPatch(input, [CLAWDI_MANAGED_PROVIDER_ID]).content,
+			);
+			expect(patch).not.toHaveProperty("memory");
+			expect(patch).not.toHaveProperty("agents.defaults.memorySearch");
+		}
+	});
+
 	test("projects complete keyed Hermes providers", () => {
 		const catalog: AiProviderCatalog = {
 			schema_version: 1,
@@ -350,11 +372,8 @@ describe("AI provider projection", () => {
 			memory?: { search?: { model?: null; provider?: null } };
 			models?: { providers?: Record<string, unknown> };
 		};
-		expect(managedToByokPatch.agents?.defaults?.memorySearch).toBeNull();
-		expect(managedToByokPatch.memory?.search).toEqual({
-			provider: null,
-			model: null,
-		});
+		expect(managedToByokPatch.agents?.defaults?.memorySearch).toBeUndefined();
+		expect(managedToByokPatch.memory).toBeUndefined();
 		expect(managedToByokPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toBeNull();
 
 		const hermes = buildAgentTargetProjection("hermes", byokOpenAiCatalog, primaryModel);

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -306,7 +306,6 @@ function buildOpenClawProjection(
 	primaryModel: AgentPrimaryModel | null,
 	embeddingModel: AgentPrimaryModel | undefined,
 ): string {
-	const hasClawdiManagedProvider = providers.some((provider) => provider.managed_by === "clawdi");
 	const projectedProviders = Object.fromEntries(
 		providers
 			.filter((provider) => !usesNativeCodexOpenAiProvider(provider))
@@ -347,7 +346,7 @@ function buildOpenClawProjection(
 								primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 							}
 						: undefined,
-				memorySearch: embeddingModel || hasClawdiManagedProvider ? null : undefined,
+				memorySearch: embeddingModel ? null : undefined,
 			},
 		},
 		memory: embeddingModel
@@ -357,9 +356,7 @@ function buildOpenClawProjection(
 						model: embeddingModel.model,
 					},
 				}
-			: hasClawdiManagedProvider
-				? { search: { provider: null, model: null } }
-				: undefined,
+			: undefined,
 		models:
 			Object.keys(projectedProviders).length > 0
 				? {

--- a/packages/cli/src/runtime/catalog-provider-config.ts
+++ b/packages/cli/src/runtime/catalog-provider-config.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { isClawdiManagedProviderId } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import {
@@ -300,19 +299,6 @@ function mergeProviderDeletes(
 	container.providers = providers;
 	if (runtime === "openclaw") {
 		patch.models = container;
-		if (deletedProviderIds.some(isClawdiManagedProviderId)) {
-			const agents = { ...(recordValue(patch.agents) ?? {}) };
-			const defaults = { ...(recordValue(agents.defaults) ?? {}) };
-			defaults.memorySearch = null;
-			agents.defaults = defaults;
-			patch.agents = agents;
-			const memory = { ...(recordValue(patch.memory) ?? {}) };
-			const search = { ...(recordValue(memory.search) ?? {}) };
-			if (!Object.hasOwn(search, "provider")) search.provider = null;
-			if (!Object.hasOwn(search, "model")) search.model = null;
-			memory.search = search;
-			patch.memory = memory;
-		}
 	}
 	return runtime === "openclaw"
 		? `${JSON.stringify(patch, null, 2)}\n`

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -22,33 +22,17 @@ export function buildHermesManagedChannelsPatch(
 	if (whatsappEnabled && !whatsappAuthDir) {
 		throw new Error("managed Hermes WhatsApp projection is missing its exact auth directory");
 	}
-	const whatsapp = whatsappEnabled
-		? {
-				enabled: true,
-			}
-		: {
-				enabled: false,
-			};
-	const whatsappPlatform = whatsappEnabled
-		? {
-				enabled: true,
-				extra: {
-					session_path: whatsappAuthDir,
-				},
-			}
-		: {
-				enabled: false,
-				extra: {
-					session_path: null,
-				},
-			};
 	return {
-		telegram: { enabled: telegramEnabled },
-		discord: { enabled: discordEnabled },
-		whatsapp,
-		platforms: {
-			whatsapp: whatsappPlatform,
-		},
+		...(telegramEnabled ? { telegram: { enabled: true } } : {}),
+		...(discordEnabled ? { discord: { enabled: true } } : {}),
+		...(whatsappEnabled
+			? {
+					whatsapp: { enabled: true },
+					platforms: {
+						whatsapp: { enabled: true, extra: { session_path: whatsappAuthDir } },
+					},
+				}
+			: {}),
 	};
 }
 

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -26,72 +26,8 @@ const ACCOUNT_KEY = "clawdi_whatsapp_test";
 const SECRET_REF = `secret://channels/whatsapp/${ACCOUNT_KEY}/credentials/credential-test/creds-json`;
 
 describe("native channel ownership", () => {
-	const managed = {
-		enabled: true,
-		botToken: { source: "env", provider: "default", id: "MANAGED_TOKEN" },
-	};
-	const previous = {
-		telegram: { enabled: true, defaultAccount: "managed", accounts: { managed } },
-	};
-
-	test("patches only the selected account fields and retains native preferences", () => {
-		const current = {
-			channels: {
-				telegram: {
-					defaultAccount: "personal",
-					accounts: {
-						personal: { botToken: "user-token" },
-						managed: { ...managed, dmPolicy: "pairing", allowFrom: ["owner"] },
-					},
-				},
-			},
-		};
-		const patch = openClawManagedChannelsPatch(previous, current, previous);
-		expect(patch).toMatchObject({
-			channels: { telegram: { accounts: { managed } } },
-			session: { dmScope: "per-account-channel-peer" },
-		});
-		expect(patch).not.toHaveProperty("channels.telegram.accounts.personal");
-		expect(patch).not.toHaveProperty("channels.telegram.accounts.managed.dmPolicy");
-		expect(patch).not.toHaveProperty("channels.telegram.defaultAccount");
-	});
-
-	test("unlinks only a committed account whose credential still matches", () => {
-		const current = {
-			channels: {
-				telegram: {
-					...previous.telegram,
-					accounts: {
-						managed,
-						personal: { botToken: "user-token" },
-					},
-				},
-			},
-		};
-		expect(openClawManagedChannelsPatch({}, current, previous)).toMatchObject({
-			channels: { telegram: { accounts: { managed: null }, defaultAccount: null } },
-		});
-		expect(openClawManagedChannelsPatch({}, current)).not.toHaveProperty("channels.telegram");
-		current.channels.telegram.accounts.managed = {
-			...managed,
-			botToken: { ...managed.botToken, id: "USER_TOKEN" },
-		};
-		expect(openClawManagedChannelsPatch({}, current, previous)).not.toHaveProperty(
-			"channels.telegram",
-		);
-		expect(() => openClawManagedChannelsPatch(previous, current, previous)).toThrow(
-			"unmanaged telegram account",
-		);
-	});
-
-	test("does not delete independent channels or reset DM isolation on unlink", () => {
-		const patch = openClawManagedChannelsPatch(
-			{},
-			{
-				channels: { telegram: { accounts: { personal: { botToken: "user-token" } } } },
-				session: { dmScope: "per-channel-peer" },
-			},
-		);
+	test("an empty desired projection does not carry deletion intent", () => {
+		const patch = openClawManagedChannelsPatch({});
 		expect(patch).not.toHaveProperty("channels.telegram");
 		expect(patch).not.toHaveProperty("plugins.entries.telegram");
 		expect(patch).not.toHaveProperty("session.dmScope");

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -13,15 +13,94 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildHermesManagedChannelsPatch } from "./managed-channel-reconciliation";
 import {
 	materializeHostedChannelCredentials,
 	normalizeOpenClawRuntimeVersion,
+	openClawManagedChannelsPatch,
 } from "./manifest-channels";
 import type { RuntimeManifest } from "./manifest-contract";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const ACCOUNT_KEY = "clawdi_whatsapp_test";
 const SECRET_REF = `secret://channels/whatsapp/${ACCOUNT_KEY}/credentials/credential-test/creds-json`;
+
+describe("native channel ownership", () => {
+	const managed = {
+		enabled: true,
+		botToken: { source: "env", provider: "default", id: "MANAGED_TOKEN" },
+	};
+	const previous = {
+		telegram: { enabled: true, defaultAccount: "managed", accounts: { managed } },
+	};
+
+	test("patches only the selected account fields and retains native preferences", () => {
+		const current = {
+			channels: {
+				telegram: {
+					defaultAccount: "personal",
+					accounts: {
+						personal: { botToken: "user-token" },
+						managed: { ...managed, dmPolicy: "pairing", allowFrom: ["owner"] },
+					},
+				},
+			},
+		};
+		const patch = openClawManagedChannelsPatch(previous, current, previous);
+		expect(patch).toMatchObject({
+			channels: { telegram: { accounts: { managed } } },
+			session: { dmScope: "per-account-channel-peer" },
+		});
+		expect(patch).not.toHaveProperty("channels.telegram.accounts.personal");
+		expect(patch).not.toHaveProperty("channels.telegram.accounts.managed.dmPolicy");
+		expect(patch).not.toHaveProperty("channels.telegram.defaultAccount");
+	});
+
+	test("unlinks only a committed account whose credential still matches", () => {
+		const current = {
+			channels: {
+				telegram: {
+					...previous.telegram,
+					accounts: {
+						managed,
+						personal: { botToken: "user-token" },
+					},
+				},
+			},
+		};
+		expect(openClawManagedChannelsPatch({}, current, previous)).toMatchObject({
+			channels: { telegram: { accounts: { managed: null }, defaultAccount: null } },
+		});
+		expect(openClawManagedChannelsPatch({}, current)).not.toHaveProperty("channels.telegram");
+		current.channels.telegram.accounts.managed = {
+			...managed,
+			botToken: { ...managed.botToken, id: "USER_TOKEN" },
+		};
+		expect(openClawManagedChannelsPatch({}, current, previous)).not.toHaveProperty(
+			"channels.telegram",
+		);
+		expect(() => openClawManagedChannelsPatch(previous, current, previous)).toThrow(
+			"unmanaged telegram account",
+		);
+	});
+
+	test("does not delete independent channels or reset DM isolation on unlink", () => {
+		const patch = openClawManagedChannelsPatch(
+			{},
+			{
+				channels: { telegram: { accounts: { personal: { botToken: "user-token" } } } },
+				session: { dmScope: "per-channel-peer" },
+			},
+		);
+		expect(patch).not.toHaveProperty("channels.telegram");
+		expect(patch).not.toHaveProperty("plugins.entries.telegram");
+		expect(patch).not.toHaveProperty("session.dmScope");
+	});
+
+	test("does not disable independently configured Hermes platforms on unlink", () => {
+		expect(buildHermesManagedChannelsPatch({}, null)).toEqual({});
+	});
+});
 
 let root: string;
 let home: string;

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -13,11 +13,16 @@ import { join, resolve } from "node:path";
 import type { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { isValidSemver } from "../lib/semver";
-import { type HermesConfigTransaction, reconcileHermesConfigValue } from "./hermes-config";
+import {
+	getHermesRawConfigValue,
+	type HermesConfigTransaction,
+	reconcileHermesConfigValue,
+} from "./hermes-config";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
 import {
 	buildHermesManagedChannelsPatch,
 	managedChannelHasAccounts,
+	managedHermesWhatsAppAuthDir,
 } from "./managed-channel-reconciliation";
 import type { RuntimeManifest } from "./manifest-contract";
 import {
@@ -411,6 +416,7 @@ export function applyHostedChannelProjection(
 	workspaceRoot: string,
 	hermesWhatsAppAuthDir: string | null,
 	hermesConfig: HermesConfigTransaction | null,
+	previousManifest: RuntimeManifest | null = null,
 ): boolean {
 	if (name !== "openclaw" && name !== "hermes") return false;
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
@@ -421,22 +427,31 @@ export function applyHostedChannelProjection(
 
 	if (name === "hermes") {
 		if (!hermesConfig) throw new Error("Hermes config command is unavailable");
-		return applyHermesChannelConfig(
-			hermesConfig,
-			buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
-		);
+		const patch = buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir);
+		const previousAuthDir = previousManifest
+			? managedHermesWhatsAppAuthDir(previousManifest, home)
+			: null;
+		if (
+			!hermesWhatsAppAuthDir &&
+			previousAuthDir &&
+			getHermesRawConfigValue(hermesConfig, "platforms.whatsapp.extra.session_path").value ===
+				previousAuthDir
+		) {
+			patch.platforms = { whatsapp: { extra: { session_path: null } } };
+		}
+		return applyHermesChannelConfig(hermesConfig, patch);
 	}
 	const currentConfig = readOpenClawConfig(openClawContext.configPath);
-	const patch = openClawManagedChannelsPatch(channels, currentConfig);
-	if (
-		openClawConfigPatchIsApplied(openClawContext, patch) &&
-		openClawManagedAccountMapsAreApplied(currentConfig, patch, channels)
-	) {
-		return false;
-	}
+	const patch = openClawManagedChannelsPatch(
+		channels,
+		currentConfig,
+		previousManifest ? hostedChannelProjection(previousManifest) : null,
+	);
+	if (openClawConfigPatchIsApplied(openClawContext, patch)) return false;
+
 	runRuntimeUserCommand(
 		observation.commandPath,
-		["config", "patch", "--stdin", ...openClawManagedAccountReplaceArgs(channels)],
+		["config", "patch", "--stdin"],
 		`${JSON.stringify(patch, null, 2)}\n`,
 		home,
 		workspaceRoot,
@@ -471,22 +486,22 @@ function openClawManagedChannelUsesEnvSecretRefs(channels: Record<string, unknow
 export function openClawManagedChannelsPatch(
 	channels: Record<string, unknown>,
 	currentConfig: Record<string, unknown> | null = null,
+	previousChannels: Record<string, unknown> | null = null,
 ): Record<string, unknown> {
-	const deleteEntries = openClawManagedChannelDeletes();
 	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(channels);
 	const isolatesManagedDms =
 		managedChannelHasAccounts(channels.telegram) ||
 		managedChannelHasAccounts(channels.discord) ||
 		managedChannelHasAccounts(channels.whatsapp);
-	const effectiveChannels = mergeOpenClawManagedAccountPreferences(channels, currentConfig);
+	const effectiveChannels = mergeOpenClawManagedAccountPreferences(
+		channels,
+		currentConfig,
+		previousChannels,
+	);
 	return {
-		channels: {
-			...deleteEntries,
-			...effectiveChannels,
-		},
+		channels: effectiveChannels,
 		plugins: {
 			entries: {
-				...deleteEntries,
 				...channelPluginEntries(channels),
 			},
 		},
@@ -500,9 +515,7 @@ export function openClawManagedChannelsPatch(
 					},
 				}
 			: undefined,
-		session: {
-			dmScope: isolatesManagedDms ? "per-account-channel-peer" : null,
-		},
+		...(isolatesManagedDms ? { session: { dmScope: "per-account-channel-peer" } } : {}),
 	};
 }
 
@@ -517,74 +530,77 @@ function readOpenClawConfig(path: string): Record<string, unknown> | null {
 function mergeOpenClawManagedAccountPreferences(
 	channels: Record<string, unknown>,
 	currentConfig: Record<string, unknown> | null,
+	previousChannels: Record<string, unknown> | null,
 ): Record<string, unknown> {
 	const currentChannels = recordValue(currentConfig?.channels);
-	if (!currentChannels) return channels;
-	const mergedChannels = { ...channels };
+	const patches: Record<string, unknown> = {};
 	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
 		const desiredChannel = recordValue(channels[provider]);
-		const desiredAccounts = recordValue(desiredChannel?.accounts);
-		if (!desiredChannel || !desiredAccounts) continue;
-		const currentAccounts = recordValue(recordValue(currentChannels[provider])?.accounts);
-		const mergedAccounts: Record<string, unknown> = {};
-		for (const [accountId, desiredValue] of Object.entries(desiredAccounts)) {
-			const desiredAccount = recordValue(desiredValue);
-			if (!desiredAccount) {
-				mergedAccounts[accountId] = desiredValue;
+		const desiredAccounts = recordValue(desiredChannel?.accounts) ?? {};
+		const currentChannel = recordValue(currentChannels?.[provider]);
+		const currentAccounts = recordValue(currentChannel?.accounts) ?? {};
+		const previousChannel = recordValue(previousChannels?.[provider]);
+		const previousAccounts = recordValue(previousChannel?.accounts) ?? {};
+		const accounts: Record<string, unknown> = {};
+		const credentialField =
+			provider === "telegram" ? "botToken" : provider === "discord" ? "token" : "authDir";
+		const matchesCredential = (current: unknown, expected: unknown): boolean => {
+			const actual = recordValue(current);
+			const owned = recordValue(expected);
+			return Boolean(
+				actual &&
+					owned &&
+					Object.hasOwn(owned, credentialField) &&
+					canonicalJsonEqual(actual[credentialField], owned[credentialField]),
+			);
+		};
+		for (const [accountId, previous] of Object.entries(previousAccounts)) {
+			if (
+				!Object.hasOwn(desiredAccounts, accountId) &&
+				matchesCredential(currentAccounts[accountId], previous)
+			) {
+				accounts[accountId] = null;
+			}
+		}
+		for (const [accountId, value] of Object.entries(desiredAccounts)) {
+			const desired = recordValue(value);
+			if (!desired) throw new Error(`Invalid managed ${provider} account`);
+			if (!Object.hasOwn(currentAccounts, accountId)) {
+				accounts[accountId] = desired;
 				continue;
 			}
-			const currentAccount = recordValue(currentAccounts?.[accountId]);
-			const mergedAccount = { ...desiredAccount, ...(currentAccount ?? {}) };
-			for (const key of openClawManagedAccountFields(provider)) {
-				if (Object.hasOwn(desiredAccount, key)) mergedAccount[key] = desiredAccount[key];
+			if (
+				!matchesCredential(currentAccounts[accountId], desired) &&
+				!matchesCredential(currentAccounts[accountId], previousAccounts[accountId])
+			) {
+				throw new Error(`refusing to replace unmanaged ${provider} account ${accountId}`);
 			}
-			mergedAccounts[accountId] = mergedAccount;
+			// Patch only managed fields; native policies and concurrent sibling edits stay native.
+			accounts[accountId] = {
+				enabled: desired.enabled,
+				[credentialField]: desired[credentialField],
+			};
 		}
-		mergedChannels[provider] = { ...desiredChannel, accounts: mergedAccounts };
+		if (Object.keys(accounts).length === 0) continue;
+		const patch: Record<string, unknown> = {
+			...(desiredChannel ? { enabled: true } : {}),
+			accounts,
+		};
+		const currentDefault = currentChannel?.defaultAccount;
+		if (!currentChannel && desiredChannel?.defaultAccount !== undefined) {
+			patch.defaultAccount = desiredChannel.defaultAccount;
+		} else if (
+			typeof currentDefault === "string" &&
+			accounts[currentDefault] === null &&
+			previousChannel?.defaultAccount === currentDefault
+		) {
+			patch.defaultAccount = desiredChannel?.defaultAccount ?? null;
+		}
+		patches[provider] = patch;
 	}
-	return mergedChannels;
+	return patches;
 }
 
-function openClawManagedAccountFields(
-	provider: (typeof OPENCLAW_MANAGED_CHANNELS)[number],
-): readonly string[] {
-	if (provider === "telegram") return ["enabled", "botToken"];
-	if (provider === "discord") return ["enabled", "token"];
-	return ["enabled", "authDir"];
-}
-
-function openClawManagedAccountMapsAreApplied(
-	currentConfig: Record<string, unknown> | null,
-	patch: Record<string, unknown>,
-	channels: Record<string, unknown>,
-): boolean {
-	const currentChannels = recordValue(currentConfig?.channels);
-	const patchedChannels = recordValue(patch.channels);
-	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
-		const desiredAccounts = recordValue(recordValue(channels[provider])?.accounts);
-		if (!desiredAccounts) continue;
-		if (!currentChannels || !patchedChannels) return false;
-		const currentAccounts = recordValue(recordValue(currentChannels[provider])?.accounts);
-		const patchedAccounts = recordValue(recordValue(patchedChannels[provider])?.accounts);
-		if (!canonicalJsonEqual(currentAccounts, patchedAccounts)) return false;
-	}
-	return true;
-}
-function openClawManagedAccountReplaceArgs(channels: Record<string, unknown>): string[] {
-	const args: string[] = [];
-	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
-		const channel = channels[provider];
-		if (!isPlainRecord(channel) || !isPlainRecord(channel.accounts)) continue;
-		args.push("--replace-path", `channels.${provider}.accounts`);
-	}
-	return args;
-}
-function openClawManagedChannelDeletes(): Record<string, null> {
-	return Object.fromEntries(OPENCLAW_MANAGED_CHANNELS.map((channel) => [channel, null])) as Record<
-		string,
-		null
-	>;
-}
 function installOpenClawChannelPlugins(input: {
 	commandPath: string;
 	channels: Record<string, unknown>;

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -31,10 +31,10 @@ import {
 	runtimeCommandVersion,
 	runtimeFileCurrentRevision,
 } from "./manifest-install";
-import { openClawConfigPatchIsApplied } from "./manifest-providers";
-import { canonicalJsonEqual, isPlainRecord, recordValue } from "./manifest-shared";
+import { isPlainRecord, recordValue } from "./manifest-shared";
 import { openClawPluginCapabilityConsentArgs } from "./openclaw-plugin-cli";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
+import { applyOpenClawHostedChannelPatch } from "./openclaw-provider-config";
 import {
 	runRuntimeUserCommand,
 	spawnRuntimeUserCommand,
@@ -441,19 +441,11 @@ export function applyHostedChannelProjection(
 		}
 		return applyHermesChannelConfig(hermesConfig, patch);
 	}
-	const currentConfig = readOpenClawConfig(openClawContext.configPath);
-	const patch = openClawManagedChannelsPatch(
-		channels,
-		currentConfig,
+	applyOpenClawHostedChannelPatch(
+		openClawManagedChannelsPatch(channels),
 		previousManifest ? hostedChannelProjection(previousManifest) : null,
-	);
-	if (openClawConfigPatchIsApplied(openClawContext, patch)) return false;
-
-	runRuntimeUserCommand(
-		observation.commandPath,
-		["config", "patch", "--stdin"],
-		`${JSON.stringify(patch, null, 2)}\n`,
-		home,
+		Object.keys(manifest.runtimes.openclaw?.run?.secretEnv ?? {}),
+		openClawContext,
 		workspaceRoot,
 	);
 	return true;
@@ -485,21 +477,15 @@ function openClawManagedChannelUsesEnvSecretRefs(channels: Record<string, unknow
 }
 export function openClawManagedChannelsPatch(
 	channels: Record<string, unknown>,
-	currentConfig: Record<string, unknown> | null = null,
-	previousChannels: Record<string, unknown> | null = null,
 ): Record<string, unknown> {
 	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(channels);
 	const isolatesManagedDms =
 		managedChannelHasAccounts(channels.telegram) ||
 		managedChannelHasAccounts(channels.discord) ||
 		managedChannelHasAccounts(channels.whatsapp);
-	const effectiveChannels = mergeOpenClawManagedAccountPreferences(
-		channels,
-		currentConfig,
-		previousChannels,
-	);
+
 	return {
-		channels: effectiveChannels,
+		channels,
 		plugins: {
 			entries: {
 				...channelPluginEntries(channels),
@@ -517,88 +503,6 @@ export function openClawManagedChannelsPatch(
 			: undefined,
 		...(isolatesManagedDms ? { session: { dmScope: "per-account-channel-peer" } } : {}),
 	};
-}
-
-function readOpenClawConfig(path: string): Record<string, unknown> | null {
-	try {
-		return recordValue(JSON.parse(readFileSync(path, "utf-8")) as unknown);
-	} catch {
-		return null;
-	}
-}
-
-function mergeOpenClawManagedAccountPreferences(
-	channels: Record<string, unknown>,
-	currentConfig: Record<string, unknown> | null,
-	previousChannels: Record<string, unknown> | null,
-): Record<string, unknown> {
-	const currentChannels = recordValue(currentConfig?.channels);
-	const patches: Record<string, unknown> = {};
-	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
-		const desiredChannel = recordValue(channels[provider]);
-		const desiredAccounts = recordValue(desiredChannel?.accounts) ?? {};
-		const currentChannel = recordValue(currentChannels?.[provider]);
-		const currentAccounts = recordValue(currentChannel?.accounts) ?? {};
-		const previousChannel = recordValue(previousChannels?.[provider]);
-		const previousAccounts = recordValue(previousChannel?.accounts) ?? {};
-		const accounts: Record<string, unknown> = {};
-		const credentialField =
-			provider === "telegram" ? "botToken" : provider === "discord" ? "token" : "authDir";
-		const matchesCredential = (current: unknown, expected: unknown): boolean => {
-			const actual = recordValue(current);
-			const owned = recordValue(expected);
-			return Boolean(
-				actual &&
-					owned &&
-					Object.hasOwn(owned, credentialField) &&
-					canonicalJsonEqual(actual[credentialField], owned[credentialField]),
-			);
-		};
-		for (const [accountId, previous] of Object.entries(previousAccounts)) {
-			if (
-				!Object.hasOwn(desiredAccounts, accountId) &&
-				matchesCredential(currentAccounts[accountId], previous)
-			) {
-				accounts[accountId] = null;
-			}
-		}
-		for (const [accountId, value] of Object.entries(desiredAccounts)) {
-			const desired = recordValue(value);
-			if (!desired) throw new Error(`Invalid managed ${provider} account`);
-			if (!Object.hasOwn(currentAccounts, accountId)) {
-				accounts[accountId] = desired;
-				continue;
-			}
-			if (
-				!matchesCredential(currentAccounts[accountId], desired) &&
-				!matchesCredential(currentAccounts[accountId], previousAccounts[accountId])
-			) {
-				throw new Error(`refusing to replace unmanaged ${provider} account ${accountId}`);
-			}
-			// Patch only managed fields; native policies and concurrent sibling edits stay native.
-			accounts[accountId] = {
-				enabled: desired.enabled,
-				[credentialField]: desired[credentialField],
-			};
-		}
-		if (Object.keys(accounts).length === 0) continue;
-		const patch: Record<string, unknown> = {
-			...(desiredChannel ? { enabled: true } : {}),
-			accounts,
-		};
-		const currentDefault = currentChannel?.defaultAccount;
-		if (!currentChannel && desiredChannel?.defaultAccount !== undefined) {
-			patch.defaultAccount = desiredChannel.defaultAccount;
-		} else if (
-			typeof currentDefault === "string" &&
-			accounts[currentDefault] === null &&
-			previousChannel?.defaultAccount === currentDefault
-		) {
-			patch.defaultAccount = desiredChannel?.defaultAccount ?? null;
-		}
-		patches[provider] = patch;
-	}
-	return patches;
 }
 
 function installOpenClawChannelPlugins(input: {
@@ -767,4 +671,3 @@ export function normalizeOpenClawRuntimeVersion(output: string): string | null {
 export const OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS: Record<string, readonly string[]> = {
 	discord: ["@openclaw/discord"],
 };
-const OPENCLAW_MANAGED_CHANNELS = ["telegram", "discord", "whatsapp"] as const;

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -99,7 +99,7 @@ import {
 } from "./manifest-secrets";
 import type { RuntimeConvergenceResult } from "./manifest-shared";
 import { reconcileHostedSkillProjection } from "./manifest-skills-apply";
-import type { RuntimeManifestLoad } from "./manifest-source";
+import { loadCommittedRuntimeManifest, type RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { removeLegacyManagedOpenClawProviderPlugin } from "./openclaw-legacy-provider-plugin";
 import type { RuntimePaths } from "./paths";
@@ -152,6 +152,7 @@ interface RuntimeConvergenceContext {
 	egressProfileBundle: ReturnType<typeof buildEgressProfileBundle>;
 	plannedEgressProfileBundlePath: string | null;
 	appliedState: ReturnType<typeof readRuntimeAppliedState>;
+	previousChannelManifest: RuntimeManifest | null;
 	previousProjectedProviderIds: Record<string, string[]>;
 	providerOwnership: ProviderOwnership;
 	connectionPlans: Record<string, PreparedConnectionProviderTransfers>;
@@ -280,6 +281,15 @@ function initializeRuntimeConvergence(
 		? paths.egressProfileBundle
 		: null;
 	const appliedState = readRuntimeAppliedState(paths);
+	// Reuse committed content authority, never provider names, to authorize channel removal.
+	const committed = appliedState ? loadCommittedRuntimeManifest(paths, applyContext) : null;
+	const previousChannelManifest =
+		committed &&
+		"manifest" in committed &&
+		committed.manifest.instanceId === manifest.instanceId &&
+		committed.manifest.deploymentId === manifest.deploymentId
+			? committed.manifest
+			: null;
 	const providerOwnership = readProviderOwnership(
 		paths,
 		manifest.instanceId,
@@ -344,6 +354,7 @@ function initializeRuntimeConvergence(
 			egressProfileBundle,
 			plannedEgressProfileBundlePath,
 			appliedState,
+			previousChannelManifest,
 			previousProjectedProviderIds,
 			providerOwnership,
 			connectionPlans: {},
@@ -1057,6 +1068,7 @@ function applyRuntimeEntryProjections(
 					workspaceRoot,
 					hermesWhatsAppAuthDir,
 					hermesConfig,
+					context.previousChannelManifest,
 				);
 			} catch (error) {
 				state.installErrors.push(

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -22,6 +22,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { commitRuntimeAppliedState } from "../commands/runtime";
 import { installHermesNativeFixture } from "../test-support/hermes-native-fixture";
+import { writeFakeOpenClawConfigMutationSdk } from "../test-support/openclaw-config-mutation";
 import {
 	readRuntimeAppliedState,
 	runtimeContentSha256,
@@ -774,74 +775,6 @@ esac
 `,
 	);
 	chmodSync(input.path, 0o700);
-}
-
-function writeFakeOpenClawConfigMutationSdk(
-	home: string,
-	options: {
-		importLog?: string;
-		initialConfig?: Record<string, unknown>;
-		beforeMutation?: Record<string, unknown>;
-	} = {},
-): string {
-	const { importLog, initialConfig = {} } = options;
-	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
-	const configPath = join(home, ".openclaw", "openclaw.json");
-	mkdirSync(packageRoot, { recursive: true });
-	mkdirSync(dirname(configPath), { recursive: true });
-	writeFileSync(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`);
-	writeFileSync(
-		join(packageRoot, "package.json"),
-		JSON.stringify({
-			name: "openclaw",
-			type: "module",
-			exports: {
-				"./plugin-sdk/config-mutation": "./config-mutation.mjs",
-				"./plugin-sdk/device-bootstrap": "./device-bootstrap.mjs",
-				"./plugin-sdk/provider-auth": "./provider-auth.mjs",
-			},
-		}),
-	);
-	const logImport = (name: string) =>
-		importLog
-			? `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(importLog)}, ${JSON.stringify(`${name}\n`)});\n`
-			: "";
-	writeFileSync(
-		join(packageRoot, "config-mutation.mjs"),
-		`${logImport("config-mutation")}import { readFileSync, writeFileSync } from "node:fs";
-const configPath = ${JSON.stringify(configPath)};
-const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
-const hasLegacyMemorySearch = (config) => {
-  const agents = isRecord(config) ? config.agents : undefined;
-  const defaults = isRecord(agents) ? agents.defaults : undefined;
-  return isRecord(defaults) && Object.hasOwn(defaults, "memorySearch");
-};
-export async function readConfigFileSnapshotForWrite() {
-  const config = JSON.parse(readFileSync(configPath, "utf8"));
-  return { snapshot: { valid: !hasLegacyMemorySearch(config), config, sourceConfig: structuredClone(config) } };
-}
-export async function mutateConfigFile(options) {
-  ${options.beforeMutation ? `writeFileSync(configPath, ${JSON.stringify(JSON.stringify(options.beforeMutation))});` : ""}
-  const config = JSON.parse(readFileSync(configPath, "utf8"));
-  await options.mutate(config, { snapshot: {}, previousHash: null, attempt: 1 });
-  if (hasLegacyMemorySearch(config)) throw new Error("OpenClaw config validation failed");
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
-}
-`,
-	);
-	writeFileSync(
-		join(packageRoot, "device-bootstrap.mjs"),
-		`${logImport("device-bootstrap")}export const normalizeDeviceBootstrapProfile = (profile) => profile;\n`,
-	);
-	writeFileSync(
-		join(packageRoot, "provider-auth.mjs"),
-		`${logImport("provider-auth")}export const ensureAuthProfileStoreForLocalUpdate = () => ({ profiles: {} });
-export const updateAuthProfileStoreWithLock = async () => ({});
-export const listProfilesForProvider = () => [];
-export const removeProviderAuthProfilesWithLock = async () => ({});
-`,
-	);
-	return configPath;
 }
 
 type FileBrowserCompanion = NonNullable<NonNullable<RuntimeManifest["companions"]>["filebrowser"]>;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -35,6 +35,7 @@ import type {
 import type { HostedAgentPluginCommandRunner } from "./hosted-agent-plugin-runtime";
 import { resolveHostedBundledSkill } from "./hosted-bundled-skill";
 import { hostedHermesSkillSourceMatches } from "./hosted-hermes-skill";
+import { createOpenClawHostedContext } from "./hosted-openclaw-context";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSkill } from "./hosted-sourced-skill-archive";
 import {
@@ -49,6 +50,7 @@ import {
 	type RuntimeManifest,
 	type RuntimePrivateAppliedAuthority,
 } from "./manifest";
+import { openClawManagedChannelsPatch } from "./manifest-channels";
 import {
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
@@ -64,6 +66,7 @@ import {
 	type HostedSkillSource,
 } from "./manifest-resources";
 import { parseHostedRuntimeBundleV2, type RuntimeManifestLoad } from "./manifest-source";
+import { applyOpenClawHostedChannelPatch } from "./openclaw-provider-config";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import {
@@ -775,7 +778,11 @@ esac
 
 function writeFakeOpenClawConfigMutationSdk(
 	home: string,
-	options: { importLog?: string; initialConfig?: Record<string, unknown> } = {},
+	options: {
+		importLog?: string;
+		initialConfig?: Record<string, unknown>;
+		beforeMutation?: Record<string, unknown>;
+	} = {},
 ): string {
 	const { importLog, initialConfig = {} } = options;
 	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
@@ -814,6 +821,7 @@ export async function readConfigFileSnapshotForWrite() {
   return { snapshot: { valid: !hasLegacyMemorySearch(config), config, sourceConfig: structuredClone(config) } };
 }
 export async function mutateConfigFile(options) {
+  ${options.beforeMutation ? `writeFileSync(configPath, ${JSON.stringify(JSON.stringify(options.beforeMutation))});` : ""}
   const config = JSON.parse(readFileSync(configPath, "utf8"));
   await options.mutate(config, { snapshot: {}, previousHash: null, attempt: 1 });
   if (hasLegacyMemorySearch(config)) throw new Error("OpenClaw config validation failed");
@@ -2671,6 +2679,120 @@ fi
 		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(restored);
 	});
 
+	test.each(["update", "delete"])(
+		"guards channel %s against credential replacement before native mutation",
+		(operation) => {
+			const paths = tempRuntimePaths();
+			const managed = {
+				enabled: true,
+				botToken: { source: "env", provider: "default", id: "CLAWDI_CHANNEL_TEST_AGENT_TOKEN" },
+			};
+			const previous = {
+				telegram: { enabled: true, defaultAccount: "managed", accounts: { managed } },
+			};
+			const edited = {
+				channels: {
+					telegram: {
+						defaultAccount: "personal",
+						accounts: {
+							managed: {
+								enabled: true,
+								botToken: "native-replacement",
+								dmPolicy: "pairing",
+								allowFrom: ["owner"],
+							},
+							personal: { enabled: true, botToken: "native-personal" },
+						},
+					},
+				},
+				session: { dmScope: "per-channel-peer" },
+			};
+			const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
+				initialConfig: { channels: previous },
+				beforeMutation: edited,
+			});
+			const context = createOpenClawHostedContext(baseManifest(paths, {}), paths.userHome);
+			const apply = () =>
+				applyOpenClawHostedChannelPatch(
+					openClawManagedChannelsPatch(operation === "update" ? previous : {}),
+					previous,
+					operation === "update" ? [managed.botToken.id] : [],
+					context,
+					paths.userHome,
+				);
+			if (operation === "update") expect(apply).toThrow("ownership changed");
+			else apply();
+			const result = JSON.parse(readFileSync(configPath, "utf8"));
+			expect(result.channels).toEqual(edited.channels);
+			expect(result.session).toEqual(edited.session);
+		},
+	);
+
+	test("native channel unlink removes only committed accounts and rejects unowned missing refs", () => {
+		const paths = tempRuntimePaths();
+		const managed = {
+			enabled: true,
+			botToken: { source: "env", provider: "default", id: "CLAWDI_CHANNEL_TEST_AGENT_TOKEN" },
+		};
+		const previous = {
+			telegram: { enabled: true, defaultAccount: "managed", accounts: { managed } },
+		};
+		const native = { enabled: true, botToken: "native-personal", dmPolicy: "pairing" };
+		const original = {
+			channels: { telegram: { ...previous.telegram, accounts: { managed, personal: native } } },
+		};
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
+			initialConfig: original,
+		});
+		const context = createOpenClawHostedContext(baseManifest(paths, {}), paths.userHome);
+		expect(() =>
+			applyOpenClawHostedChannelPatch(
+				openClawManagedChannelsPatch({}),
+				null,
+				[],
+				context,
+				paths.userHome,
+			),
+		).toThrow("withdrawn managed credential");
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(original);
+		const command = join(paths.userHome, ".local", "bin", "openclaw");
+		writeFakeGatewayCli({
+			path: command,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
+		const desired = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					services: {},
+					providerMode: "unmanaged",
+					run: runSettings(command, ["gateway", "run"]),
+				},
+			},
+			{ projection: { channels: {} } },
+		);
+		const failed = convergeRuntimeManifest(
+			manifestLoad(desired, "missing-channel-ownership"),
+			paths,
+		);
+		expect(failed.installErrors.join("\n")).toContain("withdrawn managed credential");
+		expect(failed.outputs.manifestLastGood).toBeNull();
+		expect(existsSync(paths.appliedState)).toBe(false);
+		expect(existsSync(paths.manifestLastGood)).toBe(false);
+		applyOpenClawHostedChannelPatch(
+			openClawManagedChannelsPatch({}),
+			previous,
+			[],
+			context,
+			paths.userHome,
+		);
+		const result = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(result.channels.telegram.accounts).toEqual({ personal: native });
+		expect(result.channels.telegram).not.toHaveProperty("defaultAccount");
+	});
+
 	test.each(["legacy", "current"])(
 		"preserves user memory selection in the %s layout and keeps the provider key out of agent env",
 		(layout) => {
@@ -2679,6 +2801,7 @@ fi
 				provider: "local",
 				model: "user-embedding-model",
 				cache: { enabled: false },
+				query: { hybrid: { enabled: true, vectorWeight: 0.7 }, maxResults: 9 },
 			};
 			const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
 				initialConfig:
@@ -2686,9 +2809,10 @@ fi
 						? {
 								agents: {
 									defaults: {
-										memorySearch: search,
+										memorySearch: { ...search, query: { hybrid: search.query.hybrid } },
 									},
 								},
+								memory: { search: { query: { maxResults: 9 } } },
 							}
 						: { memory: { search } },
 			});

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2671,95 +2671,107 @@ fi
 		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(restored);
 	});
 
-	test("repairs legacy managed memory config and keeps the provider key out of agent env", () => {
-		const paths = tempRuntimePaths();
-		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
-			initialConfig: {
-				agents: {
-					defaults: {
-						memorySearch: { provider: "clawdi", model: "legacy-embedding-model" },
+	test.each(["legacy", "current"])(
+		"preserves user memory selection in the %s layout and keeps the provider key out of agent env",
+		(layout) => {
+			const paths = tempRuntimePaths();
+			const search = {
+				provider: "local",
+				model: "user-embedding-model",
+				cache: { enabled: false },
+			};
+			const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
+				initialConfig:
+					layout === "legacy"
+						? {
+								agents: {
+									defaults: {
+										memorySearch: search,
+									},
+								},
+							}
+						: { memory: { search } },
+			});
+			writeFakeGatewayCli({
+				path: join(paths.userHome, ".local", "bin", "openclaw"),
+				runtime: "openclaw",
+				unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+			});
+			const hosted = hostedRuntimeBundleV2ManifestSchema.parse(
+				hostedManifestFixture({
+					providers: {
+						default: {
+							kind: "openai-compatible",
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl: "https://api.example.test/v1",
+							models: [
+								{ id: "gpt-test" },
+								{
+									id: "test-embedding-model",
+									capabilities: { embeddings: true, chat: false },
+								},
+							],
+							apiMode: "openai_responses",
+							runtimeEnvName: "CLAWDI_AI_API_KEY",
+							apiKeySecretRef: "secret://providers/default/api-key",
+						},
+					},
+				}),
+			);
+			const manifest = {
+				...hosted,
+				egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-provider-model"),
+			};
+			const provider = hostedAiProviderCatalog(manifest, "openclaw")?.catalog.providers[0];
+			expect(provider?.runtime_env_name).toBe("CLAWDI_AI_API_KEY");
+
+			const result = convergeRuntimeManifest(
+				manifestLoad(manifest, "inline-managed-provider", {
+					...TEST_HOSTED_SECRET_VALUES,
+					"secret://providers/default/api-key": "sk-managed",
+				}),
+				paths,
+			);
+
+			expect(result.installErrors).toEqual([]);
+			expect(result.projectedProviderIds.openclaw).toEqual(["clawdi-managed"]);
+			const config = JSON.parse(readFileSync(configPath, "utf8"));
+			expect(config.agents.defaults).not.toHaveProperty("memorySearch");
+			expect(config).toMatchObject({
+				memory: {
+					search: {
+						...search,
 					},
 				},
-			},
-		});
-		writeFakeGatewayCli({
-			path: join(paths.userHome, ".local", "bin", "openclaw"),
-			runtime: "openclaw",
-			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
-		});
-		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(
-			hostedManifestFixture({
-				providers: {
-					default: {
-						kind: "openai-compatible",
-						type: "custom_openai_compatible",
-						managed_by: "clawdi",
-						baseUrl: "https://api.example.test/v1",
-						models: [
-							{ id: "gpt-test" },
-							{
-								id: "test-embedding-model",
-								capabilities: { embeddings: true, chat: false },
+				models: {
+					providers: {
+						"clawdi-managed": {
+							apiKey: {
+								source: "env",
+								provider: "default",
+								id: "CLAWDI_AI_API_KEY",
 							},
-						],
-						apiMode: "openai_responses",
-						runtimeEnvName: "CLAWDI_AI_API_KEY",
-						apiKeySecretRef: "secret://providers/default/api-key",
-					},
-				},
-			}),
-		);
-		const manifest = {
-			...hosted,
-			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-provider-model"),
-		};
-		const provider = hostedAiProviderCatalog(manifest, "openclaw")?.catalog.providers[0];
-		expect(provider?.runtime_env_name).toBe("CLAWDI_AI_API_KEY");
-
-		const result = convergeRuntimeManifest(
-			manifestLoad(manifest, "inline-managed-provider", {
-				...TEST_HOSTED_SECRET_VALUES,
-				"secret://providers/default/api-key": "sk-managed",
-			}),
-			paths,
-		);
-
-		expect(result.installErrors).toEqual([]);
-		expect(result.projectedProviderIds.openclaw).toEqual(["clawdi-managed"]);
-		const config = JSON.parse(readFileSync(configPath, "utf8"));
-		expect(config.agents.defaults).not.toHaveProperty("memorySearch");
-		expect(config).toMatchObject({
-			memory: {
-				search: {
-					provider: "clawdi-managed",
-					model: "test-embedding-model",
-				},
-			},
-			models: {
-				providers: {
-					"clawdi-managed": {
-						apiKey: {
-							source: "env",
-							provider: "default",
-							id: "CLAWDI_AI_API_KEY",
 						},
 					},
 				},
-			},
-		});
-		const runConfig = JSON.parse(readFileSync(runtimeRunConfigPath("openclaw", paths), "utf8")) as {
-			env?: Record<string, string>;
-		};
-		expect(runConfig.env?.CLAWDI_AI_API_KEY).toBe("clawdi-egress-placeholder");
-		expect(runConfig.env?.OPENAI_API_KEY).toBeUndefined();
-		const envFile = readFileSync(
-			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
-			"utf8",
-		);
-		expect(envFile).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
-		expect(envFile).not.toMatch(/^OPENAI_API_KEY=/m);
-		expect(envFile).not.toContain("sk-managed");
-	});
+			});
+			const runConfig = JSON.parse(
+				readFileSync(runtimeRunConfigPath("openclaw", paths), "utf8"),
+			) as {
+				env?: Record<string, string>;
+			};
+			expect(runConfig.env?.CLAWDI_AI_API_KEY).toBe("clawdi-egress-placeholder");
+			expect(runConfig.env?.OPENAI_API_KEY).toBeUndefined();
+			const envFile = readFileSync(
+				join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
+				"utf8",
+			);
+			expect(envFile).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
+			expect(envFile).not.toMatch(/^OPENAI_API_KEY=/m);
+			expect(envFile).not.toContain("sk-managed");
+		},
+	);
 
 	test("reuses OpenClaw probes until the provider revision changes", () => {
 		const paths = tempRuntimePaths();

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { commitRuntimeAppliedState } from "../commands/runtime";
+import { writeFakeOpenClawConfigMutationSdk } from "../test-support/openclaw-config-mutation";
 import { ensureTestOpenClawWorkspaceCli } from "../test-support/runtime-workspace";
 import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
@@ -805,15 +806,30 @@ esac
 		expect(readFileSync(commandLog, "utf8")).not.toContain("doctor --fix");
 	});
 
-	test("repairs managed OpenClaw channel config drift", () => {
+	test("repairs managed OpenClaw account drift without replacing native siblings or policies", () => {
 		const paths = tempRuntimePaths();
 		const command = join(paths.userHome, ".local", "bin", "openclaw");
-		const configPath = join(paths.userHome, ".openclaw", "openclaw.json");
+		const accountKey = "clawdi_50000000000040008000000000000005";
+		const tokenEnv = "CLAWDI_CHANNEL_TELEGRAM_CLAWDI_50000000000040008000000000000005_AGENT_TOKEN";
+		const tokenRef = `secret://channels/telegram/${accountKey}/placeholder-token`;
+		const managed = {
+			enabled: true,
+			botToken: { source: "env", provider: "default", id: tokenEnv },
+		};
+		const personal = {
+			enabled: true,
+			botToken: "native-user-token",
+			dmPolicy: "pairing",
+			allowFrom: ["42"],
+		};
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
+			initialConfig: {
+				channels: { telegram: { defaultAccount: "personal", accounts: { personal } } },
+			},
+		});
 		const patchPath = join(paths.runRoot, "openclaw-config-patch.json");
 		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
 		mkdirSync(dirname(command), { recursive: true });
-		mkdirSync(dirname(configPath), { recursive: true });
-		writeFileSync(configPath, "{}\n");
 		writeFileSync(
 			command,
 			`#!/usr/bin/env bash
@@ -850,12 +866,24 @@ esac
 		);
 		chmodSync(command, 0o700);
 		const manifest = installGateManifest(paths, "openclaw", command);
-		manifest.projection = { channels: { telegram: { enabled: true } } };
+		manifest.projection = {
+			channels: {
+				telegram: {
+					enabled: true,
+					defaultAccount: accountKey,
+					accounts: { [accountKey]: managed },
+				},
+			},
+		};
+		const run = manifest.runtimes.openclaw?.run;
+		if (!run) throw new Error("managed OpenClaw run settings are missing");
+		run.secretEnv = { ...run.secretEnv, [tokenEnv]: tokenRef };
 		const load: RuntimeManifestLoad = {
 			manifest,
 			source: "remote-datasource",
 			sourcePath: "inline-openclaw-channel-drift",
 			offline: false,
+			secretValues: { [tokenRef]: "managed-placeholder-token" },
 		};
 		const converge = () =>
 			convergeRuntimeManifest(load, paths, {
@@ -881,24 +909,28 @@ esac
 			});
 
 		expect(converge().installErrors).toEqual([]);
+		const installed = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(installed.channels.telegram.accounts).toEqual({ personal, [accountKey]: managed });
+		expect(installed.channels.telegram.defaultAccount).toBe("personal");
 		expect(converge().installErrors).toEqual([]);
-		const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
-		delete config.channels;
-		writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(installed);
 
+		const policy = {
+			dmPolicy: "pairing",
+			allowFrom: ["owner"],
+			groups: { "*": { requireMention: true } },
+		};
+		installed.channels.telegram.accounts[accountKey] = { ...managed, ...policy, enabled: false };
+		writeFileSync(configPath, `${JSON.stringify(installed)}\n`);
 		expect(converge().installErrors).toEqual([]);
-
-		manifest.projection = { channels: {} };
-		writeFileSync(configPath, "{}\n");
-		expect(converge().installErrors).toEqual([]);
-		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
-			gateway: {
-				mode: "local",
-				port: 18789,
-				bind: "lan",
-				auth: { mode: "token", token: "test-gateway-token" },
-			},
+		const repaired = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(repaired.channels.telegram.accounts).toEqual({
+			personal,
+			[accountKey]: { ...managed, ...policy },
 		});
+		expect(repaired.channels.telegram.defaultAccount).toBe("personal");
+		expect(repaired.session.dmScope).toBe("per-account-channel-peer");
+		expect(repaired.gateway.auth).toEqual({ mode: "token", token: "test-gateway-token" });
 	});
 
 	test("renders systemd runtime services without creating user command shims", () => {

--- a/packages/cli/src/runtime/openclaw-provider-config.ts
+++ b/packages/cli/src/runtime/openclaw-provider-config.ts
@@ -34,7 +34,9 @@ if (
 ) {
   throw new Error("required public config-mutation export is missing");
 }
-const patch = JSON.parse(readFileSync(0, "utf8"));
+const input = JSON.parse(readFileSync(0, "utf8"));
+const channelMutation = process.argv[2] === "channels";
+const patch = channelMutation ? input.patch : input;
 const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
 if (!isRecord(patch)) throw new Error("OpenClaw provider patch must be an object");
 const blockedKeys = new Set(["__proto__", "constructor", "prototype"]);
@@ -82,16 +84,76 @@ const repairsUnsupportedMemorySearch =
 if (
   !snapshot ||
   !isRecord(sourceConfig) ||
-  (snapshot.valid !== true && !repairsUnsupportedMemorySearch)
+  (snapshot.valid !== true && !repairsUnsupportedMemorySearch && !channelMutation)
 ) {
   throw new Error("OpenClaw config snapshot is unavailable for provider projection");
 }
+const applyChannelPatch = (draft) => {
+  const desired = structuredClone(patch);
+  const channels = {};
+  for (const provider of ["telegram", "discord", "whatsapp"]) {
+    const selected = desired.channels?.[provider];
+    const selectedAccounts = selected?.accounts ?? {};
+    const current = draft.channels?.[provider];
+    const currentAccounts = current?.accounts ?? {};
+    const previous = input.previousChannels?.[provider];
+    const previousAccounts = previous?.accounts ?? {};
+    const credential = provider === "telegram" ? "botToken" : provider === "discord" ? "token" : "authDir";
+    const matches = (actual, owned) => isRecord(actual) && isRecord(owned) &&
+      Object.hasOwn(owned, credential) && isDeepStrictEqual(actual[credential], owned[credential]);
+    const accounts = {};
+    for (const [id, owned] of Object.entries(previousAccounts)) {
+      if (!Object.hasOwn(selectedAccounts, id) && matches(currentAccounts[id], owned)) accounts[id] = null;
+    }
+    for (const [id, account] of Object.entries(selectedAccounts)) {
+      if (!isRecord(account)) throw new Error("Invalid managed channel account");
+      if (!Object.hasOwn(currentAccounts, id)) accounts[id] = account;
+      else {
+        if (!matches(currentAccounts[id], account) && !matches(currentAccounts[id], previousAccounts[id])) {
+          throw new Error("Native channel account ownership changed; refusing managed update");
+        }
+        accounts[id] = { enabled: account.enabled, [credential]: account[credential] };
+      }
+    }
+    if (Object.keys(accounts).length === 0) continue;
+    const channel = { ...(selected ? { enabled: true } : {}), accounts };
+    if (!current && selected?.defaultAccount !== undefined) channel.defaultAccount = selected.defaultAccount;
+    else if (typeof current?.defaultAccount === "string" && accounts[current.defaultAccount] === null &&
+        previous?.defaultAccount === current.defaultAccount) channel.defaultAccount = selected?.defaultAccount ?? null;
+    channels[provider] = channel;
+  }
+  desired.channels = channels;
+  applyMergePatch(draft, desired);
+  // A retained entry is not delete authority. Reject missing managed references instead of
+  // committing an invalid configuration after its environment has been withdrawn.
+  for (const provider of ["telegram", "discord"]) {
+    const channel = draft.channels?.[provider];
+    const credential = provider === "telegram" ? "botToken" : "token";
+    for (const account of [channel, ...Object.values(channel?.accounts ?? {})]) {
+      const ref = account?.[credential];
+      if (ref?.source === "env" && ref.provider === "default" && typeof ref.id === "string" &&
+          ref.id.startsWith("CLAWDI_CHANNEL_") && ref.id.endsWith("_AGENT_TOKEN") &&
+          !input.availableChannelEnv.includes(ref.id)) {
+        throw new Error("Retained channel references a withdrawn managed credential; ownership repair required");
+      }
+    }
+  }
+};
+const mergeNativeOptions = (legacy, current) => {
+  if (!isRecord(legacy) || !isRecord(current)) return structuredClone(current);
+  const merged = structuredClone(legacy);
+  for (const [key, value] of Object.entries(current)) {
+    if (blockedKeys.has(key)) throw new Error("Invalid native memory option");
+    merged[key] = Object.hasOwn(merged, key) ? mergeNativeOptions(merged[key], value) : structuredClone(value);
+  }
+  return merged;
+};
 const applyProviderPatch = (draft) => {
   const desired = structuredClone(patch);
   const defaults = isRecord(draft.agents) ? draft.agents.defaults : undefined;
   const legacy = isRecord(defaults) ? defaults.memorySearch : undefined;
   const current = isRecord(draft.memory) ? draft.memory.search : undefined;
-  const authored = { ...(isRecord(legacy) ? legacy : {}), ...(isRecord(current) ? current : {}) };
+  const authored = mergeNativeOptions(isRecord(legacy) ? legacy : {}, isRecord(current) ? current : {});
   const desiredDefaults = isRecord(desired.agents) ? desired.agents.defaults : undefined;
   const searchContainer = isRecord(desired.memory?.search) ? desired.memory : desiredDefaults;
   const searchKey = isRecord(desired.memory?.search) ? "search" : "memorySearch";
@@ -103,16 +165,17 @@ const applyProviderPatch = (draft) => {
   }
   applyMergePatch(draft, desired);
 };
+const mutate = channelMutation ? applyChannelPatch : applyProviderPatch;
 const projected = structuredClone(sourceConfig);
-applyProviderPatch(projected);
-if (isDeepStrictEqual(projected, sourceConfig)) process.exit(0);
+mutate(projected);
+if (snapshot.valid === true && isDeepStrictEqual(projected, sourceConfig)) process.exit(0);
 explicitSetPaths.length = 0;
 unsetPaths.length = 0;
 await sdk.mutateConfigFile({
   base: "source",
   afterWrite: { mode: "none", reason: "Clawdi runtime convergence owns service reconciliation" },
   writeOptions: { allowConfigSizeDrop: true, explicitSetPaths, unsetPaths },
-  mutate: applyProviderPatch,
+  mutate,
 });
 `;
 export function applyOpenClawHostedProviderPatch(
@@ -148,6 +211,29 @@ export function applyOpenClawHostedProviderPatch(
 		workspaceRoot,
 	);
 	openClawProviderPatchRevisions.set(context.configPath, patchRevision);
+}
+
+export function applyOpenClawHostedChannelPatch(
+	patch: Record<string, unknown>,
+	previousChannels: Record<string, unknown> | null,
+	availableChannelEnv: string[],
+	context: OpenClawHostedContext,
+	workspaceRoot: string,
+): void {
+	// No custom IO: the official writer owns its cross-process lock, snapshot and commit checks.
+	runRuntimeUserCommand(
+		"node",
+		[
+			"--input-type=module",
+			"--eval",
+			OPENCLAW_CONFIG_MUTATION_HELPER,
+			context.requireSdkExport("configMutation"),
+			"channels",
+		],
+		JSON.stringify({ patch, previousChannels, availableChannelEnv }),
+		context.home,
+		workspaceRoot,
+	);
 }
 
 function adaptOpenClawMemorySearchPatch(

--- a/packages/cli/src/runtime/openclaw-provider-config.ts
+++ b/packages/cli/src/runtime/openclaw-provider-config.ts
@@ -86,8 +86,25 @@ if (
 ) {
   throw new Error("OpenClaw config snapshot is unavailable for provider projection");
 }
+const applyProviderPatch = (draft) => {
+  const desired = structuredClone(patch);
+  const defaults = isRecord(draft.agents) ? draft.agents.defaults : undefined;
+  const legacy = isRecord(defaults) ? defaults.memorySearch : undefined;
+  const current = isRecord(draft.memory) ? draft.memory.search : undefined;
+  const authored = { ...(isRecord(legacy) ? legacy : {}), ...(isRecord(current) ? current : {}) };
+  const desiredDefaults = isRecord(desired.agents) ? desired.agents.defaults : undefined;
+  const searchContainer = isRecord(desired.memory?.search) ? desired.memory : desiredDefaults;
+  const searchKey = isRecord(desired.memory?.search) ? "search" : "memorySearch";
+  // A hosted embedding default does not own native selection. Read inside the native mutation
+  // as well as the preview, so a concurrent user edit is not restored from an earlier snapshot.
+  if (isRecord(searchContainer?.[searchKey])) {
+    searchContainer[searchKey] = Object.hasOwn(authored, "provider") || Object.hasOwn(authored, "model")
+      ? authored : { ...authored, ...searchContainer[searchKey] };
+  }
+  applyMergePatch(draft, desired);
+};
 const projected = structuredClone(sourceConfig);
-applyMergePatch(projected, patch);
+applyProviderPatch(projected);
 if (isDeepStrictEqual(projected, sourceConfig)) process.exit(0);
 explicitSetPaths.length = 0;
 unsetPaths.length = 0;
@@ -95,7 +112,7 @@ await sdk.mutateConfigFile({
   base: "source",
   afterWrite: { mode: "none", reason: "Clawdi runtime convergence owns service reconciliation" },
   writeOptions: { allowConfigSizeDrop: true, explicitSetPaths, unsetPaths },
-  mutate: (draft) => applyMergePatch(draft, patch),
+  mutate: applyProviderPatch,
 });
 `;
 export function applyOpenClawHostedProviderPatch(

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -37,6 +37,7 @@ import {
 } from "./manifest";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+	loadCommittedRuntimeManifest,
 	loadRemoteRuntimeManifest,
 	loadRuntimeManifest,
 	parseHostedRuntimeBundleV2,
@@ -688,7 +689,6 @@ describe("hosted runtime bundle v2", () => {
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const openclawBin = join(paths.userHome, ".local", "bin", "openclaw");
 		const openclawConfigPath = join(paths.userHome, ".openclaw", "openclaw.json");
-		const channelPatchPath = join(root, "openclaw-channel-patch.json");
 		const mcpSecretRef = "secret://mcp/sidecar-only/token";
 		const mcpSecret = "mcp-sidecar-only-secret";
 		const egressEngine = {
@@ -718,10 +718,7 @@ describe("hosted runtime bundle v2", () => {
 				'if [[ "$1 $2 $3" == "agents list --json" ]]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				'elif [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
-				"  payload=$(cat)",
-				`  if [[ "$payload" == *'"channels"'* && "$payload" == *'"telegram"'* ]]; then`,
-				`    printf '%s\\n' "$payload" > '${channelPatchPath}'`,
-				"  fi",
+				"  cat >/dev/null",
 				'elif [[ "$1 $2" == "mcp set" ]]; then',
 				`  python3 - "$3" "$4" '${openclawConfigPath}' <<'PY'`,
 				"import json",
@@ -738,6 +735,7 @@ describe("hosted runtime bundle v2", () => {
 			].join("\n"),
 		);
 		chmodSync(openclawBin, 0o700);
+		writeOpenClawPublicAuthSdkFixture(paths.userHome);
 		writeFileSync(openclawConfigPath, '{"mcp":{"servers":{}}}\n');
 
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
@@ -889,7 +887,7 @@ describe("hosted runtime bundle v2", () => {
 			expect(egressSecretStat.uid).toBe(10_002);
 			expect(egressSecretStat.gid).toBe(10_002);
 		}
-		expect(JSON.parse(readFileSync(channelPatchPath, "utf-8"))).toMatchObject({
+		expect(JSON.parse(readFileSync(openclawConfigPath, "utf-8"))).toMatchObject({
 			channels: {
 				telegram: {
 					accounts: {
@@ -1722,6 +1720,22 @@ exit 0
 			expect(offlineEgressSecretStat.gid).toBe(10002);
 		}
 
+		const nextContext: RuntimeApplyContext = {
+			...applyContext,
+			identity: {
+				...applyContext.identity,
+				generation: applyContext.identity.generation + 1,
+				manifestETag: '"next-candidate"',
+				applyReceiptId: "next-apply-receipt-0001",
+				bootNonce: "next-boot-nonce-000001",
+			},
+		};
+		const committedPrevious = loadCommittedRuntimeManifest(paths, nextContext);
+		if (!("manifest" in committedPrevious)) throw new Error(JSON.stringify(committedPrevious));
+		expect(committedPrevious.manifest.generation).toBe(onlineLoad.manifest.generation);
+		expect(committedPrevious.sourceRevision).toBe(onlineLoad.sourceRevision);
+		expect(committedPrevious.channelBindings).toEqual(onlineLoad.channelBindings);
+
 		rmSync(paths.appliedState);
 		const uncommittedCacheLoad = await loadRuntimeManifest(paths, { applyContext });
 		expect("errors" in uncommittedCacheLoad).toBe(true);
@@ -1755,6 +1769,7 @@ exit 0
 				},
 			})}\n`,
 		);
+		expect("errors" in loadCommittedRuntimeManifest(paths, nextContext)).toBe(true);
 		const manifestOnlyCrashLoad = await loadRuntimeManifest(paths, { applyContext });
 		expect("errors" in manifestOnlyCrashLoad).toBe(true);
 		if (!("errors" in manifestOnlyCrashLoad)) {

--- a/packages/cli/src/test-support/openclaw-config-mutation.ts
+++ b/packages/cli/src/test-support/openclaw-config-mutation.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export function writeFakeOpenClawConfigMutationSdk(
+	home: string,
+	options: {
+		importLog?: string;
+		initialConfig?: Record<string, unknown>;
+		beforeMutation?: Record<string, unknown>;
+	} = {},
+): string {
+	const { importLog, initialConfig = {} } = options;
+	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
+	const configPath = join(home, ".openclaw", "openclaw.json");
+	mkdirSync(packageRoot, { recursive: true });
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`);
+	writeFileSync(
+		join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "openclaw",
+			type: "module",
+			exports: {
+				"./plugin-sdk/config-mutation": "./config-mutation.mjs",
+				"./plugin-sdk/device-bootstrap": "./device-bootstrap.mjs",
+				"./plugin-sdk/provider-auth": "./provider-auth.mjs",
+			},
+		}),
+	);
+	const logImport = (name: string) =>
+		importLog
+			? `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(importLog)}, ${JSON.stringify(`${name}\n`)});\n`
+			: "";
+	writeFileSync(
+		join(packageRoot, "config-mutation.mjs"),
+		`${logImport("config-mutation")}import { readFileSync, writeFileSync } from "node:fs";
+const configPath = ${JSON.stringify(configPath)};
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const hasLegacyMemorySearch = (config) => {
+  const agents = isRecord(config) ? config.agents : undefined;
+  const defaults = isRecord(agents) ? agents.defaults : undefined;
+  return isRecord(defaults) && Object.hasOwn(defaults, "memorySearch");
+};
+export async function readConfigFileSnapshotForWrite() {
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  return { snapshot: { valid: !hasLegacyMemorySearch(config), config, sourceConfig: structuredClone(config) } };
+}
+export async function mutateConfigFile(options) {
+  ${options.beforeMutation ? `writeFileSync(configPath, ${JSON.stringify(JSON.stringify(options.beforeMutation))});` : ""}
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  await options.mutate(config, { snapshot: {}, previousHash: null, attempt: 1 });
+  if (hasLegacyMemorySearch(config)) throw new Error("OpenClaw config validation failed");
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
+}
+`,
+	);
+	writeFileSync(
+		join(packageRoot, "device-bootstrap.mjs"),
+		`${logImport("device-bootstrap")}export const normalizeDeviceBootstrapProfile = (profile) => profile;\n`,
+	);
+	writeFileSync(
+		join(packageRoot, "provider-auth.mjs"),
+		`${logImport("provider-auth")}export const ensureAuthProfileStoreForLocalUpdate = () => ({ profiles: {} });
+export const updateAuthProfileStoreWithLock = async () => ({});
+export const listProfilesForProvider = () => [];
+export const removeProviderAuthProfilesWithLock = async () => ({});
+`,
+	);
+	return configPath;
+}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -87,7 +87,6 @@ import {
 	validateUnmanagedProviderSecretValues,
 } from "../src/runtime/manifest-contract";
 import { runtimeConvergenceWithoutApply } from "../src/runtime/manifest-planning";
-import { recordValue } from "../src/runtime/manifest-shared";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest as loadRemoteRuntimeManifestWithContext,
@@ -116,6 +115,7 @@ import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-us
 import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
 import { log } from "../src/serve/log";
 import { getDaemonControlTokenPath } from "../src/serve/paths";
+import { writeFakeOpenClawConfigMutationSdk } from "../src/test-support/openclaw-config-mutation";
 import { ensureTestOpenClawWorkspaceCli } from "../src/test-support/runtime-workspace";
 import { mockFetch } from "./commands/helpers";
 
@@ -978,6 +978,39 @@ function hostedRuntimeWatchLocalePayload(
 	};
 }
 
+async function hostedChannelBundleLoad(
+	home: string,
+	runtime: "hermes" | "openclaw",
+	generation: number,
+	channelBindings: RuntimeBundleChannelBinding[],
+	secretValues: Record<string, string>,
+): Promise<RuntimeManifestLoad> {
+	const payload = hostedRuntimeWatchLocalePayload(home, generation, "en", "UTC");
+	const { primary_model: _primary, ...entry } =
+		runtime === "hermes" ? hostedHermesRuntime() : hostedOpenClawRuntime();
+	const response = hostedRuntimeBundleResponse({
+		manifest: {
+			...payload.manifest,
+			runtime,
+			providers: {},
+			system: runtime === "hermes" ? hostedHermesSystemFixture(home) : hostedSystemFixture(home),
+			runtimes: {
+				[runtime]: {
+					...entry,
+					providerMode: "unmanaged",
+					provider_ids: [],
+					run: entry.run,
+				},
+			},
+		},
+		channelBindings,
+		secretValues,
+	});
+	return applyRuntimeBundleChannelsToManifestLoad(
+		parseHostedRuntimeBundleV2(await response.json(), "test://channel-bundle"),
+	);
+}
+
 function hostedEgressSecretRotationPayload(
 	home: string,
 	egressEngine: typeof TEST_EGRESS_ENGINE_PIN,
@@ -1427,10 +1460,10 @@ function installSuccessfulSystemctlFixture(
 	process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 }
 
-function startHealthyOpenClawGateway() {
+function startHealthyOpenClawGateway(port = 0) {
 	const server = Bun.serve({
 		hostname: "127.0.0.1",
-		port: 0,
+		port,
 		fetch(request) {
 			const path = new URL(request.url).pathname;
 			if (request.method === "GET" && path === "/readyz") {
@@ -2225,6 +2258,20 @@ function writeTestRuntimeAppliedState(
 			...[...systemdUnits.system].filter(([unit]) => unit !== RUNTIME_WATCH_SYSTEM_UNIT),
 			...systemdUnits.user,
 		]);
+	if (load.sourceBundle !== undefined) {
+		// Canonical bundles need the real source-cache commit as well as the applied receipt.
+		commitRuntimeAppliedState({
+			load,
+			paths,
+			convergence,
+			sourceRevision,
+			etag: input.etag ?? load.etag ?? `"sha256:${sourceRevision}"`,
+			applyIdentity: applyContext?.identity ?? null,
+			activated,
+			officialServiceCommandRevisions: input.officialServiceCommandRevisions ?? {},
+		});
+		return;
+	}
 	writeRuntimeAppliedState(
 		{
 			schemaVersion: "clawdi.runtimeAppliedState.v2",
@@ -6535,13 +6582,12 @@ cp '${sdkSource}' '${sdkTarget}'
 		const bin = join(root, "bin");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawUnit = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
-		const openclawPatch = join(root, "openclaw-watch-channel-patch.jsonl");
 		const sidecarReadyPath = join(run, "egress", "systemd", "ca.pem");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
-		writeOpenClawConfigMutationFixture(home, { gateway: startHealthyOpenClawGateway() });
+		writeOpenClawConfigMutationFixture(home, { gateway: startHealthyOpenClawGateway(18789) });
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -6555,11 +6601,7 @@ if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\\n'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >> '${openclawPatch}'
-  printf '\\n' >> '${openclawPatch}'
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "$*" = "gateway install --force --json" ]; then
   mkdir -p '${dirname(openclawUnit)}'
   printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${openclawUnit}'
@@ -6740,7 +6782,7 @@ exit 64
 			expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 			expect(gatewayEnv).not.toContain("gateway-token-watch");
 			expect(watchEnv).not.toContain("file-runtime-token");
-			const patchText = readFileSync(openclawPatch, "utf-8");
+			const patchText = readFileSync(join(home, ".openclaw", "openclaw.json"), "utf-8");
 			expect(patchText).toContain('"telegram"');
 			expect(patchText).toContain('"botToken"');
 			expect(patchText).toContain(
@@ -6869,6 +6911,7 @@ exit 64
 			stateRoot: join(root, "systemctl-generation-state"),
 			sidecarReadyPath,
 		});
+		writeFakeOpenClawConfigMutationSdk(home);
 		seedOfficialOpenClawServiceInstaller(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -9168,8 +9211,6 @@ exit 64
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawUnit = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
-		const openclawPatch = join(root, "openclaw-channel-patch.json");
-		const openclawPatchArgs = join(root, "openclaw-channel-patch-args.txt");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
 		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		const previousExitCode = process.exitCode;
@@ -9179,6 +9220,7 @@ exit 64
 		mkdirSync(join(home, ".local", "bin"), { recursive: true });
 		mkdirSync(join(home, ".openclaw"), { recursive: true });
 		mkdirSync(join(root, "etc", "clawdi"), { recursive: true });
+		writeFakeOpenClawConfigMutationSdk(home);
 		writeFileSync(
 			join(home, ".openclaw", "openclaw.json"),
 			`${JSON.stringify(
@@ -9193,7 +9235,7 @@ exit 64
 									allowFrom: ["discord-user"],
 									guilds: { "discord-guild": { requireMention: true } },
 								},
-								stale: { enabled: true, token: "stale-token" },
+								personal: { enabled: true, token: "personal-token" },
 							},
 						},
 					},
@@ -9218,12 +9260,7 @@ if [ "$*" = "plugins install --help" ]; then
   printf '%s\\n' '--accept-capabilities'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  printf '%s\n' "$*" >> '${openclawPatchArgs}'
-  cat >> '${openclawPatch}'
-  printf '\\n---\\n' >> '${openclawPatch}'
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "$*" = "plugins install @openclaw/discord --force --accept-capabilities" ]; then
   printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   mkdir -p '${dirname(openclawPluginSource)}'
@@ -9327,63 +9364,55 @@ exit 64
 
 		try {
 			await runtimeInit({ nonInteractive: true, json: true });
+			expect(process.exitCode).toBe(23);
+			expect(JSON.parse(logs.at(-1) ?? "{}").errors.join("\n")).toContain("ownership changed");
+			expect(readRuntimeAppliedState(paths)).toBeNull();
+			const configPath = join(home, ".openclaw", "openclaw.json");
+			const native = JSON.parse(readFileSync(configPath, "utf8"));
+			expect(native.channels.discord.accounts.clawdi_acctdiscord1.token).toBe("user-token");
+			expect(native.channels.discord.accounts.personal).toEqual({
+				enabled: true,
+				token: "personal-token",
+			});
+			// Explicit native credential selection resolves the collision; convergence must retain policies.
+			native.channels.discord.accounts.clawdi_acctdiscord1.token = {
+				source: "env",
+				provider: "default",
+				id: "CLAWDI_CHANNEL_DISCORD_CLAWDI_ACCTDISCORD1_AGENT_TOKEN",
+			};
+			writeFileSync(configPath, JSON.stringify(native));
+			process.exitCode = undefined;
+			await runtimeInit({ nonInteractive: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
 			expect(process.exitCode).toBe(0);
-			expect(captured).toHaveLength(1);
+			expect(captured).toHaveLength(2);
 			expect(captured[0].path).toBe("/v1/runtime/manifest");
 			expect(readRuntimeAppliedState(paths)).toMatchObject({
 				etag: testBundleEtag("manifest-etag-init-7"),
 				generation: 7,
 			});
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
-			const patchText = readFileSync(openclawPatch, "utf-8");
-			expect(patchText).not.toContain('"$patch"');
-			expect(patchText).toContain('"telegram"');
-			expect(patchText).toContain('"botToken": {');
-			expect(patchText).toContain(
-				'"id": "CLAWDI_CHANNEL_TELEGRAM_CLAWDI_ACCTTELEGRAM_AGENT_TOKEN"',
-			);
-			expect(patchText).not.toContain("agent-token-init");
-			expect(patchText).toContain('"discord"');
-			expect(patchText).toContain('"token": {');
-			expect(patchText).toContain('"id": "CLAWDI_CHANNEL_DISCORD_CLAWDI_ACCTDISCORD1_AGENT_TOKEN"');
-			expect(patchText).not.toContain("discord-agent-token-init");
-			expect(patchText).toContain('"default": {');
-			expect(patchText).toContain('"source": "env"');
-			expect(patchText).toContain('"plugins"');
-			expect(patchText).toContain('"dmScope": "per-account-channel-peer"');
-			expect(patchText).not.toContain('"streaming"');
-			expect(readFileSync(openclawPatchArgs, "utf-8")).toContain(
-				"config patch --stdin --replace-path channels.telegram.accounts --replace-path channels.discord.accounts",
-			);
-			const isolationPatch = patchText
-				.split("\n---\n")
-				.filter((entry) => entry.trim().length > 0)
-				.map((entry): unknown => JSON.parse(entry))
-				.map((entry) => expectRecord(entry, "OpenClaw config patch"))
-				.find((entry) => entry.session !== undefined);
-			if (!isolationPatch) throw new Error("OpenClaw session isolation patch was not rendered");
-			const sessionPatch = expectRecord(isolationPatch.session, "OpenClaw session patch");
-			expect(sessionPatch).toEqual({ dmScope: "per-account-channel-peer" });
-			const channelPatch = patchText
-				.split("\n---\n")
-				.filter((entry) => entry.trim().length > 0)
-				.map((entry): unknown => JSON.parse(entry))
-				.map((entry) => expectRecord(entry, "OpenClaw config patch"))
-				.find((entry) => recordValue(entry.channels)?.telegram !== undefined);
-			if (!channelPatch) throw new Error("OpenClaw channel patch was not rendered");
-			const patchedChannels = expectRecord(channelPatch.channels, "OpenClaw channel patch");
-			const discordAccounts = expectRecord(
-				expectRecord(patchedChannels.discord, "OpenClaw Discord patch").accounts,
-				"OpenClaw Discord accounts",
-			);
-			const discordAccount = expectRecord(
-				discordAccounts.clawdi_acctdiscord1,
-				"OpenClaw Discord account",
-			);
+			const nativeConfigText = readFileSync(configPath, "utf8");
+			const nativeConfig = JSON.parse(nativeConfigText);
+			expect(nativeConfigText).not.toContain("agent-token-init");
+			expect(nativeConfigText).not.toContain("discord-agent-token-init");
+			expect(nativeConfig.channels.telegram.accounts.clawdi_accttelegram.botToken).toEqual({
+				source: "env",
+				provider: "default",
+				id: "CLAWDI_CHANNEL_TELEGRAM_CLAWDI_ACCTTELEGRAM_AGENT_TOKEN",
+			});
+			expect(nativeConfig.secrets.providers.default).toEqual({ source: "env" });
+			expect(nativeConfig.plugins.entries).toMatchObject({
+				telegram: { enabled: true },
+				discord: { enabled: true },
+			});
+			expect(nativeConfig.session.dmScope).toBe("per-account-channel-peer");
+			expect(nativeConfig.channels).not.toHaveProperty("streaming");
+			const discordAccounts = nativeConfig.channels.discord.accounts;
+			const discordAccount = discordAccounts.clawdi_acctdiscord1;
 			expect(discordAccount).toMatchObject({
 				enabled: true,
 				token: {
@@ -9395,13 +9424,8 @@ exit 64
 				allowFrom: ["discord-user"],
 				guilds: { "discord-guild": { requireMention: true } },
 			});
-			expect(Object.keys(discordAccounts)).toEqual(["clawdi_acctdiscord1"]);
-			for (const current of ["main", "per-peer", "per-channel-peer", "per-account-channel-peer"]) {
-				expect({ dmScope: current, resetTriggers: ["/new"], ...sessionPatch }).toEqual({
-					dmScope: "per-account-channel-peer",
-					resetTriggers: ["/new"],
-				});
-			}
+			expect(Object.keys(discordAccounts).sort()).toEqual(["clawdi_acctdiscord1", "personal"]);
+			expect(discordAccounts.personal).toEqual({ enabled: true, token: "personal-token" });
 			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
 				"plugins install @openclaw/discord --force --accept-capabilities\n",
 			);
@@ -9472,7 +9496,7 @@ exit 64
 			expect(profileBundleText).not.toContain("agent-token-init");
 			expect(profileBundleText).not.toContain("replacementSecretRef");
 			expect(profileBundleText).toContain("placeholder-token");
-			const status = JSON.parse(logs[0] ?? "{}");
+			const status = JSON.parse(logs.at(-1) ?? "{}");
 			expect(status.status).toBe("ok");
 			expect(status.activeGeneration).toBe(7);
 		} finally {
@@ -9812,7 +9836,7 @@ exit 64
 		expect(discordOnlyHermesConfig.group_sessions_per_user).toBe(false);
 		expect(discordOnlyHermesConfig.thread_sessions_per_user).toBe(true);
 		expect(discordOnlyHermesConfig.telegram).toMatchObject({
-			enabled: false,
+			enabled: true,
 			dm_policy: "allowlist",
 			group_policy: "allowlist",
 			allow_from: ["telegram-user"],
@@ -9834,9 +9858,13 @@ exit 64
 			paths,
 		);
 		expect(removed.installErrors).toEqual([]);
+		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("TELEGRAM_BOT_TOKEN=");
+		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("DISCORD_BOT_TOKEN=");
 		const clearedHermesConfig = readHermesConfigYaml(home);
 		expect(clearedHermesConfig.streaming).toEqual({ enabled: false });
+		expect(clearedHermesConfig.telegram.enabled).toBe(true);
 		expect(clearedHermesConfig.discord).toMatchObject({
+			enabled: true,
 			dm_policy: "pairing",
 			group_policy: "allowlist",
 			allow_from: ["discord-user"],
@@ -9873,13 +9901,13 @@ exit 64
 		});
 	}, 30_000);
 
-	it("projects and removes Hermes native WhatsApp through the stock adapter config", () => {
+	it("projects and removes Hermes native WhatsApp through the stock adapter config", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "clawdi");
 		const hermesBin = join(home, ".local", "bin", "hermes");
-		const accountId = "00000000-0000-0000-0000-000000000001";
+		const accountId = "00000000-0000-4000-8000-000000000001";
 		const accountKey = "clawdi_000000000000";
 		const linkId = "60000000-0000-4000-8000-000000000006";
 		const credentialId = "80000000-0000-4000-8000-000000000011";
@@ -9949,76 +9977,34 @@ exit 64
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
 
-		const load: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				runtime: "hermes",
-				deploymentId: "dep_hermes_whatsapp",
-				environmentId: "env_hermes_whatsapp",
-				instanceId: "iid_hermes_whatsapp",
-				generation: 14,
-				issuedAt: "2026-07-07T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test/" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: "clawdi@0.13.66",
-					registry: "https://registry.npmjs.org",
-				},
-				egressEngine: seedMitmproxyCache(paths),
-				runtimes: {
-					hermes: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: [],
-						},
-						run: {
-							args: ["gateway", "run"],
-							env: { HERMES_EXISTING_ENV: "kept" },
-							prependPath: [],
-						},
-						services: {},
-					},
-				},
-				projection: {
-					system: { home, workspace },
-				},
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: "test://hermes-whatsapp",
-			offline: false,
-			secretValues: {
-				[agentTokenSecretRef]: "wa-hermes-agent-token",
-				[capabilitySecretRef]: capability,
-				[credentialSecretRef]: JSON.stringify(creds),
-			},
-			channelBindings: [
-				{
-					provider: "whatsapp",
-					accountId,
-					accountKey,
-					linkId,
-					agentTokenSecretRef,
-					placeholderTokenSecretRef: capabilitySecretRef,
-					credential: {
-						id: credentialId,
-						credsSecretRef: credentialSecretRef,
-						authCert: {
-							SERIAL: 7,
-							ISSUER: "clawdi",
-							PUBLIC_KEY: {
-								type: "Buffer",
-								data: Buffer.alloc(32, 7).toString("base64"),
-							},
-						},
-					},
-				},
-			],
+		const channelSecrets = {
+			[agentTokenSecretRef]: "wa-hermes-agent-token",
+			[capabilitySecretRef]: capability,
+			[credentialSecretRef]: JSON.stringify(creds),
 		};
+		const channelBindings: RuntimeBundleChannelBinding[] = [
+			{
+				provider: "whatsapp",
+				accountId,
+				accountKey,
+				linkId,
+				agentTokenSecretRef,
+				placeholderTokenSecretRef: capabilitySecretRef,
+				credential: {
+					id: credentialId,
+					credsSecretRef: credentialSecretRef,
+					authCert: {
+						SERIAL: 7,
+						ISSUER: "clawdi",
+						PUBLIC_KEY: {
+							type: "Buffer",
+							data: Buffer.alloc(32, 7).toString("base64"),
+						},
+					},
+				},
+			},
+		];
+		const load = await hostedChannelBundleLoad(home, "hermes", 14, channelBindings, channelSecrets);
 
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load, paths);
 		const credentialProjection = projected.manifest.projection?.channelCredentials as unknown[];
@@ -10048,7 +10034,6 @@ exit 64
 			},
 		});
 		expect(projected.manifest.runtimes.hermes?.run?.env).toMatchObject({
-			HERMES_EXISTING_ENV: "kept",
 			WHATSAPP_MODE: "bot",
 			WHATSAPP_ALLOWED_USERS: "*",
 			WHATSAPP_ALLOW_ALL_USERS: "true",
@@ -10117,30 +10102,18 @@ exit 64
 			initialHermesRevision,
 		);
 
-		const projectedCreds = JSON.parse(
-			projected.secretValues?.[credentialSecretRef] ?? "null",
-		) as Record<string, unknown>;
 		const beforeCredentialChange = readSystemdUnitSnapshot(paths);
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
-		const changedCheckpoint: RuntimeManifestLoad = {
-			...projected,
-			manifest: {
-				...projected.manifest,
-				clawdiCli: {
-					...projected.manifest.clawdiCli,
-					packageSpec: "clawdi@0.13.67",
-				},
-			},
-			secretValues: {
-				...projected.secretValues,
-				[credentialSecretRef]: JSON.stringify({
-					...projectedCreds,
-					advSecretKey: "wa-hermes-secret-rotated",
-				}),
-			},
-		};
+		const changedCheckpoint = await hostedChannelBundleLoad(home, "hermes", 14, channelBindings, {
+			...channelSecrets,
+			[credentialSecretRef]: JSON.stringify({
+				...creds,
+				advSecretKey: "wa-hermes-secret-rotated",
+			}),
+		});
 		const changedCredential = convergeRuntimeManifest(changedCheckpoint, paths);
 		expect(changedCredential.installErrors).toEqual([]);
+		writeTestRuntimeAppliedState(paths, changedCheckpoint, changedCredential);
 		expect(systemdEnvDigest(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
 			initialHermesRevision,
 		);
@@ -10156,10 +10129,7 @@ exit 64
 		const systemctlCalls = readFileSync(systemctlLog, "utf-8");
 		expect(systemctlCalls).toContain("--user restart hermes-gateway.service");
 
-		const removed = applyRuntimeBundleChannelsToManifestLoad(
-			{ ...load, channelBindings: [], secretValues: {} },
-			paths,
-		);
+		const removed = await hostedChannelBundleLoad(home, "hermes", 15, [], {});
 		const patchedSocket = readFileSync(baileysSocket, "utf8");
 		writeFileSync(
 			baileysSocket,
@@ -10179,20 +10149,27 @@ exit 64
 		writeFileSync(baileysSocket, patchedSocket);
 		const removedConvergence = convergeRuntimeManifest(removed, paths);
 		expect(removedConvergence.installErrors).toEqual([]);
-		expect(existsSync(paths.egressProfileBundle)).toBe(false);
+		expect(readFileSync(paths.egressProfileBundle, "utf8")).not.toContain(
+			"native-whatsapp-baileys-managed",
+		);
+		expect(readFileSync(join(run, "secrets", "egress-secrets.json"), "utf8")).not.toContain(
+			agentTokenSecretRef,
+		);
 		expect(existsSync(sessionDir)).toBe(false);
+		writeTestRuntimeAppliedState(paths, removed, removedConvergence);
 		const removedHermesConfig = readHermesConfigYaml(home);
+		expect(removedHermesConfig).not.toHaveProperty("platforms.whatsapp.extra.session_path");
 		expect(removedHermesConfig).toHaveProperty("whatsapp", {
 			user_owned: "keep-whatsapp",
 			dm_policy: "allowlist",
 			allow_from: ["15550000001"],
 			group_policy: "allowlist",
 			group_allow_from: ["120363000000000000@g.us"],
-			enabled: false,
+			enabled: true,
 		});
 		expect(removedHermesConfig).toHaveProperty("platforms.whatsapp", {
 			custom: "keep-platform",
-			enabled: false,
+			enabled: true,
 			extra: {
 				custom_extra: "keep-extra",
 				dm_policy: "allowlist",
@@ -10233,10 +10210,13 @@ exit 64
 		const driftRepair = convergeRuntimeManifest(removed, paths);
 		expect(driftRepair.installErrors).toEqual([]);
 		expect(readHermesConfigYaml(home)).toMatchObject({
-			whatsapp: { enabled: false, user_owned: "manual" },
-			platforms: { whatsapp: { enabled: false } },
+			whatsapp: { enabled: true, user_owned: "manual" },
+			platforms: { whatsapp: { enabled: true } },
 		});
-		expect(readHermesConfigYaml(home)).not.toHaveProperty("platforms.whatsapp.extra.session_path");
+		expect(readHermesConfigYaml(home)).toHaveProperty(
+			"platforms.whatsapp.extra.session_path",
+			"/user/session",
+		);
 		expect(systemdEnvDigest(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
 			removedHermesRevision,
 		);
@@ -10251,7 +10231,6 @@ exit 64
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatch = join(root, "openclaw-channel-delete-patch.jsonl");
 		const openclawPluginInstalls = join(root, "openclaw-whatsapp-plugin-installs.txt");
 		const openclawPluginSource = join(
 			home,
@@ -10267,11 +10246,7 @@ exit 64
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >> '${openclawPatch}'
-  printf '\\n---\\n' >> '${openclawPatch}'
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw 2026.7.1-2\\n'
   exit 0
@@ -10294,6 +10269,7 @@ exit 0
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
+		writeFakeOpenClawConfigMutationSdk(home);
 		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 8);
 		loaded.manifest.projection = {
 			...loaded.manifest.projection,
@@ -10311,9 +10287,20 @@ exit 0
 			},
 		};
 
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
-		const unchangedConvergence = convergeRuntimeManifest(loaded, getRuntimePaths());
-		const removed: RuntimeManifestLoad = {
+		const paths = getRuntimePaths();
+		const convergence = convergeRuntimeManifest(loaded, paths);
+		expect(convergence.installErrors).toEqual([]);
+		const configPath = join(home, ".openclaw", "openclaw.json");
+		const configured = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(configured.channels.whatsapp.accounts.clawdi_whatsapp.authDir).toBe(
+			join(home, ".openclaw", "credentials", "whatsapp"),
+		);
+		expect(configured.session.dmScope).toBe("per-account-channel-peer");
+		expect(convergeRuntimeManifest(loaded, paths).installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(configured);
+		// This synthetic source has no committed bundle: omission must not authorize native deletion.
+		expect(readRuntimeAppliedState(paths)).toBeNull();
+		const removed = {
 			...loaded,
 			manifest: {
 				...loaded.manifest,
@@ -10321,27 +10308,11 @@ exit 0
 				projection: { ...loaded.manifest.projection, channels: {} },
 			},
 		};
-		const removedConvergence = convergeRuntimeManifest(removed, getRuntimePaths());
-
-		expect(convergence.installErrors).toEqual([]);
-		expect(unchangedConvergence.installErrors).toEqual([]);
-		expect(removedConvergence.installErrors).toEqual([]);
-		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+		expect(convergeRuntimeManifest(removed, paths).installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(configured);
+		expect(readFileSync(openclawPluginInstalls, "utf8")).toBe(
 			"plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force\n",
 		);
-		const patches = readFileSync(openclawPatch, "utf-8")
-			.split("\n---\n")
-			.filter((entry) => entry.trim().length > 0)
-			.map((entry) => JSON.parse(entry))
-			.filter((patch) => Object.hasOwn(patch, "channels"));
-		expect(patches).toHaveLength(3);
-		expect(patches[0].channels.whatsapp.accounts).toHaveProperty("clawdi_whatsapp");
-		expect(patches[0].channels.whatsapp.accounts.clawdi_whatsapp.authDir).toBe(
-			join(home, ".openclaw", "credentials", "whatsapp"),
-		);
-		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
-		expect(patches[2].channels.whatsapp).toBeNull();
-		expect(patches[2].session).toEqual({ dmScope: null });
 	});
 
 	it("reinstalls OpenClaw WhatsApp when the installed version differs", () => {
@@ -10372,10 +10343,7 @@ if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw 2026.7.1-2\\n'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >/dev/null
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "$*" = "plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force" ]; then
   printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   touch '${installedMarker}'
@@ -10398,6 +10366,7 @@ exit 0
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
+		writeFakeOpenClawConfigMutationSdk(home);
 		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 10);
 		loaded.manifest.projection = {
 			...loaded.manifest.projection,
@@ -10453,6 +10422,9 @@ exit 0
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
 		const paths = getRuntimePaths();
+		const nativeConfigPath = writeFakeOpenClawConfigMutationSdk(home, {
+			initialConfig: { channels: { telegram: { botToken: "user-token" } } },
+		});
 		const liveFiles = [
 			join(paths.runConfigRoot, "openclaw.json"),
 			join(paths.runConfigRoot, "stale-runtime.json"),
@@ -10463,7 +10435,7 @@ exit 0
 			writeFileSync(path, `generation-1:${path.split("/").at(-1)}\n`);
 		}
 		const previousLiveSnapshot = Object.fromEntries(
-			liveFiles.map((path) => [path, readFileSync(path, "utf-8")]),
+			[...liveFiles, nativeConfigPath].map((path) => [path, readFileSync(path, "utf-8")]),
 		);
 		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2);
 		loaded.manifest.projection = {
@@ -10726,13 +10698,12 @@ exit 64
 		expect(existsSync(openclawPluginInstalls)).toBe(false);
 	});
 
-	it("removes stale native channels when a later projection omits them", () => {
+	it("removes only committed managed accounts when a later projection omits them", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatch = join(root, "openclaw-channel-remove-patch.jsonl");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
 		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		mkdirSync(join(home, ".local", "bin"), { recursive: true });
@@ -10749,11 +10720,7 @@ if [ "$*" = "plugins install --help" ]; then
   printf '%s\\n' '--accept-capabilities'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >> '${openclawPatch}'
-  printf '\\n---\\n' >> '${openclawPatch}'
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "$*" = "plugins install @openclaw/discord --force --accept-capabilities" ]; then
   printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   mkdir -p '${dirname(openclawPluginSource)}'
@@ -10773,52 +10740,73 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const manifestWithChannels = (
-			channels: Record<string, unknown>,
-			generation: number,
-		): RuntimeManifestLoad => {
-			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", generation);
-			loaded.manifest.projection = { ...loaded.manifest.projection, channels };
-			return loaded;
-		};
-		const telegramChannel = {
-			enabled: true,
-			defaultAccount: "default",
-			accounts: { default: { enabled: true, botToken: "telegram-token" } },
-		};
-
-		const initial = convergeRuntimeManifest(
-			manifestWithChannels(
-				{
-					telegram: telegramChannel,
-					discord: { enabled: true, token: "discord-token" },
-				},
-				1,
-			),
-			getRuntimePaths(),
+		const personal = { enabled: true, token: "native-personal-token", dmPolicy: "pairing" };
+		const configPath = writeFakeOpenClawConfigMutationSdk(home, {
+			initialConfig: {
+				channels: { discord: { defaultAccount: "personal", accounts: { personal } } },
+			},
+		});
+		const bindings = (["telegram", "discord"] as const).map((provider) => ({
+			provider,
+			accountKey: `clawdi_${provider}`,
+			agentTokenSecretRef: `secret://channels/${provider}/clawdi_${provider}/agent-token`,
+			placeholderTokenSecretRef: `secret://channels/${provider}/clawdi_${provider}/placeholder-token`,
+		}));
+		const secrets = Object.fromEntries(
+			bindings.flatMap((binding) => [
+				[binding.agentTokenSecretRef, `${binding.provider}-agent-token`],
+				[
+					binding.placeholderTokenSecretRef,
+					binding.provider === "telegram"
+						? `999999999:${"0".repeat(32)}`
+						: `clawdi_${"0".repeat(32)}`,
+				],
+			]),
 		);
-		const removed = convergeRuntimeManifest(
-			manifestWithChannels({ telegram: telegramChannel }, 2),
-			getRuntimePaths(),
-		);
-		const unlinked = convergeRuntimeManifest(manifestWithChannels({}, 3), getRuntimePaths());
-
+		const paths = getRuntimePaths();
+		const initialLoad = await hostedChannelBundleLoad(home, "openclaw", 1, bindings, secrets);
+		const initial = convergeAndCommitTestRuntimeManifest(initialLoad, paths);
 		expect(initial.installErrors).toEqual([]);
+		const configured = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(configured.channels.discord.accounts).toMatchObject({
+			personal,
+			clawdi_discord: { enabled: true },
+		});
+		expect(configured.channels.telegram.accounts).toHaveProperty("clawdi_telegram");
+		expect(configured.session.dmScope).toBe("per-account-channel-peer");
+
+		const telegramOnly = bindings.filter((binding) => binding.provider === "telegram");
+		const telegramSecrets = Object.fromEntries(
+			Object.entries(secrets).filter(([ref]) => ref.includes("/telegram/")),
+		);
+		const removedLoad = await hostedChannelBundleLoad(
+			home,
+			"openclaw",
+			2,
+			telegramOnly,
+			telegramSecrets,
+		);
+		const removed = convergeAndCommitTestRuntimeManifest(removedLoad, paths);
 		expect(removed.installErrors).toEqual([]);
+		const remaining = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(remaining.channels.discord.accounts).toEqual({ personal });
+		expect(remaining.channels.discord.defaultAccount).toBe("personal");
+		expect(remaining.plugins.entries.discord.enabled).toBe(true);
+		expect(remaining.channels.telegram).toEqual(configured.channels.telegram);
+		expect(readSystemdEnvFile(paths, "openclaw-gateway")).not.toContain(
+			"CLAWDI_CHANNEL_DISCORD_CLAWDI_DISCORD_AGENT_TOKEN=",
+		);
+
+		const unlinkedLoad = await hostedChannelBundleLoad(home, "openclaw", 3, [], {});
+		const unlinked = convergeAndCommitTestRuntimeManifest(unlinkedLoad, paths);
 		expect(unlinked.installErrors).toEqual([]);
-		const patches = readFileSync(openclawPatch, "utf-8")
-			.split("\n---\n")
-			.filter((entry) => entry.trim().length > 0)
-			.map((entry) => JSON.parse(entry))
-			.filter((patch) => Object.hasOwn(patch, "channels"));
-		expect(patches).toHaveLength(3);
-		expect(patches[0].channels.discord).toEqual({ enabled: true, token: "discord-token" });
-		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
-		expect(patches[1].channels.discord).toBeNull();
-		expect(patches[1].plugins.entries.discord).toBeNull();
-		expect(patches[1].channels.telegram).toEqual(telegramChannel);
-		expect(patches[2].session).toEqual({ dmScope: null });
-		expect(patches[2].channels.telegram).toBeNull();
+		const final = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(final.channels.telegram.accounts).toEqual({});
+		expect(final.channels.discord).toEqual(remaining.channels.discord);
+		expect(final.session.dmScope).toBe("per-account-channel-peer");
+		expect(readSystemdEnvFile(paths, "openclaw-gateway")).not.toContain(
+			"CLAWDI_CHANNEL_TELEGRAM_CLAWDI_TELEGRAM_AGENT_TOKEN=",
+		);
 		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
 			"plugins install @openclaw/discord --force --accept-capabilities\n",
 		);
@@ -10829,7 +10817,6 @@ exit 64
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatch = join(root, "openclaw-channel-patch.json");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
 		const openclawPluginSource = join(home, ".openclaw", "extensions", "discord", "index.js");
 		mkdirSync(dirname(openclawBin), { recursive: true });
@@ -10847,10 +10834,7 @@ if [ "$*" = "plugins install --help" ]; then
   printf '%s\\n' '--accept-capabilities'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat > '${openclawPatch}'
-  exit 0
-fi
+${fakeOpenClawConfigPatchCommand(join(home, ".openclaw", "openclaw.json"))}
 if [ "$*" = "plugins install @openclaw/discord --force --accept-capabilities" ]; then
   printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
@@ -10870,11 +10854,15 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
+		writeFakeOpenClawConfigMutationSdk(home);
 		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2);
 		loaded.manifest.projection = {
 			...loaded.manifest.projection,
 			channels: {
-				discord: { token: "secret://channels/discord/acct-discord-1" },
+				discord: {
+					enabled: true,
+					accounts: { managed: { enabled: true, token: "native-discord-token" } },
+				},
 			},
 		};
 
@@ -10882,9 +10870,12 @@ exit 64
 
 		expect(convergence.installErrors).toEqual([]);
 		expect(existsSync(openclawPluginInstalls)).toBe(false);
-		const patchText = readFileSync(openclawPatch, "utf-8");
-		expect(patchText).toContain('"discord"');
-		expect(patchText).toContain('"plugins"');
+		const native = JSON.parse(readFileSync(join(home, ".openclaw", "openclaw.json"), "utf8"));
+		expect(native.channels.discord.accounts.managed).toEqual({
+			enabled: true,
+			token: "native-discord-token",
+		});
+		expect(native.plugins.entries.discord.enabled).toBe(true);
 	});
 
 	it("derives hosted workspace and explicit process cwd from HOME", async () => {


### PR DESCRIPTION
Managed channel reconciliation replaced native account maps and disabled unrelated Hermes platforms; managed chat provider changes also cleared independent memory search settings. Preserve native accounts, policies and memory choices, and remove only previously committed managed accounts whose credentials still match.

OpenClaw channel ownership checks execute against the current draft inside the official configuration mutation lock for both updates and deletion. Missing managed credential references fail convergence instead of publishing a successful applied state. Existing nested native memory settings are preserved. The user-approved managed WhatsApp transport and Hermes scanner policy are unchanged.

Validation: the final integrated 0.14.79 candidate passed the complete CLI suite (156 files, exit 0), all five workspace typechecks, Biome, Node/Linux native builds, pack manifest and generated API checks in isolated Docker. Existing upstream component/sync changes are preserved. Native writer locking was verified against OpenClaw 2026.9.4; arbitrary writes ignoring that lock are not covered.

Release: publishes CLI 0.14.79. Configured managed channel permission defaults, private-message isolation, credential routing, Baileys compatibility and scanner policy are preserved. Unknown historical ownership is retained instead of guessed; obsolete embedding references may require explicit native configuration. Other discretionary native-defaults audit items remain outside this PR. Exact final-head CI is required before merge.
