### PR TITLE
Release CLI 0.14.78 with component failure isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### CLI 0.14.78
+
+- Session and Skill synchronization recover independently after startup or watcher
+  failures, keeping queued changes while unaffected synchronization continues.
+- Recovery and Project changes wait for in-flight work to finish before restarting
+  synchronization, preventing cancelled work from confirming stale changes.
+- Managed runtimes report Files, Hermes UI, and OpenClaw UI readiness independently,
+  allowing healthy components to remain accessible during unrelated failures when
+  supported by the server. Existing runtimes need a successful configuration apply
+  before independent readiness is available.
+- Hermes UI readiness recognizes its native login page even when the gateway is
+  unavailable; inconclusive component checks no longer imply a definite failure.
+
 ### Fixed
 
 - CLI 0.14.77 restores missing managed OpenClaw service environment files before

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.77",
+      "version": "0.14.78",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.77",
+	"version": "0.14.78",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Title: Release CLI 0.14.78 with independent sync recovery and component readiness

Prepare `clawdi@0.14.78` from merged component-isolation changes. Session and Skill synchronization recover independently while retaining queued changes; cancelled work cannot confirm stale changes during recovery or Project changes. Managed runtimes can report independent Files, Hermes UI, and OpenClaw UI readiness, including the native Hermes login page when its gateway is unavailable. Independent access requires supporting servers and a successful configuration apply.

Only `packages/cli/package.json`, the Bun-generated workspace version in `bun.lock`, and curated `CHANGELOG.md` notes change. No feature code or dependency versions change. npm `latest` was `0.14.77`, released from `1d206a9458bda24631bf989d3453c66494df55d3`; the delta is PR #1509. Queue/systemd recovery (#1505) and retained OpenClaw recovery (#1508) are already in 0.14.77 and are excluded from the new notes.

Release impact: merging the package identity change into main automatically starts Publish Agent v2 CLI and publishes stable to `latest`. HOLD merge until the root operator verifies Cloud reader source `8896b64679f9bd02a1b3a0e2d11bdc48888403cf` is deployed. Hosted reader `ebbf1b848` deployment and live OpenAPI confirmation were supplied by the root; this candidate task does not independently establish live state. No schema migration is introduced by this PR.

Qualification: see the accompanying candidate report for exact source/artifact identity and local Docker results. Required release CI still runs the complete CLI suite, builds the six-target native matrix, verifies its manifest, exercises Linux installer/daemon lifecycle, and packs/installs one immutable npm tarball. The protected job verifies the same transferred artifacts and publishes through OIDC. A published version cannot be reused for different bytes or a different source commit; recover an incomplete release by rerunning its original workflow.

No publication, beta publication, push, merge, workflow dispatch, Hosted mutation, or tenant upgrade was performed. Preserve model selection, existing image cohorts, and V1. Candidate artifacts are local qualification outputs, not evidence of installed-user adoption or the future workflow's byte identity.

Candidate head: `a3f07032466c9a988a449c5e5c96a19e3ff9ce49` (base `8896b64679f9bd02a1b3a0e2d11bdc48888403cf`).

Verified in bounded Docker: CLI typecheck; 431 tests across 17 files (0 failures); `bun run check` (4 existing warnings, no fixes); official CLI build; publish manifest and npm pack inventory; isolated npm tarball installation with exact version and bundled resources. Full CLI release CI remains required.

Native verification: 4 Linux installer/daemon lifecycle tests, 69 assertions, 0 failures; all six native targets built and verified by the official exact-version manifest checker. The first matrix attempt failed extracting the Bun macOS cross-compiler; a fresh bounded container with Bun temporary/cache directories on its disposable filesystem completed without source changes.
