### PR TITLE
Add extra fields and dotenv import to private Vault requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ database migration, CI, and implementation details.
 
 ## Unreleased
 
+### CLI 0.14.81
+
+- Vault request pages support added fields and pasted or uploaded `.env` imports,
+  with an explicit preview before one save. Requested fields stay required; up to
+  32 fields can be saved together.
+- Bundled agent guidance recognizes user-added fields and their saved Vault references.
+- The accompanying Vault update expires older pending request links. Ask your agent
+  for a new link; saved credentials and request history are preserved.
+
 ### CLI 0.14.80
 
 - Hermes dashboard readiness proves both inline and file-backed credentials and

--- a/apps/web/e2e/vault-request.pw.ts
+++ b/apps/web/e2e/vault-request.pw.ts
@@ -147,3 +147,110 @@ test("an intervening change clears the mixed form without claiming success", asy
 	await expect(page.getByRole("textbox")).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Copy message for agent" })).toHaveCount(0);
 });
+
+for (const viewport of [
+	{ width: 1280, height: 900 },
+	{ width: 390, height: 844 },
+]) {
+	test(`dotenv preview and user-added fields at ${viewport.width}px`, async ({
+		page,
+	}, testInfo) => {
+		await page.setViewportSize(viewport);
+		let submissions = 0;
+		await page.route("**/v1/vault/requests/**", async (route) => {
+			const body = route.request().postDataJSON();
+			if (route.request().url().endsWith("/supply")) {
+				submissions++;
+				expect(body.fields).toEqual({
+					API_KEY: "synthetic-import",
+					API_SECRET: "synthetic-secret",
+					"api.key": "${LITERAL}",
+					"api-key": "synthetic-new",
+				});
+				return route.fulfill({
+					json: {
+						...context,
+						fields: Object.keys(body.fields),
+						extra_fields: ["api.key", "api-key"],
+						status: "supplied",
+					},
+				});
+			}
+			return route.fulfill({
+				json: { ...context, update_fields: body.fields?.includes("api.key") ? ["api.key"] : [] },
+			});
+		});
+		await page.goto(`/vault-request#${token}`);
+		await page.getByLabel("API_KEY", { exact: true }).fill("synthetic-draft");
+		await page.getByLabel("API_SECRET", { exact: true }).fill("synthetic-secret");
+		await page.getByRole("button", { name: "Add field", exact: true }).click();
+		await page.getByRole("textbox", { name: "Field name", exact: true }).fill("temporary");
+		await page.getByRole("textbox", { name: "Field name", exact: true }).fill("renamed");
+		await page.getByRole("button", { name: "Remove renamed" }).click();
+		await expect(page.getByRole("textbox", { name: "Field name", exact: true })).toHaveCount(0);
+		await page.getByRole("button", { name: "Import .env", exact: true }).click();
+		const dotenv = "API_KEY=synthetic-import\napi.key=${LITERAL}\napi-key=synthetic-new";
+		if (viewport.width < 500) {
+			await page
+				.getByLabel("Choose .env file")
+				.setInputFiles({ name: ".env", mimeType: "text/plain", buffer: Buffer.from(dotenv) });
+		} else {
+			await page.getByLabel("Dotenv text").fill(dotenv);
+		}
+		await expect(page.getByLabel("Dotenv text")).toHaveValue(dotenv);
+		await expect(page.getByRole("button", { name: "Save secrets", exact: true })).toBeDisabled();
+		await page.getByRole("button", { name: "Preview import", exact: true }).click();
+		await expect(page.getByText("Replace entered value", { exact: false })).toBeVisible();
+		await expect(
+			page.getByText("Update existing Vault value on save", { exact: false }),
+		).toBeVisible();
+		await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-draft");
+		await page.screenshot({
+			path: testInfo.outputPath(`preview-${viewport.width}.png`),
+			fullPage: true,
+		});
+		expect(submissions).toBe(0);
+		await page.getByRole("button", { name: "Apply import", exact: true }).click();
+		await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-import");
+		await expect(page.getByRole("textbox", { name: "Field name", exact: true })).toHaveCount(2);
+		await expect(page.getByText("Update", { exact: true })).toHaveCount(1);
+		await page.screenshot({
+			path: testInfo.outputPath(`fields-${viewport.width}.png`),
+			fullPage: true,
+		});
+		expect(
+			await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+		).toBe(true);
+		await page.getByRole("button", { name: "Save secrets", exact: true }).click();
+		await expect(page.getByRole("status")).toContainText("Your secrets are saved");
+		expect(submissions).toBe(1);
+		await page.screenshot({
+			path: testInfo.outputPath(`saved-${viewport.width}.png`),
+			fullPage: true,
+		});
+	});
+}
+
+test("an import of only requested names requires Apply and keeps a usable Save", async ({
+	page,
+}) => {
+	await page.route("**/v1/vault/requests/inspect", (route) => route.fulfill({ json: context }));
+	await page.goto(`/vault-request#${token}`);
+	await page.getByLabel("API_KEY", { exact: true }).fill("synthetic-original");
+	await page.getByRole("button", { name: "Import .env", exact: true }).click();
+	await page.getByLabel("Dotenv text").fill("API_KEY=synthetic-new\nAPI_KEY=duplicate");
+	await page.getByRole("button", { name: "Preview import", exact: true }).click();
+	await expect(page.getByRole("alert")).toContainText("duplicate");
+	await expect(page.getByRole("button", { name: "Apply import", exact: true })).toHaveCount(0);
+	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-original");
+	await page.getByLabel("Dotenv text").fill("API_KEY=synthetic-new");
+	await page.getByRole("button", { name: "Preview import", exact: true }).click();
+	await page.getByRole("button", { name: "Cancel import", exact: true }).click();
+	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-original");
+	await page.getByRole("button", { name: "Import .env", exact: true }).click();
+	await page.getByLabel("Dotenv text").fill("API_KEY=synthetic-new");
+	await page.getByRole("button", { name: "Preview import", exact: true }).click();
+	await page.getByRole("button", { name: "Apply import", exact: true }).click();
+	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-new");
+	await expect(page.getByRole("button", { name: "Save secrets", exact: true })).toBeEnabled();
+});

