### PR TITLE
Fix Hermes inline credential proof and release CLI 0.14.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### CLI 0.14.80
+
+- Hermes dashboard readiness proves both inline and file-backed credentials and
+  invalidates stale proof when either configuration changes.
+
 ### CLI 0.14.79
 
 - Managed channel changes preserve native accounts, access policies, and independent

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.79",
+      "version": "0.14.80",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.79",
+	"version": "0.14.80",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/component-observation.ts
+++ b/packages/cli/src/runtime/component-observation.ts
@@ -120,8 +120,9 @@ function configRevision(
 			files = [join(paths.userHome, ".openclaw", "openclaw.json")];
 		else {
 			const run = readRuntimeServiceRunConfig("hermes", "dashboard", paths);
-			if (run.status !== "ok" || !run.config.secretFilePath) return null;
-			files = [runtimeRunConfigPath("hermes", paths, "dashboard"), run.config.secretFilePath];
+			if (run.status !== "ok") return null;
+			files = [runtimeRunConfigPath("hermes", paths, "dashboard")];
+			if (run.config.secretFilePath) files.push(run.config.secretFilePath);
 		}
 		const contents = files.map((path) => {
 			const stat = lstatSync(path);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5317,15 +5317,27 @@ test("Hermes component proof accepts inline credentials and detects their mutati
 	};
 	writeRuntimeAppliedState(applied, paths);
 	persistComponentActivations(load, paths, readServiceState);
-	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("ok");
+	expect(
+		(await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]
+			?.status,
+	).toBe("ok");
 	const unitPath = join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service");
 	const unit = readFileSync(unitPath, "utf8");
 	writeFileSync(unitPath, unit.replace("inline-password", "mutated-password"));
-	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("unknown");
+	expect(
+		(await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]
+			?.status,
+	).toBe("unknown");
 	writeFileSync(unitPath, unit);
-	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("ok");
+	expect(
+		(await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]
+			?.status,
+	).toBe("ok");
 	const runConfigPath = runtimeRunConfigPath("hermes", paths, "dashboard");
 	const runConfigBytes = readFileSync(runConfigPath, "utf8");
 	writeFileSync(runConfigPath, runConfigBytes.replace('"generation": 1', '"generation": 2'));
-	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("unknown");
+	expect(
+		(await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]
+			?.status,
+	).toBe("unknown");
 });

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5284,7 +5284,7 @@ test("Hermes component proof accepts inline credentials and detects their mutati
 		join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
 		`${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n[Unit]\nDescription=Hermes dashboard\n[Service]\nExecStart=/home/clawdi/.local/bin/hermes dashboard\nEnvironment=HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=inline-password\nEnvironment=HERMES_DASHBOARD_BASIC_AUTH_SECRET=inline-session\n`,
 	);
-	const runConfig = buildRuntimeRunConfig({
+	const generatedRunConfig = buildRuntimeRunConfig({
 		runtime: "hermes",
 		service: "dashboard",
 		enabled: true,
@@ -5299,9 +5299,9 @@ test("Hermes component proof accepts inline credentials and detects their mutati
 			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "secret://runtime/hermes/dashboard-session-secret",
 		},
 	});
-	expect(runConfig.secretFilePath).toBeNull();
+	expect(generatedRunConfig.secretFilePath).toBeNull();
 	ensureRuntimeStateDirs(paths);
-	writeRuntimeRunConfig(runConfig, paths);
+	writeRuntimeRunConfig(generatedRunConfig, paths);
 	const activated = Object.fromEntries(readSystemdUnitSnapshot(paths).user);
 	const serviceState = { invocationId: "a".repeat(32), configurationRevision: "1".repeat(64) };
 	const readServiceState = (_scope: "system" | "user", _unit: string) => serviceState;
@@ -5318,6 +5318,14 @@ test("Hermes component proof accepts inline credentials and detects their mutati
 	writeRuntimeAppliedState(applied, paths);
 	persistComponentActivations(load, paths, readServiceState);
 	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("ok");
-	writeFileSync(join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"), "mutated-inline-credential");
+	const unitPath = join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service");
+	const unit = readFileSync(unitPath, "utf8");
+	writeFileSync(unitPath, unit.replace("inline-password", "mutated-password"));
+	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("unknown");
+	writeFileSync(unitPath, unit);
+	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("ok");
+	const runConfigPath = runtimeRunConfigPath("hermes", paths, "dashboard");
+	const runConfigBytes = readFileSync(runConfigPath, "utf8");
+	writeFileSync(runConfigPath, runConfigBytes.replace('"generation": 1', '"generation": 2'));
 	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("unknown");
 });

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -74,7 +74,12 @@ import {
 import { parseHostedRuntimeBundleV2, type RuntimeManifestLoad } from "./manifest-source";
 import { applyOpenClawHostedChannelPatch } from "./openclaw-provider-config";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
-import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
+import {
+	buildRuntimeRunConfig,
+	type RuntimeRunSettings,
+	runtimeRunConfigPath,
+	writeRuntimeRunConfig,
+} from "./run-config";
 import {
 	canonicalSecretRefSchema,
 	normalizeSecretValues,
@@ -5264,4 +5269,55 @@ test("component proof requires committed configuration and a stable live invocat
 			async () => true,
 		),
 	).toBeUndefined();
+});
+
+test("Hermes component proof accepts inline credentials and detects their mutation", async () => {
+	const paths = tempRuntimePaths();
+	const load = normalizeHostedBundleFixture(hostedHermesManifestFixture({ generation: 1 }), {
+		...TEST_HOSTED_SECRET_VALUES,
+		"secret://runtime/hermes/dashboard-password": "inline-password",
+		"secret://runtime/hermes/dashboard-session-secret": "inline-session",
+	});
+	const manifest = load.manifest;
+	mkdirSync(paths.systemdUserRoot, { recursive: true });
+	writeFileSync(
+		join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
+		`${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n[Unit]\nDescription=Hermes dashboard\n[Service]\nExecStart=/home/clawdi/.local/bin/hermes dashboard\nEnvironment=HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=inline-password\nEnvironment=HERMES_DASHBOARD_BASIC_AUTH_SECRET=inline-session\n`,
+	);
+	const runConfig = buildRuntimeRunConfig({
+		runtime: "hermes",
+		service: "dashboard",
+		enabled: true,
+		generatedAt: "2026-08-05T00:00:00.000Z",
+		generation: 1,
+		instanceId: manifest.instanceId,
+		commandPath: "/home/clawdi/.local/bin/hermes",
+		appRoot: null,
+		workspaceRoot: paths.userHome,
+		secretEnv: {
+			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "secret://runtime/hermes/dashboard-password",
+			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "secret://runtime/hermes/dashboard-session-secret",
+		},
+	});
+	expect(runConfig.secretFilePath).toBeNull();
+	ensureRuntimeStateDirs(paths);
+	writeRuntimeRunConfig(runConfig, paths);
+	const activated = Object.fromEntries(readSystemdUnitSnapshot(paths).user);
+	const serviceState = { invocationId: "a".repeat(32), configurationRevision: "1".repeat(64) };
+	const readServiceState = (_scope: "system" | "user", _unit: string) => serviceState;
+	const activation = captureComponentActivations(load, paths, activated, readServiceState);
+	expect(activation).toHaveLength(1);
+	const applied = {
+		schemaVersion: "clawdi.runtimeAppliedState.v2" as const,
+		appliedAt: new Date().toISOString(), instanceId: manifest.instanceId,
+		sourceRevision: "b".repeat(64), etag: `"sha256:${"b".repeat(64)}"`, generation: 1,
+		manifestETag: '"fixture-manifest"', applyReceiptId: "fixture-apply-receipt", bootNonce: "fixture-boot-nonce",
+		contentIdentity: { sourcePath: "fixture", sha256: "c".repeat(64) }, activated,
+		providerIds: [], projectedProviderIds: {},
+	};
+	writeRuntimeAppliedState(applied, paths);
+	persistComponentActivations(load, paths, readServiceState);
+	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("ok");
+	writeFileSync(join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"), "mutated-inline-credential");
+	expect((await observeComponents(paths, applied, readServiceState, async () => true))?.entries[0]?.status).toBe("unknown");
 });

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5309,11 +5309,18 @@ test("Hermes component proof accepts inline credentials and detects their mutati
 	expect(activation).toHaveLength(1);
 	const applied = {
 		schemaVersion: "clawdi.runtimeAppliedState.v2" as const,
-		appliedAt: new Date().toISOString(), instanceId: manifest.instanceId,
-		sourceRevision: "b".repeat(64), etag: `"sha256:${"b".repeat(64)}"`, generation: 1,
-		manifestETag: '"fixture-manifest"', applyReceiptId: "fixture-apply-receipt", bootNonce: "fixture-boot-nonce",
-		contentIdentity: { sourcePath: "fixture", sha256: "c".repeat(64) }, activated,
-		providerIds: [], projectedProviderIds: {},
+		appliedAt: new Date().toISOString(),
+		instanceId: manifest.instanceId,
+		sourceRevision: "b".repeat(64),
+		etag: `"sha256:${"b".repeat(64)}"`,
+		generation: 1,
+		manifestETag: '"fixture-manifest"',
+		applyReceiptId: "fixture-apply-receipt",
+		bootNonce: "fixture-boot-nonce",
+		contentIdentity: { sourcePath: "fixture", sha256: "c".repeat(64) },
+		activated,
+		providerIds: [],
+		projectedProviderIds: {},
 	};
 	writeRuntimeAppliedState(applied, paths);
 	persistComponentActivations(load, paths, readServiceState);


### PR DESCRIPTION
A live owner Hermes deployment upgraded to 0.14.78 remained healthy but never emitted Hermes UI component proof: its official dashboard run config used inline credentials with secretFilePath=null, while proof capture required a separate secret file.

Always bind the generated run config and include the secret file only when configured. Preserve unit/configuration fingerprints, invocation checks, access revision and parent receipt fences. Prepare immutable CLI 0.14.80; 0.14.79 is already published and its changes are retained.

Focused hermetic regression checks pass (2 tests and CLI typecheck), covering inline credential mutation, restoration and run-config mutation alongside the existing file-backed case. The broader JS run was stopped and is not reported as passing. Full CI and independent Fable review are required before merge/publication; subsequent owner runtime validation is still pending. No fleet upgrade.