--- a/apps/web/e2e/vault-request.pw.ts
+++ b/apps/web/e2e/vault-request.pw.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Route, test } from "@playwright/test";
 
 const token = `v2_${"a".repeat(43)}`;
 const context = {
@@ -241,6 +241,7 @@ test("an import of only requested names requires Apply and keeps a usable Save",
 	await page.getByLabel("Dotenv text").fill("API_KEY=synthetic-new\nAPI_KEY=duplicate");
 	await page.getByRole("button", { name: "Preview import", exact: true }).click();
 	await expect(page.getByRole("alert")).toContainText("duplicate");
+	await expect(page.getByRole("button", { name: "Retry check", exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Apply import", exact: true })).toHaveCount(0);
 	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-original");
 	await page.getByLabel("Dotenv text").fill("API_KEY=synthetic-new");
@@ -253,4 +254,123 @@ test("an import of only requested names requires Apply and keeps a usable Save",
 	await page.getByRole("button", { name: "Apply import", exact: true }).click();
 	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-new");
 	await expect(page.getByRole("button", { name: "Save secrets", exact: true })).toBeEnabled();
+});
+
+test("selection checks debounce names and ignore an obsolete response", async ({ page }) => {
+	await page.clock.install();
+	const checkedExtras: string[] = [];
+	let obsolete: Route | undefined;
+	await page.route("**/v1/vault/requests/inspect", (route) => {
+		const fields: string[] | undefined = route.request().postDataJSON().fields;
+		const extra = fields?.find((name) => !context.fields.includes(name));
+		if (extra) checkedExtras.push(extra);
+		if (extra === "OLD") {
+			obsolete = route;
+			return;
+		}
+		return route.fulfill({ json: { ...context, update_fields: extra === "API" ? [extra] : [] } });
+	});
+	await page.goto(`/vault-request#${token}`);
+	const save = page.getByRole("button", { name: "Save secrets", exact: true });
+	await expect(save).toBeEnabled();
+	await page.clock.pauseAt(await page.evaluate(() => Date.now() + 1000));
+	await page.getByRole("button", { name: "Add field", exact: true }).click();
+	const name = page.getByRole("textbox", { name: "Field name", exact: true });
+	for (const value of ["A", "AP", "API"]) {
+		await name.fill(value);
+		await expect(save).toBeDisabled();
+		await page.clock.runFor(100);
+		expect(checkedExtras).toEqual([]);
+	}
+	await page.clock.runFor(200);
+	await expect(save).toBeEnabled();
+	expect(checkedExtras).toEqual(["API"]);
+	await expect(page.getByText("Update", { exact: true })).toHaveCount(1);
+	await name.fill("OLD");
+	await expect(save).toBeDisabled();
+	await expect(page.getByText("Update", { exact: true })).toHaveCount(0);
+	await page.clock.runFor(300);
+	await expect.poll(() => obsolete !== undefined).toBe(true);
+	await name.fill("NEW");
+	if (!obsolete) throw new Error("Expected the older selection request");
+	await obsolete.fulfill({ json: { ...context, update_fields: ["API_KEY"] } });
+	await page.clock.runFor(100);
+	await expect(save).toBeDisabled();
+	await expect(page.getByText("Update", { exact: true })).toHaveCount(0);
+	await page.clock.runFor(200);
+	await expect(save).toBeEnabled();
+	expect(checkedExtras).toEqual(["API", "OLD", "NEW"]);
+	await expect(page.getByText("Update", { exact: true })).toHaveCount(0);
+});
+
+test("selection failures distinguish retry, invalid names, conflict and terminal expiry", async ({
+	page,
+}) => {
+	let failure: number | "network" | undefined;
+	await page.route("**/v1/vault/requests/inspect", (route) => {
+		if (!route.request().postDataJSON().fields || failure === undefined)
+			return route.fulfill({ json: context });
+		if (failure === "network") return route.abort("failed");
+		return route.fulfill({
+			status: failure,
+			json: { detail: "Internal diagnostic must not be displayed" },
+		});
+	});
+	await page.goto(`/vault-request#${token}`);
+	const save = page.getByRole("button", { name: "Save secrets", exact: true });
+	const retry = page.getByRole("button", { name: "Retry check", exact: true });
+	await expect(save).toBeEnabled();
+	await page.getByLabel("API_KEY", { exact: true }).fill("synthetic-draft");
+	failure = 500;
+	await page.getByRole("button", { name: "Add field", exact: true }).click();
+	const name = page.getByRole("textbox", { name: "Field name", exact: true });
+	await name.fill("EXTRA");
+	await expect(page.getByRole("alert")).toContainText("server is unavailable");
+	await expect(save).toBeDisabled();
+	await expect(retry).toBeVisible();
+	failure = "network";
+	await retry.click();
+	await expect(page.getByRole("alert")).toContainText("Could not connect");
+	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-draft");
+	failure = 422;
+	await retry.click();
+	await expect(page.getByRole("alert")).toContainText("field names are invalid");
+	await expect(retry).toHaveCount(0);
+	failure = 409;
+	await name.fill("RESERVED");
+	await expect(page.getByRole("alert")).toContainText("changed or are reserved");
+	await expect(retry).toHaveCount(0);
+	await expect(save).toBeDisabled();
+	await expect(page.getByLabel("API_KEY", { exact: true })).toHaveValue("synthetic-draft");
+	failure = 410;
+	await name.fill("EXPIRED");
+	await expect(page.getByRole("alert")).toContainText("link has expired");
+	await expect(page.getByRole("textbox")).toHaveCount(0);
+	await expect(save).toHaveCount(0);
+	await expect(retry).toHaveCount(0);
+});
+
+test("import preview retries server failure and clears the form on terminal expiry", async ({
+	page,
+}) => {
+	let failure = 500;
+	await page.route("**/v1/vault/requests/inspect", (route) => {
+		if (route.request().postDataJSON().fields?.includes("imported")) {
+			return route.fulfill({ status: failure, json: { detail: "Unavailable" } });
+		}
+		return route.fulfill({ json: context });
+	});
+	await page.goto(`/vault-request#${token}`);
+	await page.getByLabel("API_KEY", { exact: true }).fill("synthetic-draft");
+	await page.getByRole("button", { name: "Import .env", exact: true }).click();
+	await page.getByLabel("Dotenv text").fill("imported=synthetic-value");
+	await page.getByRole("button", { name: "Preview import", exact: true }).click();
+	await expect(page.getByRole("alert")).toContainText("server is unavailable");
+	await expect(page.getByRole("button", { name: "Retry check", exact: true })).toHaveCount(0);
+	await expect(page.getByLabel("Dotenv text")).toHaveValue("imported=synthetic-value");
+	failure = 410;
+	await page.getByRole("button", { name: "Preview import", exact: true }).click();
+	await expect(page.getByRole("alert")).toContainText("link has expired");
+	await expect(page.getByRole("textbox")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Save secrets", exact: true })).toHaveCount(0);
 });

--- a/apps/web/src/components/vault/key-import-parse.ts
+++ b/apps/web/src/components/vault/key-import-parse.ts
@@ -16,21 +16,57 @@ export interface ParsedKeyImport {
 	errors: string[];
 }
 
+export interface KeyImportOptions {
+	/** Preserve dotenv names for APIs whose field names are case-sensitive. */
+	preserveKeyCase?: boolean;
+}
+
+export const REQUEST_FIELD_NAME_RE = /^[A-Za-z0-9_.-]{1,200}$/;
+export const MAX_ENV_IMPORT_BYTES = 4 * 1024 * 1024;
+
+/** Dotenv text only: never evaluate substitutions or accept JSON. */
+export function parseVaultRequestEnv(raw: string): ParsedKeyImport {
+	if (new TextEncoder().encode(raw).length > MAX_ENV_IMPORT_BYTES) {
+		return { entries: [], errors: ["Import must be at most 4 MiB."] };
+	}
+	const parsed = parseEnvKeyImport(raw, { preserveKeyCase: true });
+	if (parsed.errors.length)
+		return {
+			entries: [],
+			errors: parsed.errors.map((error) => {
+				const line = /^Line \d+/.exec(error)?.[0];
+				return `${line ?? "Import"}: invalid assignment or duplicate field.`;
+			}),
+		};
+	if (
+		parsed.entries.length > 32 ||
+		parsed.entries.some(({ value }) => !value || [...value].length > 65536 || value.includes("\0"))
+	) {
+		return {
+			entries: [],
+			errors: [
+				"Use at most 32 fields with nonempty text values of at most 65536 characters and no NUL characters.",
+			],
+		};
+	}
+	return parsed;
+}
+
 const KEY_NAME_RE = /^[A-Z0-9_]+$/;
 const KEY_NAME_RULE =
 	"Key names can use only letters, numbers, and underscores (_). Hyphens, spaces, and other characters aren't allowed.";
 
-export function parseVaultKeyImport(raw: string): ParsedKeyImport {
+export function parseVaultKeyImport(raw: string, options: KeyImportOptions = {}): ParsedKeyImport {
 	const text = raw.trim();
 	if (!text) return { entries: [], errors: [] };
 
 	if (text.startsWith("{")) {
-		return parseJsonKeyImport(text);
+		return parseJsonKeyImport(text, options);
 	}
-	return parseEnvKeyImport(raw);
+	return parseEnvKeyImport(raw, options);
 }
 
-function parseJsonKeyImport(text: string): ParsedKeyImport {
+function parseJsonKeyImport(text: string, options: KeyImportOptions): ParsedKeyImport {
 	try {
 		const parsed = JSON.parse(text) as unknown;
 		if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
@@ -39,8 +75,8 @@ function parseJsonKeyImport(text: string): ParsedKeyImport {
 		const entries: ParsedKey[] = [];
 		const errors: string[] = [];
 		for (const [rawKey, rawValue] of Object.entries(parsed)) {
-			const key = normalizeImportKey(rawKey);
-			if (!KEY_NAME_RE.test(key)) {
+			const key = normalizeImportKey(rawKey, options.preserveKeyCase);
+			if (!(options.preserveKeyCase ? REQUEST_FIELD_NAME_RE.test(key) : KEY_NAME_RE.test(key))) {
 				errors.push(`Invalid key "${rawKey}". ${KEY_NAME_RULE}`);
 				continue;
 			}
@@ -56,7 +92,7 @@ function parseJsonKeyImport(text: string): ParsedKeyImport {
 	}
 }
 
-function parseEnvKeyImport(raw: string): ParsedKeyImport {
+function parseEnvKeyImport(raw: string, options: KeyImportOptions): ParsedKeyImport {
 	const entries: ParsedKey[] = [];
 	const errors: string[] = [];
 	raw.split(/\r?\n/).forEach((line, index) => {
@@ -70,59 +106,54 @@ function parseEnvKeyImport(raw: string): ParsedKeyImport {
 			return;
 		}
 		const rawKey = source.slice(0, equalsIndex).trim();
-		const key = normalizeImportKey(rawKey);
-		if (!KEY_NAME_RE.test(key)) {
+		const key = normalizeImportKey(rawKey, options.preserveKeyCase);
+		if (!(options.preserveKeyCase ? REQUEST_FIELD_NAME_RE.test(key) : KEY_NAME_RE.test(key))) {
 			errors.push(`Line ${lineNumber}: invalid key "${rawKey}". ${KEY_NAME_RULE}`);
+			return;
+		}
+		const valueSource = source.slice(equalsIndex + 1);
+		const value = parseEnvValue(valueSource);
+		if (value === null) {
+			errors.push(`Line ${lineNumber}: unterminated quoted value.`);
 			return;
 		}
 		entries.push({
 			key,
 			rawKey,
-			value: parseEnvValue(source.slice(equalsIndex + 1)),
+			value,
 			line: lineNumber,
 		});
 	});
 	return withDuplicateErrors(entries, errors);
 }
 
-function parseEnvValue(rawValue: string) {
-	const value = stripEnvInlineComment(rawValue).trim();
-	if (
-		(value.startsWith('"') && value.endsWith('"')) ||
-		(value.startsWith("'") && value.endsWith("'"))
-	) {
-		const unquoted = value.slice(1, -1);
-		if (value.startsWith('"')) {
-			return unquoted
-				.replace(/\\n/g, "\n")
-				.replace(/\\r/g, "\r")
-				.replace(/\\t/g, "\t")
-				.replace(/\\"/g, '"')
-				.replace(/\\\\/g, "\\");
+function parseEnvValue(rawValue: string): string | null {
+	const value = rawValue.trim();
+	const quote = value[0];
+	if (quote !== '"' && quote !== "'") return value.replace(/\s+#.*$/, "").trimEnd();
+	let result = "";
+	for (let i = 1; i < value.length; i++) {
+		const char = value[i];
+		if (char === quote) {
+			const tail = value.slice(i + 1);
+			return /^\s*(?:#.*)?$/.test(tail) ? result : null;
 		}
-		return unquoted;
+		if (char === "\\" && quote === '"') {
+			const next = value[i + 1];
+			const decoded: Record<string, string> = { n: "\n", r: "\r", t: "\t", '"': '"', "\\": "\\" };
+			if (next !== undefined && decoded[next] !== undefined) {
+				result += decoded[next];
+				i++;
+				continue;
+			}
+		}
+		result += char;
 	}
-	return value;
+	return null;
 }
 
-function stripEnvInlineComment(rawValue: string) {
-	let quote: '"' | "'" | null = null;
-	for (let i = 0; i < rawValue.length; i++) {
-		const char = rawValue[i];
-		const prev = i > 0 ? rawValue[i - 1] : "";
-		if ((char === '"' || char === "'") && prev !== "\\") {
-			quote = quote === char ? null : (quote ?? char);
-			continue;
-		}
-		if (char === "#" && quote === null && /\s/.test(prev)) {
-			return rawValue.slice(0, i).trimEnd();
-		}
-	}
-	return rawValue;
-}
-
-function normalizeImportKey(rawKey: string) {
-	return rawKey.trim().toUpperCase();
+function normalizeImportKey(rawKey: string, preserveCase = false) {
+	return preserveCase ? rawKey.trim() : rawKey.trim().toUpperCase();
 }
 
 function withDuplicateErrors(entries: ParsedKey[], errors: string[]): ParsedKeyImport {

--- a/apps/web/src/components/vault/key-import.test.ts
+++ b/apps/web/src/components/vault/key-import.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { parseVaultKeyImport } from "./key-import-parse";
+import { parseVaultKeyImport, parseVaultRequestEnv } from "./key-import-parse";
 
 describe("parseVaultKeyImport", () => {
+	test("preserves exact request field names and rejects malformed lines", () => {
+		expect(
+			parseVaultKeyImport("api-key=one\napi.token=two\nAPI_TOKEN=three", { preserveKeyCase: true }),
+		).toEqual({
+			entries: [
+				{ key: "api-key", rawKey: "api-key", value: "one", line: 1 },
+				{ key: "api.token", rawKey: "api.token", value: "two", line: 2 },
+				{ key: "API_TOKEN", rawKey: "API_TOKEN", value: "three", line: 3 },
+			],
+			errors: [],
+		});
+	});
+
+	test("rejects unterminated quotes without lossy backslash decoding", () => {
+		expect(
+			parseVaultKeyImport('TOKEN="literal\\n"', { preserveKeyCase: true }).entries[0]?.value,
+		).toBe("literal\n");
+		expect(parseVaultKeyImport('TOKEN="unterminated', { preserveKeyCase: true }).errors).toEqual([
+			"Line 1: unterminated quoted value.",
+		]);
+	});
 	test("parses dotenv key-value lines", () => {
 		expect(
 			parseVaultKeyImport(`
@@ -83,5 +104,46 @@ describe("parseVaultKeyImport", () => {
 			entries: [],
 			errors: ['Key "API_KEY" has a nested value. Use a string, number, or boolean.'],
 		});
+	});
+});
+
+describe("request dotenv boundary", () => {
+	test("preserves exact names and literal substitutions", () => {
+		const result = parseVaultRequestEnv(
+			'export api.key="${TOKEN} $(command) `command`"\napi-key=one\nAPI-KEY=two',
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.entries.map(({ key, value }) => [key, value])).toEqual([
+			["api.key", "${TOKEN} $(command) `command`"],
+			["api-key", "one"],
+			["API-KEY", "two"],
+		]);
+	});
+	test("rejects malformed, duplicate, invalid and oversized input atomically without echoing it", () => {
+		for (const text of [
+			'K="',
+			'K="one" trailing',
+			'K="one" "two"',
+			"K=secret\nK=other",
+			"bad/name=secret",
+			"K=",
+			"K=\0secret",
+			'{"K":"secret"}',
+			`K=${"s".repeat(65537)}`,
+			Array.from({ length: 33 }, (_, i) => `K${i}=secret`).join("\n"),
+		]) {
+			const result = parseVaultRequestEnv(text);
+			expect(result.entries).toEqual([]);
+			expect(result.errors.length).toBeGreaterThan(0);
+			expect(result.errors.join()).not.toContain("secret");
+		}
+	});
+	test("handles comments, CRLF, quotes and backslash parity", () => {
+		expect(
+			parseVaultRequestEnv(
+				"A=\"path\\\\\" # comment\r\nB=hash#tail\r\nC=one # comment\r\nD='literal\\n'",
+			).entries.map((entry) => entry.value),
+		).toEqual(["path\\", "hash#tail", "one", "literal\\n"]);
+		expect(parseVaultRequestEnv(`K=${"x".repeat(65536)}`).errors).toEqual([]);
 	});
 });

--- a/apps/web/src/pages/vault-request.tsx
+++ b/apps/web/src/pages/vault-request.tsx
@@ -3,8 +3,15 @@ import createClient from "openapi-fetch";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+	MAX_ENV_IMPORT_BYTES,
+	type ParsedKey,
+	parseVaultRequestEnv,
+	REQUEST_FIELD_NAME_RE,
+} from "@/components/vault/key-import-parse";
 import { env } from "@/lib/env";
 
 type RequestContext = components["schemas"]["VaultSecretRequestStatus"];
@@ -15,7 +22,18 @@ const UNAVAILABLE =
 export function VaultRequestPage() {
 	const token = useRef("");
 	const [context, setContext] = useState<RequestContext>();
-	const [values, setValues] = useState<Record<string, string>>({});
+	const [rows, setRows] = useState<
+		{ id: string; name: string; value: string; required: boolean }[]
+	>([]);
+	const [importOpen, setImportOpen] = useState(false);
+	const [importText, setImportText] = useState("");
+	const [preview, setPreview] = useState<{ entries: ParsedKey[]; updateFields: string[] }>();
+	const [selectionError, setSelectionError] = useState("");
+	const [importBusy, setImportBusy] = useState(false);
+	const [updates, setUpdates] = useState<string[]>([]);
+	const [selectionAttempt, setSelectionAttempt] = useState(0);
+	const [selectionReady, setSelectionReady] = useState(false);
+	const names = JSON.stringify(rows.map((row) => row.name));
 	const [phase, setPhase] = useState<
 		"loading" | "ready" | "saving" | "done" | "unavailable" | "error"
 	>("loading");
@@ -59,6 +77,15 @@ export function VaultRequestPage() {
 				if (controller.signal.aborted) return;
 				if (data) {
 					setContext(data);
+					setRows(
+						data.fields.map((name) => ({
+							id: crypto.randomUUID(),
+							name,
+							value: "",
+							required: true,
+						})),
+					);
+					setUpdates(data.update_fields);
 					setPhase("ready");
 				} else if (response.status === 410 || response.status === 422) setPhase("unavailable");
 				else {
@@ -75,24 +102,136 @@ export function VaultRequestPage() {
 		return () => controller.abort();
 	}, [attempt]);
 
+	useEffect(() => {
+		if (phase !== "ready") return;
+		const fields: string[] = JSON.parse(names);
+		setSelectionReady(false);
+		if (
+			!fields.length ||
+			fields.some((name) => !REQUEST_FIELD_NAME_RE.test(name)) ||
+			new Set(fields).size !== fields.length
+		) {
+			setSelectionError(
+				"Use valid, distinct field names (letters, numbers, dots, underscores, and hyphens).",
+			);
+			return;
+		}
+		const controller = new AbortController();
+		void client
+			.POST("/v1/vault/requests/inspect", {
+				body: { token: token.current, fields },
+				cache: "no-store",
+				referrerPolicy: "no-referrer",
+				signal: AbortSignal.any([controller.signal, AbortSignal.timeout(20000)]),
+			})
+			.then(({ data }) => {
+				if (controller.signal.aborted) return;
+				if (!data) {
+					setSelectionError(
+						"Selected fields changed or are reserved. Remove added fields or ask your agent for a new link.",
+					);
+					return;
+				}
+				setUpdates(data.update_fields);
+				setSelectionReady(true);
+				setSelectionError("");
+			})
+			.catch(() => {
+				if (!controller.signal.aborted)
+					setSelectionError("Could not check selected fields. Try again.");
+			});
+		return () => controller.abort();
+	}, [names, phase, selectionAttempt]);
+
+	async function previewImport() {
+		setError("");
+		const parsed = parseVaultRequestEnv(importText);
+		if (parsed.errors.length || !parsed.entries.length) {
+			setError(parsed.errors[0] ?? "Enter at least one dotenv assignment.");
+			return;
+		}
+		const fields = [
+			...new Set([...rows.map((row) => row.name), ...parsed.entries.map((entry) => entry.key)]),
+		];
+		if (
+			fields.length > 32 ||
+			new Set(rows.map((row) => row.name)).size !== rows.length ||
+			fields.some((name) => !REQUEST_FIELD_NAME_RE.test(name))
+		) {
+			setError("Use valid, distinct field names and at most 32 fields total.");
+			return;
+		}
+		setImportBusy(true);
+		try {
+			const { data } = await client.POST("/v1/vault/requests/inspect", {
+				body: { token: token.current, fields },
+				cache: "no-store",
+				referrerPolicy: "no-referrer",
+				signal: AbortSignal.timeout(20000),
+			});
+			if (!data) {
+				setError("Could not preview these fields. A selected field changed or is reserved.");
+				return;
+			}
+			setPreview({ entries: parsed.entries, updateFields: data.update_fields });
+		} catch {
+			setError("Could not connect. Try previewing again.");
+		} finally {
+			setImportBusy(false);
+		}
+	}
+
+	function applyImport() {
+		if (!preview) return;
+		setRows((current) => {
+			const imported = new Map(preview.entries.map((entry) => [entry.key, entry.value]));
+			return [
+				...current.map((row) => ({ ...row, value: imported.get(row.name) ?? row.value })),
+				...preview.entries
+					.filter((entry) => !current.some((row) => row.name === entry.key))
+					.map((entry) => ({
+						id: crypto.randomUUID(),
+						name: entry.key,
+						value: entry.value,
+						required: false,
+					})),
+			];
+		});
+		setSelectionReady(false);
+		setSelectionAttempt((value) => value + 1);
+		setPreview(undefined);
+		setImportText("");
+		setImportOpen(false);
+	}
+
 	async function save() {
-		if (!context || phase !== "ready") return;
+		if (!context || phase !== "ready" || !selectionReady || importOpen) return;
 		setPhase("saving");
 		setError("");
 		try {
 			const { data, response } = await client.POST("/v1/vault/requests/supply", {
-				body: { token: token.current, fields: values },
+				body: {
+					token: token.current,
+					fields: Object.fromEntries(rows.map((row) => [row.name, row.value])),
+				},
 				cache: "no-store",
 				referrerPolicy: "no-referrer",
 				signal: AbortSignal.timeout(20000),
 			});
 			if (data) {
 				setContext(data);
-				setValues({});
+				setRows([]);
+				setImportText("");
+				setPreview(undefined);
 				token.current = "";
 				setPhase("done");
-			} else if (response.status === 410 || response.status === 409) {
-				setValues({});
+			} else if (response.status === 409) {
+				setPhase("ready");
+				setSelectionReady(false);
+			} else if (response.status === 410) {
+				setRows([]);
+				setImportText("");
+				setPreview(undefined);
 				setPhase("unavailable");
 			} else {
 				setError("Could not save. Supply every requested field and try again.");
@@ -189,42 +328,209 @@ export function VaultRequestPage() {
 							<p className="text-sm text-muted-foreground">
 								Only these fields will be saved. Anyone with Vault access can use them.
 							</p>
-							{!!context.update_fields.length && (
+							{!!updates.length && (
 								<p className="text-sm text-muted-foreground">
 									Fields marked Update replace existing values when you save.
 								</p>
 							)}
-							{context.fields.map((name) => (
-								<div className="space-y-2" key={name}>
-									<div className="flex items-center justify-between gap-2">
-										<Label htmlFor={`secret-${name}`}>{name}</Label>
-										{context.update_fields.includes(name) && (
-											<span className="text-xs font-medium text-muted-foreground">Update</span>
-										)}
+							<fieldset
+								disabled={phase === "saving" || importBusy || !!preview}
+								className="space-y-5"
+							>
+								{rows.map(({ id, name, value, required }) => (
+									<div className="space-y-2" key={id}>
+										<div className="flex items-center justify-between gap-2">
+											{required ? (
+												<Label htmlFor={`secret-${id}`}>{name}</Label>
+											) : (
+												<Input
+													aria-label="Field name"
+													value={name}
+													maxLength={200}
+													required
+													pattern="[A-Za-z0-9_.\-]+"
+													className="font-mono"
+													onChange={(event) => {
+														setSelectionReady(false);
+														setRows((current) =>
+															current.map((row) =>
+																row.id === id ? { ...row, name: event.target.value } : row,
+															),
+														);
+													}}
+												/>
+											)}
+											{!required && (
+												<Button
+													type="button"
+													variant="ghost"
+													aria-label={`Remove ${name || "field"}`}
+													onClick={() => {
+														setSelectionReady(false);
+														setRows((current) => current.filter((row) => row.id !== id));
+													}}
+												>
+													Remove
+												</Button>
+											)}
+											{updates.includes(name) && (
+												<span className="text-xs font-medium text-muted-foreground">Update</span>
+											)}
+										</div>
+										<Textarea
+											id={`secret-${id}`}
+											aria-label={required ? undefined : `Value for ${name || "field"}`}
+											value={value}
+											required
+											maxLength={65536}
+											autoComplete="off"
+											spellCheck={false}
+											data-private="true"
+											className="font-mono"
+											disabled={phase === "saving"}
+											onChange={(event) =>
+												setRows((current) =>
+													current.map((row) =>
+														row.id === id ? { ...row, value: event.target.value } : row,
+													),
+												)
+											}
+										/>
 									</div>
-									<Textarea
-										id={`secret-${name}`}
-										value={values[name] ?? ""}
-										required
-										maxLength={65536}
-										autoComplete="off"
-										spellCheck={false}
-										data-private="true"
-										className="font-mono"
-										disabled={phase === "saving"}
-										onChange={(event) =>
-											setValues((current) => ({ ...current, [name]: event.target.value }))
-										}
-									/>
+								))}
+
+								<div className="flex gap-2">
+									<Button
+										type="button"
+										variant="outline"
+										disabled={rows.length >= 32 || importOpen}
+										onClick={() => {
+											setSelectionReady(false);
+											setRows((current) => [
+												...current,
+												{ id: crypto.randomUUID(), name: "", value: "", required: false },
+											]);
+										}}
+									>
+										Add field
+									</Button>
+									<Button
+										type="button"
+										variant="outline"
+										onClick={() => {
+											setImportOpen(true);
+											setError("");
+										}}
+									>
+										Import .env
+									</Button>
 								</div>
-							))}
-							{error && (
+							</fieldset>
+							{importOpen && (
+								<div className="space-y-3 rounded-lg border p-3">
+									<p className="text-sm text-muted-foreground">
+										Paste or choose a .env file. Values stay text; variables and commands are never
+										expanded.
+									</p>
+									{!preview && (
+										<>
+											<Label htmlFor="env-import">Dotenv text</Label>
+											<Textarea
+												id="env-import"
+												value={importText}
+												data-private="true"
+												autoComplete="off"
+												spellCheck={false}
+												disabled={importBusy}
+												onChange={(event) => setImportText(event.target.value)}
+											/>
+											<Input
+												type="file"
+												aria-label="Choose .env file"
+												disabled={importBusy}
+												onChange={async (event) => {
+													const file = event.target.files?.[0];
+													event.target.value = "";
+													if (!file) return;
+													if (file.size > MAX_ENV_IMPORT_BYTES) {
+														setError("Import must be at most 4 MiB.");
+														return;
+													}
+													setImportBusy(true);
+													try {
+														setImportText(
+															new TextDecoder("utf-8", { fatal: true }).decode(
+																await file.arrayBuffer(),
+															),
+														);
+													} catch {
+														setError("Could not read a UTF-8 text file.");
+													} finally {
+														setImportBusy(false);
+													}
+												}}
+											/>
+											<Button type="button" disabled={importBusy} onClick={previewImport}>
+												{importBusy ? "Checking…" : "Preview import"}
+											</Button>
+										</>
+									)}
+									{preview && (
+										<>
+											<p className="text-sm">
+												Apply these values to the form, then save all fields together.
+											</p>
+											<ul className="space-y-2 text-sm">
+												{preview.entries.map((entry) => (
+													<li key={entry.key} className="break-words">
+														<span className="font-mono">{entry.key}</span> —{" "}
+														{rows.some((row) => row.name === entry.key && row.value)
+															? "Replace entered value"
+															: rows.some((row) => row.name === entry.key)
+																? "Fill requested field"
+																: "Add field"}
+														{preview.updateFields.includes(entry.key)
+															? " · Update existing Vault value on save"
+															: ""}
+													</li>
+												))}
+											</ul>
+											<Button type="button" onClick={applyImport}>
+												Apply import
+											</Button>
+										</>
+									)}
+									<Button
+										type="button"
+										variant="ghost"
+										disabled={importBusy}
+										onClick={() => {
+											setImportOpen(false);
+											setImportText("");
+											setPreview(undefined);
+										}}
+									>
+										Cancel import
+									</Button>
+								</div>
+							)}
+							{(error || selectionError) && (
 								<p role="alert" className="text-sm text-destructive">
-									{error}
+									{error || selectionError}
+									<Button
+										type="button"
+										variant="ghost"
+										onClick={() => setSelectionAttempt((value) => value + 1)}
+									>
+										Retry check
+									</Button>
 								</p>
 							)}
 							<div className="flex justify-end">
-								<Button type="submit" disabled={phase === "saving"}>
+								<Button
+									type="submit"
+									disabled={phase === "saving" || !selectionReady || importOpen}
+								>
 									{phase === "saving" ? "Saving…" : "Save secrets"}
 								</Button>
 							</div>

--- a/apps/web/src/pages/vault-request.tsx
+++ b/apps/web/src/pages/vault-request.tsx
@@ -29,6 +29,8 @@ export function VaultRequestPage() {
 	const [importText, setImportText] = useState("");
 	const [preview, setPreview] = useState<{ entries: ParsedKey[]; updateFields: string[] }>();
 	const [selectionError, setSelectionError] = useState("");
+	const [selectionRetryable, setSelectionRetryable] = useState(false);
+	const selectionGeneration = useRef(0);
 	const [importBusy, setImportBusy] = useState(false);
 	const [updates, setUpdates] = useState<string[]>([]);
 	const [selectionAttempt, setSelectionAttempt] = useState(0);
@@ -102,10 +104,21 @@ export function VaultRequestPage() {
 		return () => controller.abort();
 	}, [attempt]);
 
+	function invalidateSelection() {
+		selectionGeneration.current++;
+		setSelectionReady(false);
+		setUpdates([]);
+		setSelectionError("");
+		setSelectionRetryable(false);
+	}
+
 	useEffect(() => {
 		if (phase !== "ready") return;
 		const fields: string[] = JSON.parse(names);
 		setSelectionReady(false);
+		setUpdates([]);
+		setSelectionError("");
+		setSelectionRetryable(false);
 		if (
 			!fields.length ||
 			fields.some((name) => !REQUEST_FIELD_NAME_RE.test(name)) ||
@@ -117,30 +130,51 @@ export function VaultRequestPage() {
 			return;
 		}
 		const controller = new AbortController();
-		void client
-			.POST("/v1/vault/requests/inspect", {
-				body: { token: token.current, fields },
-				cache: "no-store",
-				referrerPolicy: "no-referrer",
-				signal: AbortSignal.any([controller.signal, AbortSignal.timeout(20000)]),
-			})
-			.then(({ data }) => {
-				if (controller.signal.aborted) return;
-				if (!data) {
-					setSelectionError(
-						"Selected fields changed or are reserved. Remove added fields or ask your agent for a new link.",
-					);
-					return;
-				}
-				setUpdates(data.update_fields);
-				setSelectionReady(true);
-				setSelectionError("");
-			})
-			.catch(() => {
-				if (!controller.signal.aborted)
-					setSelectionError("Could not check selected fields. Try again.");
-			});
-		return () => controller.abort();
+		const generation = selectionGeneration.current;
+		const timer = window.setTimeout(() => {
+			void client
+				.POST("/v1/vault/requests/inspect", {
+					body: { token: token.current, fields },
+					cache: "no-store",
+					referrerPolicy: "no-referrer",
+					signal: AbortSignal.any([controller.signal, AbortSignal.timeout(20000)]),
+				})
+				.then(({ data, response }) => {
+					if (controller.signal.aborted || generation !== selectionGeneration.current) return;
+					if (data) {
+						setUpdates(data.update_fields);
+						setSelectionReady(true);
+					} else if (response.status === 410) {
+						setRows([]);
+						setImportText("");
+						setPreview(undefined);
+						token.current = "";
+						setPhase("unavailable");
+					} else if (response.status === 409) {
+						setSelectionError(
+							"Selected fields changed or are reserved. Remove added fields or ask your agent for a new link.",
+						);
+					} else if (response.status === 422) {
+						setSelectionError(
+							"Selected field names are invalid. Use distinct names and at most 32 fields.",
+						);
+					} else {
+						setSelectionError(
+							"Could not check selected fields. The server is unavailable. Try again.",
+						);
+						setSelectionRetryable(true);
+					}
+				})
+				.catch(() => {
+					if (controller.signal.aborted || generation !== selectionGeneration.current) return;
+					setSelectionError("Could not connect to check selected fields. Try again.");
+					setSelectionRetryable(true);
+				});
+		}, 300);
+		return () => {
+			window.clearTimeout(timer);
+			controller.abort();
+		};
 	}, [names, phase, selectionAttempt]);
 
 	async function previewImport() {
@@ -163,14 +197,26 @@ export function VaultRequestPage() {
 		}
 		setImportBusy(true);
 		try {
-			const { data } = await client.POST("/v1/vault/requests/inspect", {
+			const { data, response } = await client.POST("/v1/vault/requests/inspect", {
 				body: { token: token.current, fields },
 				cache: "no-store",
 				referrerPolicy: "no-referrer",
 				signal: AbortSignal.timeout(20000),
 			});
 			if (!data) {
-				setError("Could not preview these fields. A selected field changed or is reserved.");
+				if (response.status === 410) {
+					setRows([]);
+					setImportText("");
+					setPreview(undefined);
+					token.current = "";
+					setPhase("unavailable");
+				} else if (response.status === 409) {
+					setError("Could not preview these fields. A selected field changed or is reserved.");
+				} else if (response.status === 422) {
+					setError("Selected field names are invalid. Use distinct names and at most 32 fields.");
+				} else {
+					setError("Could not preview these fields. The server is unavailable. Try again.");
+				}
 				return;
 			}
 			setPreview({ entries: parsed.entries, updateFields: data.update_fields });
@@ -197,7 +243,7 @@ export function VaultRequestPage() {
 					})),
 			];
 		});
-		setSelectionReady(false);
+		invalidateSelection();
 		setSelectionAttempt((value) => value + 1);
 		setPreview(undefined);
 		setImportText("");
@@ -227,7 +273,7 @@ export function VaultRequestPage() {
 				setPhase("done");
 			} else if (response.status === 409) {
 				setPhase("ready");
-				setSelectionReady(false);
+				invalidateSelection();
 			} else if (response.status === 410) {
 				setRows([]);
 				setImportText("");
@@ -351,7 +397,7 @@ export function VaultRequestPage() {
 													pattern="[A-Za-z0-9_.\-]+"
 													className="font-mono"
 													onChange={(event) => {
-														setSelectionReady(false);
+														invalidateSelection();
 														setRows((current) =>
 															current.map((row) =>
 																row.id === id ? { ...row, name: event.target.value } : row,
@@ -366,7 +412,7 @@ export function VaultRequestPage() {
 													variant="ghost"
 													aria-label={`Remove ${name || "field"}`}
 													onClick={() => {
-														setSelectionReady(false);
+														invalidateSelection();
 														setRows((current) => current.filter((row) => row.id !== id));
 													}}
 												>
@@ -405,7 +451,7 @@ export function VaultRequestPage() {
 										variant="outline"
 										disabled={rows.length >= 32 || importOpen}
 										onClick={() => {
-											setSelectionReady(false);
+											invalidateSelection();
 											setRows((current) => [
 												...current,
 												{ id: crypto.randomUUID(), name: "", value: "", required: false },
@@ -517,13 +563,18 @@ export function VaultRequestPage() {
 							{(error || selectionError) && (
 								<p role="alert" className="text-sm text-destructive">
 									{error || selectionError}
-									<Button
-										type="button"
-										variant="ghost"
-										onClick={() => setSelectionAttempt((value) => value + 1)}
-									>
-										Retry check
-									</Button>
+									{!error && selectionRetryable && (
+										<Button
+											type="button"
+											variant="ghost"
+											onClick={() => {
+												invalidateSelection();
+												setSelectionAttempt((value) => value + 1);
+											}}
+										>
+											Retry check
+										</Button>
+									)}
 								</p>
 							)}
 							<div className="flex justify-end">

--- a/backend/alembic/versions/fa83d21c907b_vault_request_extras.py
+++ b/backend/alembic/versions/fa83d21c907b_vault_request_extras.py
@@ -1,0 +1,27 @@
+"""Capture section creation snapshots and record user-supplied extra names."""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "fa83d21c907b"
+down_revision = "e7b4c2a9d610"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vault_secret_requests",
+        sa.Column("extra_fields", postgresql.JSONB(), nullable=False, server_default="[]"),
+    )
+    # Earlier links have no full section snapshot. Preserve supplied history and values.
+    op.execute(
+        "UPDATE vault_secret_requests SET expires_at = LEAST(expires_at, now()), "
+        "conflicted_at = now() WHERE supplied_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("vault_secret_requests", "extra_fields")

--- a/backend/alembic/versions/fa83d21c907b_vault_request_extras.py
+++ b/backend/alembic/versions/fa83d21c907b_vault_request_extras.py
@@ -24,4 +24,20 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Take the DDL lock before rewriting history, excluding concurrent supplies/creates.
+    op.execute("LOCK TABLE vault_secret_requests IN ACCESS EXCLUSIVE MODE")
+    # Old readers use fields for supplied history. Retain every saved name and
+    # its creation baseline (including explicit null for newly added fields).
+    op.execute(
+        "UPDATE vault_secret_requests SET fields = fields || extra_fields, "
+        "field_baselines = (SELECT jsonb_object_agg(name, "
+        "COALESCE(field_baselines -> name, 'null'::jsonb)) "
+        "FROM jsonb_array_elements_text(fields || extra_fields) AS names(name)) "
+        "WHERE supplied_at IS NOT NULL AND extra_fields <> '[]'::jsonb"
+    )
+    # No capability created under the new contract survives a rollback.
+    op.execute(
+        "UPDATE vault_secret_requests SET expires_at = LEAST(expires_at, now()), "
+        "conflicted_at = COALESCE(conflicted_at, now()) WHERE supplied_at IS NULL"
+    )
     op.drop_column("vault_secret_requests", "extra_fields")

--- a/backend/app/models/vault.py
+++ b/backend/app/models/vault.py
@@ -135,9 +135,12 @@ class VaultSecretRequest(Base, TimestampMixin):
     token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
     section: Mapped[str] = mapped_column(String(200), nullable=False)
     fields: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
-    # Every requested field has a baseline; null records absence.
+    # Creation snapshot of every field in the section; absent required fields have null baselines.
     # Never expose these request-local snapshots through API or runtime metadata.
     field_baselines: Mapped[dict[str, str | None]] = mapped_column(JSONB, nullable=False)
+    extra_fields: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     supplied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     conflicted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -695,7 +695,9 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
             "Request a batch of new or updated Vault fields in one exact owned Vault. "
             "Returns a one-time write-only URL to show the user; never ask for secrets in chat. "
             "Existing Vault values are kept until submission and are never shown by the link. "
-            "Changes to requested fields conflict; overlapping pending requests are rejected. "
+            "Requested names are mandatory; the user can add fields or preview/apply a .env import "
+            "on the page, up to 32 total. Do not preselect extras. Selected fields must match "
+            "creation state; overlapping pending reservations are rejected. "
             "Runtime requests must target their own Workspace, not "
             "other readable linked Projects. The URL expires and is consumed only after saving."
         ),
@@ -706,7 +708,8 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
     "vault_request_status": _NativeToolSpec(
         description=(
             "Check a Vault request: pending, supplied, expired, or conflict. Returns references, "
-            "never values. After supply, continue the task using existing authorized capabilities; "
+            "never values. Supplied fields and references include user-added extras. "
+            "After supply, continue the task using existing authorized capabilities; "
             "verify local index Vault/section/fields and content_version >= "
             "this status content_version "
             "before claiming local delivery. "

--- a/backend/app/routes/vault_requests.py
+++ b/backend/app/routes/vault_requests.py
@@ -9,9 +9,9 @@ from app.core.project import resolve_default_write_project
 from app.schemas.vault_requests import (
     VaultSecretRequestCreate,
     VaultSecretRequestCreated,
+    VaultSecretRequestInspect,
     VaultSecretRequestStatus,
     VaultSecretRequestSupply,
-    VaultSecretRequestToken,
 )
 from app.services import vault_requests as service
 from app.services.vault import get_vault_for_write
@@ -30,13 +30,15 @@ async def create_request(
 
 @router.post("/inspect")
 async def inspect_request(
-    body: VaultSecretRequestToken,
+    body: VaultSecretRequestInspect,
     db: AsyncSession = Depends(get_session),
 ) -> VaultSecretRequestStatus:
     row = await service.token_request(db, body.token)
     result = await service.describe(db, row)
     if result.status != "pending":
         raise service.unavailable()
+    if "fields" in body.model_fields_set:
+        result.update_fields = await service.check_selection(db, row, body.fields)
     return result
 
 

--- a/backend/app/schemas/vault_requests.py
+++ b/backend/app/schemas/vault_requests.py
@@ -45,6 +45,7 @@ class VaultSecretRequestStatus(BaseModel):
     slug: str
     section: str
     fields: list[str]
+    extra_fields: list[str] = []
     update_fields: list[str]
     content_version: int = Field(ge=0)
     status: Literal["pending", "supplied", "expired", "conflict"]
@@ -62,12 +63,27 @@ class VaultSecretRequestToken(BaseModel):
     token: str = Field(pattern=r"^v2_[A-Za-z0-9_-]{43}$")
 
 
+class VaultSecretRequestInspect(VaultSecretRequestToken):
+    fields: list[str] = Field(default_factory=list, max_length=32)
+
+    @field_validator("fields")
+    @classmethod
+    def validate_fields(cls, fields: list[str]) -> list[str]:
+        for name in fields:
+            if clean_vault_segment(name, field_name="field name") != name:
+                raise ValueError("Field names must not contain surrounding whitespace")
+        if len(set(fields)) != len(fields):
+            raise ValueError("Fields must be distinct")
+        return fields
+
+
 class VaultSecretRequestSupply(VaultSecretRequestToken):
     fields: dict[str, str] = Field(min_length=1, max_length=32)
 
     @field_validator("fields")
     @classmethod
     def validate_values(cls, fields: dict[str, str]) -> dict[str, str]:
+        VaultSecretRequestInspect.validate_fields(list(fields))
         if any(not value or len(value) > 65536 or "\x00" in value for value in fields.values()):
             raise ValueError("Values must be nonempty text of at most 65536 characters")
         return fields

--- a/backend/app/services/vault_requests.py
+++ b/backend/app/services/vault_requests.py
@@ -52,7 +52,7 @@ def field_baseline(item: VaultItem | None) -> str | None:
 def fields_conflict(row: VaultSecretRequest, existing: dict[str, VaultItem]) -> bool:
     return (
         row.conflicted_at is not None
-        or set(row.field_baselines) != set(row.fields)
+        or not set(row.fields).issubset(row.field_baselines)
         or any(
             field_baseline(existing.get(field)) != row.field_baselines[field]
             for field in row.fields
@@ -101,9 +101,10 @@ async def describe(db: AsyncSession, row: VaultSecretRequest) -> VaultSecretRequ
             state = "expired"
         elif fields_conflict(row, existing):
             state = "conflict"
+    all_fields = [*row.fields, *row.extra_fields]
     references = {
         field: exact_vault_reference(row.project_id, vault.slug, row.section, field)
-        for field in row.fields
+        for field in all_fields
     }
     return VaultSecretRequestStatus(
         id=row.id,
@@ -113,8 +114,9 @@ async def describe(db: AsyncSession, row: VaultSecretRequest) -> VaultSecretRequ
         project_name=project.name,
         slug=vault.slug,
         section=row.section,
-        fields=row.fields,
-        update_fields=[field for field in row.fields if row.field_baselines.get(field) is not None],
+        fields=all_fields,
+        extra_fields=list(row.extra_fields),
+        update_fields=[field for field in all_fields if row.field_baselines.get(field) is not None],
         content_version=vault.runtime_revision,
         status=state,
         expires_at=row.expires_at,
@@ -182,7 +184,11 @@ async def create_request(
         project_id=body.project_id,
         section=body.section,
         fields=body.fields,
-        field_baselines={field: field_baseline(existing.get(field)) for field in body.fields},
+        field_baselines={
+            **{field: field_baseline(item) for field, item in existing.items()},
+            **{field: field_baseline(existing.get(field)) for field in body.fields},
+        },
+        extra_fields=[],
         token_hash=hashlib.sha256(token.encode()).hexdigest(),
         expires_at=datetime.now(UTC) + timedelta(seconds=body.expires_in_seconds),
     )
@@ -242,21 +248,52 @@ async def token_request(db: AsyncSession, token: str) -> VaultSecretRequest:
     return row
 
 
+async def check_selection(
+    db: AsyncSession, row: VaultSecretRequest, fields: list[str]
+) -> list[str]:
+    """Check only selected names against creation state under the Vault lock."""
+    chosen = set(row.fields) | set(fields)
+    if len(chosen) > 32:
+        raise HTTPException(422, "Supply at most 32 fields")
+    existing = await load_vault_items_by_name(db, row.vault_id, row.section)
+    if any(field_baseline(existing.get(name)) != row.field_baselines.get(name) for name in chosen):
+        raise HTTPException(409, "Selected fields changed")
+    extras = chosen - set(row.fields)
+    if extras:
+        pending = (
+            await db.scalars(
+                select(VaultSecretRequest).where(
+                    VaultSecretRequest.vault_id == row.vault_id,
+                    VaultSecretRequest.section == row.section,
+                    VaultSecretRequest.id != row.id,
+                    VaultSecretRequest.supplied_at.is_(None),
+                    VaultSecretRequest.conflicted_at.is_(None),
+                    VaultSecretRequest.expires_at > datetime.now(UTC),
+                )
+            )
+        ).all()
+        if any(
+            extras.intersection(other.fields) and not fields_conflict(other, existing)
+            for other in pending
+        ):
+            raise HTTPException(409, "Selected fields already requested")
+    return [name for name in fields if row.field_baselines.get(name) is not None]
+
+
 async def supply(db: AsyncSession, body: VaultSecretRequestSupply) -> VaultSecretRequestStatus:
     try:
         row = await token_request(db, body.token)
         context = await describe(db, row)
         if context.status != "pending":
             raise unavailable()
-        if set(body.fields) != set(row.fields):
-            raise HTTPException(422, "Supply exactly the requested fields")
-        # Lock only requested rows and recheck their state before changing any value.
+        requested_fields = list(body.fields)
+        if not set(row.fields).issubset(requested_fields):
+            raise HTTPException(422, "Supply every requested field")
+        await check_selection(db, row, requested_fields)
         existing = await load_vault_items_by_name(
-            db, row.vault_id, row.section, lock_fields=row.fields
+            db, row.vault_id, row.section, lock_fields=requested_fields
         )
-        if fields_conflict(row, existing):
-            raise unavailable()
-        for field in row.fields:
+        for field in requested_fields:
             ciphertext, nonce = encrypt(body.fields[field])
             item = existing.get(field)
             if item is None:
@@ -276,6 +313,7 @@ async def supply(db: AsyncSession, body: VaultSecretRequestSupply) -> VaultSecre
         from app.services.runtime_vaults import notify_vault_changed
 
         await notify_vault_changed(db, row.vault_id, values_changed=True)
+        row.extra_fields = [field for field in requested_fields if field not in row.fields]
         row.supplied_at = datetime.now(UTC)
         result = await describe(db, row)
         await db.commit()

--- a/backend/tests/test_vault_requests.py
+++ b/backend/tests/test_vault_requests.py
@@ -710,6 +710,7 @@ async def test_request_migration_expires_pending_and_requires_explicit_snapshots
         connection.execute(
             text(
                 "CREATE TEMP TABLE vault_secret_requests (id integer, "
+                "fields jsonb NOT NULL DEFAULT '[\"NEW\"]'::jsonb, "
                 "expires_at timestamptz DEFAULT now() + interval '1 hour', "
                 "supplied_at timestamptz) ON COMMIT DROP"
             )
@@ -757,11 +758,76 @@ async def test_request_migration_expires_pending_and_requires_explicit_snapshots
         assert connection.execute(
             text("SELECT field_baselines FROM vault_secret_requests WHERE id = 3")
         ).scalar_one() == {"NEW": None}
+        # Model requests actually created and supplied after the new upgrade.
+        connection.execute(
+            text(
+                "INSERT INTO vault_secret_requests "
+                "(id, supplied_at, field_baselines, extra_fields) "
+                "VALUES (:id, CASE WHEN :supplied THEN now() END, "
+                "CAST(:baseline AS jsonb), CAST(:extras AS jsonb))"
+            ),
+            [
+                {
+                    "id": 4,
+                    "supplied": True,
+                    "baseline": '{"NEW":null,"existing.extra":"fingerprint","UNSELECTED":"opaque"}',
+                    "extras": '["existing.extra","new-key"]',
+                },
+                {
+                    "id": 5,
+                    "supplied": False,
+                    "baseline": '{"NEW":null,"UNSELECTED":"opaque"}',
+                    "extras": "[]",
+                },
+                {"id": 6, "supplied": False, "baseline": '{"NEW":null}', "extras": "[]"},
+            ],
+        )
+        supplied_times = connection.execute(
+            text("SELECT expires_at, supplied_at FROM vault_secret_requests WHERE id = 4")
+        ).one()
+        extras_migration.downgrade()
+        history = connection.execute(
+            text(
+                "SELECT fields, field_baselines, expires_at, supplied_at "
+                "FROM vault_secret_requests WHERE id = 4"
+            )
+        ).one()
+        # The old service builds supplied references from fields and update badges
+        # from baselines. Both retain the exact saved set, without unselected names.
+        assert history.fields == ["NEW", "existing.extra", "new-key"]
+        assert history.field_baselines == {
+            "NEW": None,
+            "existing.extra": "fingerprint",
+            "new-key": None,
+        }
+        assert (history.expires_at, history.supplied_at) == supplied_times
+        assert connection.execute(
+            text(
+                "SELECT id, expires_at > now(), conflicted_at IS NOT NULL "
+                "FROM vault_secret_requests WHERE supplied_at IS NULL ORDER BY id"
+            )
+        ).all() == [(1, False, True), (3, False, True), (5, False, True), (6, False, True)]
+        extras_migration.upgrade()
+        assert (
+            connection.execute(
+                text(
+                    "SELECT fields, field_baselines, expires_at, supplied_at "
+                    "FROM vault_secret_requests WHERE id = 4"
+                )
+            ).one()
+            == history
+        )
+        assert (
+            connection.execute(
+                text("SELECT extra_fields FROM vault_secret_requests WHERE id = 4")
+            ).scalar_one()
+            == []
+        )
         extras_migration.downgrade()
         migration.downgrade()
         assert connection.execute(
             text("SELECT id, expires_at > now() FROM vault_secret_requests ORDER BY id")
-        ).all() == [(1, False), (2, True), (3, False)]
+        ).all() == [(1, False), (2, True), (3, False), (4, True), (5, False), (6, False)]
         assert (
             connection.execute(
                 text("SELECT expires_at, supplied_at FROM vault_secret_requests WHERE id = 2")

--- a/backend/tests/test_vault_requests.py
+++ b/backend/tests/test_vault_requests.py
@@ -697,6 +697,13 @@ async def test_request_migration_expires_pending_and_requires_explicit_snapshots
     migration = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(migration)
 
+    extras_spec = importlib.util.spec_from_file_location(
+        "request_extras", path.with_name("fa83d21c907b_vault_request_extras.py")
+    )
+    assert extras_spec is not None and extras_spec.loader is not None
+    extras_migration = importlib.util.module_from_spec(extras_spec)
+    extras_spec.loader.exec_module(extras_migration)
+
     def verify(connection):
         from sqlalchemy.exc import IntegrityError
 
@@ -739,6 +746,18 @@ async def test_request_migration_expires_pending_and_requires_explicit_snapshots
         assert connection.execute(
             text("SELECT expires_at > now() FROM vault_secret_requests WHERE id = 3")
         ).scalar_one()
+        extras_migration.op = migration.op
+        extras_migration.upgrade()
+        assert connection.execute(
+            text(
+                "SELECT id, extra_fields, expires_at > now(), conflicted_at IS NOT NULL "
+                "FROM vault_secret_requests ORDER BY id"
+            )
+        ).all() == [(1, [], False, True), (2, [], True, False), (3, [], False, True)]
+        assert connection.execute(
+            text("SELECT field_baselines FROM vault_secret_requests WHERE id = 3")
+        ).scalar_one() == {"NEW": None}
+        extras_migration.downgrade()
         migration.downgrade()
         assert connection.execute(
             text("SELECT id, expires_at > now() FROM vault_secret_requests ORDER BY id")
@@ -779,3 +798,200 @@ async def test_status_refreshes_terminal_state_after_concurrent_write(
         await db_session.rollback()
         await db_session.execute(delete(Vault).where(Vault.id == vault_id))
         await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_user_extras_creation_snapshot_preview_scope_and_saved_references(
+    cli_client, db_session
+):
+    body, created = await make_request(
+        cli_client,
+        fields=["REQUIRED"],
+        existing={"REQUIRED": "original", "optional.key": "old", "UNRELATED": "private"},
+    )
+    token = created["url"].split("#")[1]
+    assert (
+        await cli_client.post("/v1/vault/requests", json={**body, "extra_fields": ["x"]})
+    ).status_code == 422
+    empty_preview = await cli_client.post(
+        "/v1/vault/requests/inspect", json={"token": token, "fields": []}
+    )
+    assert empty_preview.json()["update_fields"] == []
+    for prefix in ("/v1", "/api"):
+        preview = await cli_client.post(
+            f"{prefix}/vault/requests/inspect",
+            json={"token": token, "fields": ["optional.key", "new-key"]},
+        )
+        assert preview.status_code == 200, preview.text
+        assert preview.json()["update_fields"] == ["optional.key"]
+        assert "UNRELATED" not in preview.text and "private" not in preview.text
+        assert "baseline" not in preview.text
+    await cli_client.put("/v1/vault/requested/items", json={"fields": {"UNRELATED": "changed"}})
+    values = {"REQUIRED": "required", "optional.key": "replacement", "new-key": "${LITERAL}"}
+    saved = await cli_client.post(
+        "/v1/vault/requests/supply", json={"token": token, "fields": values}
+    )
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["fields"] == list(values)
+    assert saved.json()["extra_fields"] == ["optional.key", "new-key"]
+    assert set(saved.json()["references"]) == set(values)
+    assert saved.json()["content_version"] > created["content_version"]
+    status = await cli_client.get(f"/v1/vault/requests/{created['id']}")
+    assert status.json() == saved.json()
+    row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
+    assert row.fields == ["REQUIRED"]
+    assert row.extra_fields == ["optional.key", "new-key"]
+    assert (
+        await cli_client.post("/v1/vault/requests/supply", json={"token": token, "fields": values})
+    ).status_code == 410
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing", [None, {"EXTRA": "original"}])
+async def test_extra_changed_since_creation_rejects_atomic_batch(cli_client, existing):
+    body, created = await make_request(cli_client, fields=["REQUIRED"], existing=existing)
+    token = created["url"].split("#")[1]
+    await cli_client.put("/v1/vault/requested/items", json={"fields": {"EXTRA": "concurrent"}})
+    for action in ("inspect", "supply"):
+        fields = (
+            ["EXTRA"]
+            if action == "inspect"
+            else {"REQUIRED": "must-not-write", "EXTRA": "must-not-write"}
+        )
+        response = await cli_client.post(
+            f"/v1/vault/requests/{action}", json={"token": token, "fields": fields}
+        )
+        assert response.status_code == 409
+    assert (
+        await cli_client.post(
+            "/v1/vault/material",
+            json={"vault_id": body["vault_id"], "project_id": body["project_id"]},
+        )
+    ).json()["values"] == {"EXTRA": "concurrent"}
+    assert (
+        await cli_client.post(
+            "/v1/vault/requests/supply", json={"token": token, "fields": {"REQUIRED": "ok"}}
+        )
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_extra_pending_reservation_and_name_limits(cli_client):
+    body, created = await make_request(cli_client, fields=["REQUIRED"])
+    token = created["url"].split("#")[1]
+    reserved = await cli_client.post("/v1/vault/requests", json={**body, "fields": ["RESERVED"]})
+    assert reserved.status_code == 200
+    for action in ("inspect", "supply"):
+        fields = ["RESERVED"] if action == "inspect" else {"REQUIRED": "x", "RESERVED": "y"}
+        assert (
+            await cli_client.post(
+                f"/v1/vault/requests/{action}", json={"token": token, "fields": fields}
+            )
+        ).status_code == 409
+    for fields in (
+        {"REQUIRED": "x", "bad/name": "y"},
+        {"REQUIRED": "x", " spaced ": "y"},
+        {"REQUIRED": "x", **{f"K{i}": "x" for i in range(32)}},
+    ):
+        assert (
+            await cli_client.post(
+                "/v1/vault/requests/supply", json={"token": token, "fields": fields}
+            )
+        ).status_code == 422
+    assert (
+        await cli_client.post(
+            "/v1/vault/requests/inspect", json={"token": token, "fields": ["X", "X"]}
+        )
+    ).status_code == 422
+    assert (await cli_client.get("/v1/vault/requested/items")).json() == {}
+    assert (
+        await cli_client.post(
+            "/v1/vault/requests/inspect",
+            json={"token": token, "fields": [f"K{i}" for i in range(32)]},
+        )
+    ).status_code == 422
+    maximum = await cli_client.post(
+        "/v1/vault/requests/supply",
+        json={"token": token, "fields": {"REQUIRED": "x", **{f"K{i}": "x" for i in range(31)}}},
+    )
+    assert maximum.status_code == 200, maximum.text
+    assert len(maximum.json()["references"]) == 32
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_two_requests_racing_for_same_user_extra_commit_one_batch(
+    cli_client, db_session, engine
+):
+    body, first = await make_request(cli_client, fields=["FIRST"])
+    second = (
+        await cli_client.post("/v1/vault/requests", json={**body, "fields": ["SECOND"]})
+    ).json()
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def redeem(created, name):
+        async with sessions() as session:
+            try:
+                return await supply(
+                    session,
+                    VaultSecretRequestSupply(
+                        token=created["url"].split("#")[1],
+                        fields={name: name, "shared.extra": name},
+                    ),
+                )
+            except HTTPException as exc:
+                return exc.status_code
+
+    results = await asyncio.gather(redeem(first, "FIRST"), redeem(second, "SECOND"))
+    assert sum(isinstance(result, int) and result == 409 for result in results) == 1
+    items = (
+        await db_session.scalars(
+            select(VaultItem).where(VaultItem.vault_id == uuid.UUID(body["vault_id"]))
+        )
+    ).all()
+    assert len(items) == 2
+    assert "shared.extra" in {item.item_name for item in items}
+    requests = (
+        await db_session.scalars(
+            select(VaultSecretRequest).where(
+                VaultSecretRequest.vault_id == uuid.UUID(body["vault_id"])
+            )
+        )
+    ).all()
+    assert sum(row.supplied_at is not None for row in requests) == 1
+    assert sorted(len(row.extra_fields) for row in requests) == [0, 1]
+    await db_session.execute(delete(Vault).where(Vault.id == uuid.UUID(body["vault_id"])))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_suspended_owner_cannot_preview_or_supply_user_extras(
+    cli_client, anon_client, db_session, seed_user, monkeypatch
+):
+    from app.core.config import settings
+    from app.services.principal_lifecycle import set_clerk_principal_suspension
+
+    issuer = "https://vault-request.clerk.example.test"
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", issuer)
+    _, created = await make_request(cli_client, fields=["REQUIRED"])
+    await set_clerk_principal_suspension(
+        db_session,
+        issuer=issuer,
+        subject=seed_user.clerk_id,
+        suspended=True,
+        reason="vault-request-test",
+    )
+    await db_session.commit()
+    token = created["url"].split("#")[1]
+    for action in ("inspect", "supply"):
+        fields = ["EXTRA"] if action == "inspect" else {"REQUIRED": "private", "EXTRA": "private"}
+        response = await anon_client.post(
+            f"/v1/vault/requests/{action}", json={"token": token, "fields": fields}
+        )
+        assert response.status_code == 410
+        assert "private" not in response.text and "EXTRA" not in response.text
+    row = await db_session.get(VaultSecretRequest, uuid.UUID(created["id"]))
+    assert row.supplied_at is None and row.extra_fields == []
+    assert not (
+        await db_session.scalars(select(VaultItem).where(VaultItem.vault_id == row.vault_id))
+    ).all()

--- a/bun.lock
+++ b/bun.lock
@@ -103,7 +103,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.80",
+      "version": "0.14.81",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -658,7 +658,9 @@ before requesting again; never delete a key to request an update.
 
 The request migration expires every pre-cutover pending link, preserving saved values and
 history. Request snapshots are mandatory on new inserts. Deploy the current backend and
-page together; users with expired links need a fresh request.
+page together; users with expired links need a fresh request. Downgrade also expires
+all unsupplied links and folds saved extras into historical `fields`, retaining their
+references and creation baselines for old readers and a subsequent upgrade.
 
 After supply in a managed runtime or configured connected macOS/Linux Agent, verify `vault_request_status` and inspect only
 `.clawdi/vaults/index.json` under the native workspace. Match the Vault ID, section and field

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -632,8 +632,23 @@ owned Vault/Project attachment. Names follow ordinary Vault validation, includin
 and hyphens; duplicates after trimming are rejected. Show the returned URL unchanged.
 Its fragment contains a `v2_` capability with 256 random bits, hashed at rest and valid
 for one hour by default (five minutes to one day configurable). Viewing does not consume
-it; saving exactly the requested fields in one successful transaction does. The page
-marks updates without showing existing values.
+it; saving all requested fields and user-added extras in one successful transaction does.
+The page keeps requested names fixed and lets users add, rename, or remove extras, up to
+32 total. Import .env accepts pasted or UTF-8 file text (4 MiB maximum), preserves name
+case/dots/hyphens, and requires preview then Apply before the single Save. Preview identifies
+entered values to replace and existing Vault fields to update; existing values are never
+shown. Imports reject malformed lines, duplicates, empty/NUL values, and values over 65536
+characters. Double quotes decode `\n`, `\r`, `\t`, `\"`, and `\\`; single quotes are literal.
+Variables and commands are never expanded; JSON and multiline quoted assignments are not
+accepted on this page.
+
+Creation captures ciphertext fingerprints for the whole section, with explicit nulls for
+absent required names. `POST /v1/vault/requests/inspect` accepts optional chosen `fields`
+and returns only those names in `update_fields`, never unrelated names or fingerprints.
+Supply requires the original subset, validates every chosen field against creation state
+under the Vault lock, and rejects extras reserved by another live request. Optional fields
+are chosen by the user after creation; creation does not accept `extra_fields`. Supplied
+status persists `extra_fields`, lists all saved `fields`, and includes all exact references.
 
 Changes to any requested field conflict with the entire batch; unrelated edits do not.
 A conflicted request can be replaced immediately, while true pending overlap is rejected.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.80",
+	"version": "0.14.81",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -137,7 +137,12 @@ when the user authorized updating them; do not delete them first. Existing Vault
 remain unchanged until successful submission and are never shown or prefilled. Overlapping pending requests
 are rejected; a change to any requested field conflicts with the entire batch.
 Show the returned `url` unchanged to the user; do not ask them to paste secrets into chat.
-Opening the link does not consume it. Saving all requested fields consumes it once.
+Opening the link does not consume it. The user can add fields or import a pasted/uploaded
+.env on the page, preview replacements, and apply them to the same form. Original requested
+names remain mandatory; only the user chooses extras after link creation (32 fields total).
+Saving the entire form consumes the link once. Selected fields must still match creation
+state, and extras cannot overlap another pending request. Status includes saved extras and
+their exact references; never assume only the originally requested names were saved.
 
 Check `vault_request_status` with its `request_id` after the user finishes. `pending` is not
 a secret value; `supplied` means the exact references are ready. On `expired` or `conflict`,

--- a/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
+++ b/packages/cli/skills/hosted-versions/1/clawdi/SKILL.md
@@ -122,7 +122,12 @@ when the user authorized updating them; do not delete them first. Existing Vault
 remain unchanged until successful submission and are never shown or prefilled. Overlapping pending requests
 are rejected; a change to any requested field conflicts with the entire batch.
 Show the returned `url` unchanged to the user; do not ask them to paste secrets into chat.
-Opening the link does not consume it. Saving all requested fields consumes it once.
+Opening the link does not consume it. The user can add fields or import a pasted/uploaded
+.env on the page, preview replacements, and apply them to the same form. Original requested
+names remain mandatory; only the user chooses extras after link creation (32 fields total).
+Saving the entire form consumes the link once. Selected fields must still match creation
+state, and extras cannot overlap another pending request. Status includes saved extras and
+their exact references; never assume only the originally requested names were saved.
 
 Check `vault_request_status` with its `request_id` after the user finishes. `pending` is not
 a secret value; `supplied` means the exact references are ready. On `expired` or `conflict`,

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -20,7 +20,7 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 					id: "clawdi",
 					version: 1,
 					assetDirectory: "hosted-versions/1/clawdi",
-					digest: "a70f1c53415828ac38d89e325ab976d474e5e6d6c172cb3c812174558261a176",
+					digest: "205caf55b56e136dc8a676523b6d07eea541d42af75ff6c19d10ec8dd766dc9d",
 				}),
 			],
 		]),

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -10311,6 +10311,11 @@ export interface components {
             section: string;
             /** Fields */
             fields: string[];
+            /**
+             * Extra Fields
+             * @default []
+             */
+            extra_fields: string[];
             /** Update Fields */
             update_fields: string[];
             /** Content Version */
@@ -10333,6 +10338,13 @@ export interface components {
             };
             /** Url */
             url: string;
+        };
+        /** VaultSecretRequestInspect */
+        VaultSecretRequestInspect: {
+            /** Token */
+            token: string;
+            /** Fields */
+            fields?: string[];
         };
         /** VaultSecretRequestStatus */
         VaultSecretRequestStatus: {
@@ -10361,6 +10373,11 @@ export interface components {
             section: string;
             /** Fields */
             fields: string[];
+            /**
+             * Extra Fields
+             * @default []
+             */
+            extra_fields: string[];
             /** Update Fields */
             update_fields: string[];
             /** Content Version */
@@ -10390,11 +10407,6 @@ export interface components {
             fields: {
                 [key: string]: string;
             };
-        };
-        /** VaultSecretRequestToken */
-        VaultSecretRequestToken: {
-            /** Token */
-            token: string;
         };
         /** VaultSectionsResponse */
         VaultSectionsResponse: {
@@ -16143,7 +16155,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["VaultSecretRequestToken"];
+                "application/json": components["schemas"]["VaultSecretRequestInspect"];
             };
         };
         responses: {


### PR DESCRIPTION
Users can add fields or import dotenv text/files directly on the existing private Vault request page. Preview identifies draft replacements and existing Vault updates; Apply changes the editable form, and one Save submits all fields. Original requested fields remain mandatory, names preserve case, and imports never evaluate substitutions.

Requests capture section fingerprints at creation. Inspect and supply check only selected fields under the Vault lock, reject concurrent changes and pending reservations, and preserve atomic single-use submission. Successful status includes all saved field references and the content version. MCP descriptions, current skills and generated API types are updated.

Validation: isolated Docker backend 45 tests, parser/import 15, skill 2 and Chromium 10 passed; Web/CLI types, API freshness, formatting and OSS build passed. Browser tests use synthetic API fixtures; they are not production end-to-end evidence.

Migration fa83d21c907b expires old unsupplied links because they lack full-section creation snapshots. Saved values and supplied history remain. Downgrade preserves saved extra names and baselines in request history and invalidates pending links. Deploy backend and page together. Publishes CLI 0.14.81 with the updated bundled skills. Release preparation passed isolated frozen install, typechecks, build, package and installed-version smoke. The unique migration head is fa83d21c907b.

Follow-up validation: 32 backend, 15 parser and 13 Chromium checks passed in Docker, including downgrade history, cancellable field-check debounce and stale response rejection. Network/server, input, conflict and expiry states are distinguished. Full final-head CI remains required.
